### PR TITLE
Add notebooklm-Invoke skill (Python wrapper + docs)

### DIFF
--- a/notebooklm-Invoke/QUICKSTART_CN.md
+++ b/notebooklm-Invoke/QUICKSTART_CN.md
@@ -1,0 +1,123 @@
+# notebooklm-Invoke 快速上手（中文）
+
+> 目标：用最少步骤跑通 notebooklm skill（安装 → 认证 → 提问 → 生成 PPT）。
+
+## 1. 安装依赖
+
+```bash
+python3 -m pip install --user -U notebooklm-py
+python3 -m pip install --user -U playwright
+python3 -m playwright install chromium
+```
+
+如果 Ubuntu 提示 externally-managed-environment：
+
+```bash
+python3 -m pip install --user -U notebooklm-py --break-system-packages
+python3 -m pip install --user -U playwright --break-system-packages
+```
+
+Linux 额外系统依赖：
+
+```bash
+sudo playwright install-deps
+```
+
+---
+
+## 2. 配置 PATH
+
+### macOS (zsh)
+```bash
+echo 'export PATH="$(python3 -m site --user-base)/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### Linux (bash)
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+校验：
+
+```bash
+notebooklm --version
+```
+
+---
+
+## 3. 登录认证
+
+### 有图形界面（推荐）
+```bash
+python3 {baseDir}/scripts/notebooklm.py login
+```
+按提示在浏览器完成 Google 登录。
+
+### 无图形界面服务器（推荐流程）
+1) 在本地电脑先 `login`
+2) 将本地 `~/.notebooklm/storage_state.json` 复制到服务器同路径
+3) 在服务器验证：
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py auth check
+python3 {baseDir}/scripts/notebooklm.py list --json
+```
+
+---
+
+## 4. 常用命令
+
+```bash
+# 列出 notebooks
+python3 {baseDir}/scripts/notebooklm.py list --json
+
+# 设置默认 notebook
+python3 {baseDir}/scripts/notebooklm.py use <notebook_id>
+
+# 提问
+python3 {baseDir}/scripts/notebooklm.py ask "请总结这份材料的重点" --json
+
+# 添加 source（URL/文本）
+python3 {baseDir}/scripts/notebooklm.py source add https://example.com --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source add "这里是文本内容" --title "说明" --notebook <notebook_id>
+```
+
+---
+
+## 5. 生成 PPT（Slide Deck）
+
+```bash
+# 1) 生成
+python3 {baseDir}/scripts/notebooklm.py generate slide-deck "做一份 10 页执行汇报" --notebook <notebook_id>
+
+# 2) 查看/等待
+python3 {baseDir}/scripts/notebooklm.py artifact list --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py artifact wait <artifact_id> --notebook <notebook_id> --timeout 600 --json
+
+# 3) 下载
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest
+```
+
+---
+
+## 6. 常见问题
+
+### 1) `Playwright not installed`
+```bash
+python3 -m pip install --user -U playwright
+python3 -m playwright install chromium
+```
+
+### 2) `Missing X server or $DISPLAY`
+当前环境无图形界面。请走“本地登录 + 复制 storage_state.json”方案。
+
+### 3) `notebooklm: command not found`
+PATH 未配置好，先执行：
+
+```bash
+$(python3 -m site --user-base)/bin/notebooklm --version
+```
+
+若能输出版本，再把该目录加到 PATH。

--- a/notebooklm-Invoke/QUICKSTART_CN.md
+++ b/notebooklm-Invoke/QUICKSTART_CN.md
@@ -88,6 +88,8 @@ python3 {baseDir}/scripts/notebooklm.py source add "这里是文本内容" --tit
 
 ## 5. 生成 PPT（Slide Deck）
 
+> 规则：单次生成默认不超过 **15 页**。超过 15 页时请拆成多个 deck（如 Part 1/2/3）分别生成。
+
 ```bash
 # 1) 生成
 python3 {baseDir}/scripts/notebooklm.py generate slide-deck "做一份 10 页执行汇报" --notebook <notebook_id>
@@ -96,8 +98,11 @@ python3 {baseDir}/scripts/notebooklm.py generate slide-deck "做一份 10 页执
 python3 {baseDir}/scripts/notebooklm.py artifact list --notebook <notebook_id> --json
 python3 {baseDir}/scripts/notebooklm.py artifact wait <artifact_id> --notebook <notebook_id> --timeout 600 --json
 
-# 3) 下载
-python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest
+# 3) 下载（优先 .pptx）
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pptx --notebook <notebook_id> --latest --format pptx
+
+# 可选：下载 PDF
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest --format pdf
 ```
 
 ---

--- a/notebooklm-Invoke/README.md
+++ b/notebooklm-Invoke/README.md
@@ -80,6 +80,8 @@ python3 {baseDir}/scripts/notebooklm.py list --json
 
 ## 4) Quick start (MVP)
 
+> PPT policy: one deck should target **<=15 pages**. If more pages are needed, split into multiple decks and generate in batches.
+
 ```bash
 # Check auth
 python3 {baseDir}/scripts/notebooklm.py auth check
@@ -99,7 +101,12 @@ python3 {baseDir}/scripts/notebooklm.py generate slide-deck "Create 10 slides fo
 # Wait for artifact and download
 python3 {baseDir}/scripts/notebooklm.py artifact list --notebook <notebook_id> --json
 python3 {baseDir}/scripts/notebooklm.py artifact wait <artifact_id> --notebook <notebook_id> --timeout 600 --json
-python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest
+
+# Preferred download format: PPTX
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pptx --notebook <notebook_id> --latest --format pptx
+
+# Optional: PDF
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest --format pdf
 ```
 
 ---

--- a/notebooklm-Invoke/README.md
+++ b/notebooklm-Invoke/README.md
@@ -1,0 +1,138 @@
+# notebooklm-Invoke
+
+NotebookLM skill wrapper using **Python** (`notebooklm-py`).
+
+- Wrapper entry: `scripts/notebooklm.py`
+- Command form: `python3 {baseDir}/scripts/notebooklm.py <command> [args...]`
+
+---
+
+## 1) Requirements
+
+### Core
+- Python 3.10+
+- `notebooklm-py`
+- Playwright + Chromium (required for `login`)
+
+### Install (Linux/macOS)
+```bash
+python3 -m pip install --user -U notebooklm-py
+python3 -m pip install --user -U playwright
+python3 -m playwright install chromium
+```
+
+If your Python is PEP668-managed (common on Ubuntu), use:
+```bash
+python3 -m pip install --user -U notebooklm-py --break-system-packages
+python3 -m pip install --user -U playwright --break-system-packages
+```
+
+### Linux system deps (Playwright runtime)
+```bash
+sudo playwright install-deps
+```
+Or install required libs manually (`libatk`, `libpango`, `libasound`, etc.).
+
+---
+
+## 2) PATH setup
+
+If `notebooklm` is not found, add user bin to PATH.
+
+### macOS (zsh)
+```bash
+echo 'export PATH="$(python3 -m site --user-base)/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### Linux (bash)
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Verify:
+```bash
+notebooklm --version
+```
+
+---
+
+## 3) Authentication
+
+### Interactive login (requires GUI browser)
+```bash
+python3 {baseDir}/scripts/notebooklm.py login
+```
+
+> `login` needs a visible browser session. In pure headless servers (no X server / no `$DISPLAY`), interactive login will fail.
+
+### Headless/server workflow (recommended)
+1. Login on your local machine.
+2. Copy `~/.notebooklm/storage_state.json` to server `~/.notebooklm/storage_state.json`.
+3. Validate on server:
+```bash
+python3 {baseDir}/scripts/notebooklm.py auth check
+python3 {baseDir}/scripts/notebooklm.py list --json
+```
+
+---
+
+## 4) Quick start (MVP)
+
+```bash
+# Check auth
+python3 {baseDir}/scripts/notebooklm.py auth check
+
+# List notebooks
+python3 {baseDir}/scripts/notebooklm.py list --json
+
+# Set active notebook
+python3 {baseDir}/scripts/notebooklm.py use <notebook_id>
+
+# Ask question
+python3 {baseDir}/scripts/notebooklm.py ask "Summarize key points" --json
+
+# Generate slide deck
+python3 {baseDir}/scripts/notebooklm.py generate slide-deck "Create 10 slides for executives" --notebook <notebook_id>
+
+# Wait for artifact and download
+python3 {baseDir}/scripts/notebooklm.py artifact list --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py artifact wait <artifact_id> --notebook <notebook_id> --timeout 600 --json
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest
+```
+
+---
+
+## 5) Common issues
+
+### `Playwright not installed`
+Install:
+```bash
+python3 -m pip install --user -U playwright
+python3 -m playwright install chromium
+```
+
+### `Missing X server or $DISPLAY`
+You are on headless server. Do local login and copy `storage_state.json` to server.
+
+### `notebooklm: command not found`
+Fix PATH (see section 2), or invoke directly:
+```bash
+$(python3 -m site --user-base)/bin/notebooklm --version
+```
+
+### `auth check` passes but commands fail
+- Re-login locally and replace `storage_state.json`
+- Confirm account has access to target notebook
+- Re-run with verbose mode for diagnostics:
+```bash
+notebooklm -vv list
+```
+
+---
+
+## 6) Security notes
+
+- `storage_state.json` contains sensitive session cookies. Keep permission strict (`chmod 600`) and never commit to git.
+- Use dedicated account/session for automation where possible.

--- a/notebooklm-Invoke/SKILL.md
+++ b/notebooklm-Invoke/SKILL.md
@@ -29,6 +29,12 @@ python3 {baseDir}/scripts/notebooklm.py ask "Summarize the key takeaways" --note
   - `artifact wait`
   - `research wait`
 
+## PPT generation policy
+- A single generated slide deck should target **at most 15 pages**.
+- If user requirements exceed 15 pages, split into multiple decks (e.g., Part 1/2/3) and generate separately.
+- After generation, provide downloadable **`.pptx`** output when possible:
+  - `download slide-deck ... --format pptx`
+
 ## References
 - `README.md` (installation, requirements, troubleshooting)
 - `QUICKSTART_CN.md`（中文快速上手）

--- a/notebooklm-Invoke/SKILL.md
+++ b/notebooklm-Invoke/SKILL.md
@@ -31,6 +31,7 @@ python3 {baseDir}/scripts/notebooklm.py ask "Summarize the key takeaways" --note
 
 ## References
 - `README.md` (installation, requirements, troubleshooting)
+- `QUICKSTART_CN.md`（中文快速上手）
 - `references/cli-commands.md`
 
 ## Assets

--- a/notebooklm-Invoke/SKILL.md
+++ b/notebooklm-Invoke/SKILL.md
@@ -29,6 +29,108 @@ python3 {baseDir}/scripts/notebooklm.py ask "Summarize the key takeaways" --note
   - `artifact wait`
   - `research wait`
 
+## ⚡ Sub-Agent Delegation (Anti-Blocking)
+
+### Problem
+NotebookLM operations like `source wait`, `artifact wait`, `research wait`, `generate slide-deck`, and `source add-research` can take **minutes** to complete. Running them in the main session blocks the conversation.
+
+### Strategy
+For any operation expected to take >30 seconds, **delegate to a sub-agent** via `sessions_spawn`:
+
+1. **Main session**: Acknowledge the user's request, then spawn a sub-agent with a clear task description.
+2. **Sub-agent**: Executes the long-running NotebookLM commands, waits for completion, and reports back.
+3. **Main session**: Remains responsive. The sub-agent auto-announces completion.
+
+### Which operations to delegate
+
+| Operation | Delegate? | Reason |
+|-----------|-----------|--------|
+| `login`, `status`, `list`, `use`, `clear` | ❌ No | Fast (<5s) |
+| `ask` (chat) | ❌ No | Usually fast (~10s) |
+| `source list`, `source get`, `note list` | ❌ No | Fast reads |
+| `source add` (URL/text) | ⚠️ Maybe | Fast to submit, but `source wait` after is slow |
+| `source add-research` | ✅ Yes | Deep research can take 2-5 min |
+| `source wait` | ✅ Yes | Polling wait, unpredictable duration |
+| `generate slide-deck` + `artifact wait` | ✅ Yes | Generation takes 1-5 min |
+| `research wait` | ✅ Yes | Can take several minutes |
+| `download slide-deck` | ⚠️ Maybe | Usually fast, but can be slow for large files |
+| Multi-step workflows (add sources → wait → generate → wait → download) | ✅ Yes | Compound long tasks |
+
+### How to spawn
+
+```
+sessions_spawn:
+  task: |
+    You are a NotebookLM task runner. Execute the following NotebookLM operations
+    and report results when done.
+
+    Notebook ID: <notebook_id>
+    Commands to run (in order):
+    1. <command 1>
+    2. <command 2>
+    ...
+
+    Use the CLI wrapper: python3 ~/.openclaw/skills/notebooklm-Invoke/scripts/notebooklm.py
+    Prefer --json output where supported.
+    If any step fails, report the error and stop.
+    When complete, summarize what was accomplished and any output files created.
+  mode: run
+  label: notebooklm-<short-description>
+```
+
+### Example: Generate slide deck
+
+**User**: "帮我用 notebook X 生成一个 PPT"
+
+**Main session response**:
+> 好的，我派了一个后台任务去生成 PPT，完成后会通知你 ✧
+
+**Spawn**:
+```
+sessions_spawn:
+  task: |
+    NotebookLM task: Generate a slide deck from notebook.
+
+    Steps:
+    1. python3 ~/.openclaw/skills/notebooklm-Invoke/scripts/notebooklm.py generate slide-deck "Create a comprehensive slide deck" --notebook <id>
+    2. python3 ~/.openclaw/skills/notebooklm-Invoke/scripts/notebooklm.py artifact wait <artifact_id> --notebook <id> --timeout 600 --json
+    3. python3 ~/.openclaw/skills/notebooklm-Invoke/scripts/notebooklm.py download slide-deck ./output.pptx --notebook <id> --latest --format pptx
+
+    Report: artifact details, file path, any errors.
+  mode: run
+  label: notebooklm-slide-deck
+```
+
+### Example: Add research source
+
+**User**: "在 notebook Y 里加一个关于碳足迹的深度研究"
+
+**Spawn**:
+```
+sessions_spawn:
+  task: |
+    NotebookLM task: Add deep research source.
+
+    Steps:
+    1. python3 ~/.openclaw/skills/notebooklm-Invoke/scripts/notebooklm.py source add-research "碳足迹最新研究进展" --mode deep --notebook <id>
+    2. python3 ~/.openclaw/skills/notebooklm-Invoke/scripts/notebooklm.py research wait --notebook <id> --timeout 600
+    3. python3 ~/.openclaw/skills/notebooklm-Invoke/scripts/notebooklm.py source list --notebook <id> --json
+
+    Report: research status, new sources added, any errors.
+  mode: run
+  label: notebooklm-research
+```
+
+### Guidelines
+
+- **Always tell the user** you're delegating to a background task before spawning.
+- **Use `mode: run`** (one-shot) — no need for persistent sessions.
+- **Use descriptive labels** like `notebooklm-slide-deck`, `notebooklm-research-carbon` for easy tracking.
+- **Include all context in the task** — the sub-agent has no conversation history.
+- **Error handling**: Instruct the sub-agent to report errors clearly so you can relay them.
+- **File paths**: Use absolute paths for output files so the main session can find them.
+- **Compound workflows**: Bundle related steps (add → wait → generate → wait → download) into a single sub-agent task rather than spawning multiple.
+
 ## PPT generation policy
 - A single generated slide deck should target **at most 15 pages**.
 - If user requirements exceed 15 pages, split into multiple decks (e.g., Part 1/2/3) and generate separately.

--- a/notebooklm-Invoke/SKILL.md
+++ b/notebooklm-Invoke/SKILL.md
@@ -30,6 +30,7 @@ python3 {baseDir}/scripts/notebooklm.py ask "Summarize the key takeaways" --note
   - `research wait`
 
 ## References
+- `README.md` (installation, requirements, troubleshooting)
 - `references/cli-commands.md`
 
 ## Assets

--- a/notebooklm-Invoke/SKILL.md
+++ b/notebooklm-Invoke/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: notebooklm
+description: NotebookLM CLI wrapper via `python3 {baseDir}/scripts/notebooklm.py` (backed by notebooklm-py). Use for auth, notebooks, chat, sources, notes, sharing, research, and artifact generation/download.
+---
+
+# NotebookLM CLI Wrapper (Python)
+
+## Required parameters
+- `python3` available.
+- `notebooklm-py` installed (CLI binary: `notebooklm`).
+- NotebookLM authenticated (`login`).
+
+## Quick start
+- Wrapper script: `scripts/notebooklm.py`.
+- Command form: `python3 {baseDir}/scripts/notebooklm.py <command> [args...]`.
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py login
+python3 {baseDir}/scripts/notebooklm.py list
+python3 {baseDir}/scripts/notebooklm.py use <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py status
+python3 {baseDir}/scripts/notebooklm.py ask "Summarize the key takeaways" --notebook <notebook_id>
+```
+
+## Output guidance
+- Prefer `--json` for machine-readable output where supported.
+- Long-running waits are handled by native commands like:
+  - `source wait`
+  - `artifact wait`
+  - `research wait`
+
+## References
+- `references/cli-commands.md`
+
+## Assets
+- None.

--- a/notebooklm-Invoke/references/cli-commands.md
+++ b/notebooklm-Invoke/references/cli-commands.md
@@ -60,6 +60,8 @@ python3 {baseDir}/scripts/notebooklm.py source wait <source_id> --notebook <note
 
 ## Artifacts
 
+> Slide deck best practice: target <=15 slides per generation. If more are needed, split into multiple decks and generate separately.
+
 ```bash
 python3 {baseDir}/scripts/notebooklm.py generate slide-deck "Create a 10-slide executive summary" --notebook <notebook_id>
 python3 {baseDir}/scripts/notebooklm.py artifact list --notebook <notebook_id> --json
@@ -68,7 +70,7 @@ python3 {baseDir}/scripts/notebooklm.py artifact rename <artifact_id> "New Title
 python3 {baseDir}/scripts/notebooklm.py artifact delete <artifact_id> --notebook <notebook_id>
 python3 {baseDir}/scripts/notebooklm.py artifact export <artifact_id> --notebook <notebook_id>
 python3 {baseDir}/scripts/notebooklm.py artifact suggestions --notebook <notebook_id> --json
-python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pptx --notebook <notebook_id> --latest --format pptx
 python3 {baseDir}/scripts/notebooklm.py artifact wait <artifact_id> --notebook <notebook_id> --timeout 600 --json
 ```
 

--- a/notebooklm-Invoke/references/cli-commands.md
+++ b/notebooklm-Invoke/references/cli-commands.md
@@ -1,0 +1,112 @@
+# NotebookLM CLI command catalog (aligned to notebooklm-py)
+
+Command prefix:
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py
+```
+
+Notes:
+- Global options from underlying CLI include `--storage` and `-v/--verbose`.
+- Prefer `--json` when available.
+- Most commands accept `-n/--notebook <id>`; if omitted, use `use <id>` first.
+- IDs support partial match in many commands.
+
+## Session / Auth
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py login
+python3 {baseDir}/scripts/notebooklm.py status
+python3 {baseDir}/scripts/notebooklm.py use <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py clear
+python3 {baseDir}/scripts/notebooklm.py auth check
+```
+
+## Notebooks
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py list --json
+python3 {baseDir}/scripts/notebooklm.py create "Research Notebook" --json
+python3 {baseDir}/scripts/notebooklm.py rename <notebook_id> "New Title"
+python3 {baseDir}/scripts/notebooklm.py delete <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py summary --notebook <notebook_id> --topics
+```
+
+## Chat
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py ask "What are the top risks?" --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py configure --notebook <notebook_id> --mode concise
+python3 {baseDir}/scripts/notebooklm.py history --notebook <notebook_id> --limit 20
+```
+
+## Sources
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py source list --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py source add https://example.com --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py source add "Inline notes" --title "Meeting" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source add-drive <file_id> "Drive Doc" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source add-research "market analysis" --mode deep
+python3 {baseDir}/scripts/notebooklm.py source get <source_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source guide <source_id> --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py source fulltext <source_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source rename <source_id> "New Title" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source delete <source_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source refresh <source_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source stale <source_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py source wait <source_id> --notebook <notebook_id> --timeout 300 --json
+```
+
+## Artifacts
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py generate slide-deck "Create a 10-slide executive summary" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py artifact list --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py artifact get <artifact_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py artifact rename <artifact_id> "New Title" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py artifact delete <artifact_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py artifact export <artifact_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py artifact suggestions --notebook <notebook_id> --json
+python3 {baseDir}/scripts/notebooklm.py download slide-deck ./slides.pdf --notebook <notebook_id> --latest
+python3 {baseDir}/scripts/notebooklm.py artifact wait <artifact_id> --notebook <notebook_id> --timeout 600 --json
+```
+
+## Notes
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py note create "Key points" --title "Highlights" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py note list --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py note get <note_id> --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py note save <note_id> --content "Updated notes" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py note rename <note_id> "New Title" --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py note delete <note_id> --notebook <notebook_id>
+```
+
+## Sharing
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py share status --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py share add user@example.com --permission editor --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py share update user@example.com --permission viewer --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py share remove user@example.com --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py share public --enable --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py share view-level full --notebook <notebook_id>
+```
+
+## Research
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py research status --notebook <notebook_id>
+python3 {baseDir}/scripts/notebooklm.py research wait --notebook <notebook_id> --timeout 600
+```
+
+## Language / Skill
+
+```bash
+python3 {baseDir}/scripts/notebooklm.py language list
+python3 {baseDir}/scripts/notebooklm.py language get
+python3 {baseDir}/scripts/notebooklm.py language set zh_Hans
+python3 {baseDir}/scripts/notebooklm.py skill status
+python3 {baseDir}/scripts/notebooklm.py skill install
+```

--- a/notebooklm-Invoke/scripts/notebooklm.py
+++ b/notebooklm-Invoke/scripts/notebooklm.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""NotebookLM CLI wrapper (Python).
+
+This wrapper forwards all arguments to notebooklm-py CLI.
+Preferred binary order:
+1) NOTEBOOKLM_BIN env var
+2) ~/.local/bin/notebooklm
+3) notebooklm from PATH
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def usage() -> None:
+    print("Usage: notebooklm.py <command> [args...]", file=sys.stderr)
+    print("Examples:", file=sys.stderr)
+    print("  notebooklm.py status", file=sys.stderr)
+    print("  notebooklm.py login", file=sys.stderr)
+    print("  notebooklm.py list", file=sys.stderr)
+    print("  notebooklm.py use <notebook_id>", file=sys.stderr)
+    print("  notebooklm.py ask \"Summarize the key takeaways\" --notebook <id>", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def resolve_bin() -> str:
+    env_bin = os.getenv("NOTEBOOKLM_BIN")
+    if env_bin:
+        return env_bin
+
+    user_bin = Path.home() / ".local" / "bin" / "notebooklm"
+    if user_bin.exists():
+        return str(user_bin)
+
+    path_bin = shutil.which("notebooklm")
+    return path_bin or "notebooklm"
+
+
+def missing_binary(bin_path: str) -> None:
+    print(f"NotebookLM CLI not found: {bin_path}", file=sys.stderr)
+    print("Install notebooklm-py and retry.", file=sys.stderr)
+    print("Suggested install:", file=sys.stderr)
+    print("  python3 -m pip install --user -U notebooklm-py --break-system-packages", file=sys.stderr)
+    print("Then verify:", file=sys.stderr)
+    print("  ~/.local/bin/notebooklm --version", file=sys.stderr)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args or args[0] in {"-h", "--help"}:
+        usage()
+
+    bin_path = resolve_bin()
+    try:
+        result = subprocess.run([bin_path, *args], check=False)
+        return int(result.returncode)
+    except FileNotFoundError:
+        missing_binary(bin_path)
+        return 127
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to run NotebookLM CLI: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- add new skill: `notebooklm-Invoke`\n- switch wrapper to Python (`scripts/notebooklm.py`) backed by `notebooklm-py`\n- add complete command catalog and usage references\n- add README with install requirements, auth flow, troubleshooting\n- add Chinese quickstart (`QUICKSTART_CN.md`)\n- document PPT policy: <=15 slides per generation; split when needed\n- document PPTX download format (`--format pptx`)\n\n## Notes\n- Auth supports local-login + storage_state.json migration for headless servers\n- Current docs are aligned to notebooklm-py CLI behavior\n