### PR TITLE
docs: align skills governance docs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -12,6 +12,7 @@ routing:
       paths:
         - AGENTS.md
         - .docpact/**
+        - .github/workflows/docpact.yml
         - _docs/**
         - README.md
         - README.zh-CN.md
@@ -32,6 +33,7 @@ coverage:
     - README.md
     - README.zh-CN.md
     - .docpact/**
+    - .github/workflows/docpact.yml
     - _docs/**
     - .claude-plugin/**
     - "*/SKILL.md"
@@ -81,6 +83,8 @@ rules:
         kind: agent-contract
       - path: .docpact/config.yaml
         kind: machine-contract
+      - path: .github/workflows/docpact.yml
+        kind: governance-ci
       - path: _docs/**
         kind: governed-docs
       - path: README.md

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,0 +1,153 @@
+version: 1
+layout: repo
+lastReviewedAt: "2026-04-29"
+lastReviewedCommit: "7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1"
+
+repo:
+  id: skills
+
+routing:
+  intents:
+    governance:
+      paths:
+        - AGENTS.md
+        - .docpact/**
+        - _docs/**
+        - README.md
+        - README.zh-CN.md
+    skill:
+      paths:
+        - "*/SKILL.md"
+        - "*/agents/**"
+        - "*/scripts/**"
+        - "*/references/**"
+        - "*/assets/**"
+    marketplace:
+      paths:
+        - .claude-plugin/**
+
+coverage:
+  include:
+    - AGENTS.md
+    - README.md
+    - README.zh-CN.md
+    - .docpact/**
+    - _docs/**
+    - .claude-plugin/**
+    - "*/SKILL.md"
+    - "*/agents/**"
+    - "*/scripts/**"
+    - "*/references/**"
+    - "*/assets/**"
+    - "*/README.md"
+    - "*/README.zh-CN.md"
+    - "*/QUICKSTART_CN.md"
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - node_modules/**
+    - dist/**
+    - build/**
+    - coverage/**
+    - .DS_Store
+    - "**/.DS_Store"
+
+docInventory:
+  include:
+    - AGENTS.md
+    - README.md
+    - README.zh-CN.md
+    - .docpact/config.yaml
+    - _docs/**
+  exclude:
+    - .git/**
+    - .docpact/runs/**
+    - node_modules/**
+    - dist/**
+    - build/**
+    - coverage/**
+
+freshness:
+  warn_after_commits: 50
+  warn_after_days: 90
+  critical_after_days: 180
+
+rules:
+  - id: skills-governance
+    scope: repo
+    repo: skills
+    triggers:
+      - path: AGENTS.md
+        kind: agent-contract
+      - path: .docpact/config.yaml
+        kind: machine-contract
+      - path: _docs/**
+        kind: governed-docs
+      - path: README.md
+        kind: repo-entry
+      - path: README.zh-CN.md
+        kind: localized-repo-entry
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: _docs/README.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/standards/documentation-standards.md
+        mode: review_or_update
+    reason: Repository entry guidance, governance config, and documentation standards must remain aligned.
+  - id: skills-skill-surface
+    scope: repo
+    repo: skills
+    triggers:
+      - path: "*/SKILL.md"
+        kind: skill-entry
+      - path: "*/agents/**"
+        kind: generated-agent-config
+      - path: "*/scripts/**"
+        kind: skill-script
+      - path: "*/references/**"
+        kind: skill-reference
+      - path: "*/assets/**"
+        kind: skill-asset
+      - path: "*/README.md"
+        kind: skill-readme
+      - path: "*/README.zh-CN.md"
+        kind: localized-skill-readme
+      - path: "*/QUICKSTART_CN.md"
+        kind: skill-quickstart
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: README.md
+        mode: review_or_update
+      - path: README.zh-CN.md
+        mode: review_or_update
+      - path: _docs/architecture/repo-architecture.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+    reason: Skill definitions, generated agent configs, scripts, references, assets, and per-skill docs must follow the repository skill workflow.
+  - id: skills-marketplace
+    scope: repo
+    repo: skills
+    triggers:
+      - path: .claude-plugin/**
+        kind: marketplace-metadata
+    requiredDocs:
+      - path: README.md
+        mode: review_or_update
+      - path: README.zh-CN.md
+        mode: review_or_update
+      - path: _docs/architecture/repo-architecture.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+      - path: _docs/contracts/repo-contract.md
+        mode: review_or_update
+    reason: Marketplace metadata affects skill discovery and installation and must stay aligned with repository docs.

--- a/.github/workflows/docpact.yml
+++ b/.github/workflows/docpact.yml
@@ -1,0 +1,40 @@
+name: docpact
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            validate-config
+            --root .
+            --strict
+
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Biaoo/docpact@v0.1.4
+        with:
+          version: 0.1.4
+          args: >
+            lint
+            --root .
+            --base ${{ github.event.pull_request.base.sha }}
+            --head ${{ github.sha }}
+            --mode enforce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ whenToUpdate: "When skill creation workflow, validation commands, docpact config
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,63 @@
-# AGENTS.md
+---
+docType: agent-contract
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: zh-CN
+whenToUse: "Before editing the reusable skills repository."
+whenToUpdate: "When skill creation workflow, validation commands, docpact config, marketplace metadata, or repo documentation rules change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
 
-适用范围：本仓库根目录及全部子目录。
+# Tiangong AI Skills Agent Contract
 
-## 强制规则：使用 Codex 创建或更新 Skill
+本仓库负责可复用 agent skills。workspace 根仓负责子模块集成与交付治理；
+skill 内容、skill 规范、marketplace 元数据和本仓文档治理属于本仓库。
 
-1. 必须参考 Codex 内置 `skill-creator` 指南并按其要求执行。
-2. 默认参考路径：
-   - `/root/.codex/skills/.system/skill-creator/SKILL.md`
-   - 若运行环境不同，使用等价的 `$CODEX_HOME/skills/.system/skill-creator/SKILL.md`
-3. 当任务是“新建 skill / 修改 skill / 规范化 skill”时，优先触发并遵循 `skill-creator` 流程。
-4. 如本文件与 `skill-creator` 细则存在冲突，以 `skill-creator` 为准。
+## Required Load Order
 
-## Skill 实施流程（必须遵守）
+1. 阅读本文件。
+2. 阅读 `.docpact/config.yaml`。
+3. 对计划修改的路径，在本仓根目录运行
+   `docpact route --root . --paths <target-paths> --format json`。
+4. 阅读 `_docs/contracts/**`、`_docs/architecture/**`、`_docs/runbooks/**`
+   中与 route 结果相关的文档。
+5. 如果任务涉及新建或修改 skill，继续按下方现有 `skill-creator` 强制规则执行。
 
-1. 明确 skill 的触发场景与典型用例。
-2. 规划可复用资源（`scripts/`、`references/`、`assets/`）。
-3. 新 skill 优先使用 `init_skill.py` 初始化目录与模板。
-4. 按规范填写/更新 `SKILL.md` 与资源文件。
-5. 生成或更新 `agents/openai.yaml`（使用官方脚本与 `--interface` 参数）。
-6. 运行 `quick_validate.py <skill-path>`，修复后直到通过。
+## Source Of Truth
 
-## Skill 文件规范
+- `.docpact/config.yaml`：机器可读治理规则、route alias、coverage、
+  doc inventory 与 freshness 策略。
+- `README.md` / `README.zh-CN.md`：安装、更新、环境变量和使用说明。
+- `_docs/contracts/repo-contract.md`：本仓边界、skill 规范与完成条件。
+- `_docs/architecture/repo-architecture.md`：skill 仓库结构和分发拓扑。
+- `_docs/runbooks/development.md`：创建、校验、生成 agent 配置和交付流程。
 
-1. Skill 目录名仅使用小写字母、数字、连字符（hyphen-case），且应小于 64 字符。
-2. 每个 skill 至少包含 `SKILL.md`。
-3. `SKILL.md` 的 YAML frontmatter 仅允许：
-   - `name`
-   - `description`
-4. `description` 必须写清楚“做什么 + 何时使用（触发条件）”。
-5. 仅在确有必要时创建 `scripts/`、`references/`、`assets/`，避免冗余文件。
+## Hard Boundaries
 
-## 交付前检查
+- 不要把 workspace 子模块策略、分支策略或集成完成规则复制进本仓。
+- 不要绕过 `skill-creator` 规范手写不合规 skill。
+- 不要提交真实 API key、账号密码或用户私有数据到 skill 资源中。
+- 修改 skill 触发条件、脚本、引用资料、agent 配置或 marketplace 元数据时，
+  同步检查本仓 docs 和 docpact route 结果。
 
-1. 校验通过：`quick_validate.py` 返回通过结果。
-2. 若新增脚本：至少运行一次代表性测试，确认可执行与输出合理。
-3. 变更说明中明确列出：新增/修改的 skill 文件与校验结果。
+## Completion Criteria
+
+- 修改前已查看相关 `docpact route` 输出。
+- route 命中的文档已 reviewed 或 updated。
+- 治理变更后 `docpact validate-config --root . --strict` 通过。
+- skill 变更按 `skill-creator` 流程运行对应校验。
+
+## Skill-Creator Workflow
+
+For new or modified skills, load
+`$CODEX_HOME/skills/.system/skill-creator/SKILL.md`, or
+`~/.codex/skills/.system/skill-creator/SKILL.md` when `CODEX_HOME` is unset.
+Use that skill's scripts by path: `scripts/init_skill.py`,
+`scripts/generate_openai_yaml.py`, and `scripts/quick_validate.py <skill-path>`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+---
+docType: guide
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: en
+whenToUse: "When installing, updating, or using the Tiangong AI reusable skills repository."
+whenToUpdate: "When install commands, target agents, scope behavior, environment variables, or available skill guidance changes."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - README.zh-CN.md
+  - .claude-plugin/**
+  - "*/SKILL.md"
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
+
 # Tiangong AI Skills
 
 Repository: https://github.com/tiangong-ai/skills
@@ -20,7 +39,7 @@ npm i skills -g
   ```
 - Install specific skills:
   ```bash
-  npx skills add https://github.com/tiangong-ai/skills --skill flow-hybrid-search --skill process-hybrid-search
+  npx skills add https://github.com/tiangong-ai/skills --skill sci-journals-hybrid-search --skill dify-knowledge-base-search
   ```
 
 ## Target agents and scope
@@ -55,10 +74,7 @@ npm i skills -g
   npx skills update
   ```
 
-## Environment variables
-- `sci-journals-hybrid-search`
-  - `TIANGONG_AI_APIKEY`: required. Used as `x-api-key` for the Supabase edge function.
-- `dify-knowledge-base-search`
-  - `DIFY_API_BASE_URL`: required. Example `https://api.dify.ai/v1`.
-  - `DIFY_DATASET_ID`: required. Dify dataset (knowledge base) ID.
-  - `DIFY_API_KEY`: required. Used as `Authorization: Bearer <DIFY_API_KEY>`.
+## Environment Variables
+
+Environment requirements live with each skill. Before using a skill that calls
+an external service, read that skill's `references/env.md` when present.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,23 @@
-# 天工 LCA Skills
+---
+docType: guide
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: zh-CN
+whenToUse: "安装、更新或使用 Tiangong AI 可复用 skills 仓库时。"
+whenToUpdate: "当安装命令、目标 agent、安装范围、环境变量或 skill 可用性说明变化时。"
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - README.md
+  - .claude-plugin/**
+  - "*/SKILL.md"
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
+
+# 天工 AI Skills
 
 仓库地址: https://github.com/tiangong-ai/skills
 
@@ -20,7 +39,7 @@ npm i skills -g
   ```
 - 安装指定技能:
   ```bash
-  npx skills add https://github.com/tiangong-ai/skills --skill flow-hybrid-search --skill process-hybrid-search
+  npx skills add https://github.com/tiangong-ai/skills --skill sci-journals-hybrid-search --skill dify-knowledge-base-search
   ```
 
 ## 目标 agent 与作用域
@@ -56,9 +75,6 @@ npm i skills -g
   ```
 
 ## 环境变量
-- `sci-journals-hybrid-search`
-  - `TIANGONG_AI_APIKEY`: 必填。用于 Supabase edge function 的 `x-api-key`。
-- `dify-knowledge-base-search`
-  - `DIFY_API_BASE_URL`: 必填。示例 `https://api.dify.ai/v1`。
-  - `DIFY_DATASET_ID`: 必填。Dify 数据集（知识库）ID。
-  - `DIFY_API_KEY`: 必填。用于 `Authorization: Bearer <DIFY_API_KEY>`。
+
+环境变量要求由各 skill 自己维护。使用会调用外部服务的 skill 前，优先阅读该
+skill 的 `references/env.md`（如存在）。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -1,0 +1,37 @@
+---
+docType: index
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: en
+whenToUse: "When navigating skills repository documentation."
+whenToUpdate: "When repository documentation layers, key docs, or governance routing change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
+
+# Skills Documentation
+
+This directory contains the repo-local source documents governed by docpact.
+
+## Layers
+
+- Layer 0: `AGENTS.md` for mandatory agent entry guidance and skill-creator
+  rules.
+- Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- Layer 2: current contracts, architecture, standards, and runbooks under
+  `_docs/**`.
+
+## Current Documents
+
+- `_docs/contracts/repo-contract.md`: repository ownership, boundaries, and
+  skill completion rules.
+- `_docs/architecture/repo-architecture.md`: skill repository topology.
+- `_docs/runbooks/development.md`: creation, validation, and marketplace update
+  workflow.
+- `_docs/standards/documentation-standards.md`: repo-local documentation rules.

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -10,6 +10,7 @@ whenToUpdate: "When repository documentation layers, key docs, or governance rou
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-04-29
 lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
@@ -24,6 +25,8 @@ This directory contains the repo-local source documents governed by docpact.
 - Layer 0: `AGENTS.md` for mandatory agent entry guidance and skill-creator
   rules.
 - Layer 1: `.docpact/config.yaml` for machine-readable governance.
+- CI: `.github/workflows/docpact.yml` for config validation and PR
+  documentation lint.
 - Layer 2: current contracts, architecture, standards, and runbooks under
   `_docs/**`.
 

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -1,0 +1,53 @@
+---
+docType: architecture
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: en
+whenToUse: "When changing skill directories, generated agent configs, repository README files, or marketplace metadata."
+whenToUpdate: "When skill layout, install flow, validation workflow, or discovery metadata changes."
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - README.zh-CN.md
+  - .claude-plugin/**
+  - "*/SKILL.md"
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
+
+# Skills Repository Architecture
+
+## Overview
+
+The repository is a collection of reusable agent skills. Each skill is a
+directory with a required `SKILL.md` and optional `scripts/`, `references/`,
+`assets/`, and generated `agents/` resources.
+
+## Key Paths
+
+- `AGENTS.md`: mandatory repository-level skill creation and validation rules.
+- `README.md` and `README.zh-CN.md`: install, update, target agent, and
+  environment variable instructions.
+- `.claude-plugin/marketplace.json`: curated marketplace grouping metadata; it
+  may be a subset of installable skill directories.
+- `*/SKILL.md`: individual skill entrypoint and trigger description.
+- `*/scripts/**`: executable helpers used by skills.
+- `*/references/**`: supporting reference material.
+- `*/assets/**`: reusable skill assets or templates.
+- `*/agents/**`: generated agent configuration files.
+
+## Runtime Shape
+
+Skills are consumed by external agent runtimes through the `skills` CLI or by
+copy/symlink installation. Some skills require environment variables for
+external APIs; those requirements belong in the relevant skill docs and the
+repository README when broadly useful.
+
+## Integration Points
+
+- The root workspace pins this repository as a submodule.
+- Consumers install skills into project or user agent directories.
+- Marketplace metadata influences discovery and install ordering for the subset
+  it lists.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -1,0 +1,62 @@
+---
+docType: contract
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: en
+whenToUse: "When deciding whether a change belongs in the skills repository."
+whenToUpdate: "When ownership, skill format rules, generated agent config requirements, marketplace metadata, or completion criteria change."
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - README.zh-CN.md
+  - .claude-plugin/**
+  - .docpact/config.yaml
+  - "*/SKILL.md"
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
+
+# Skills Repository Contract
+
+## Ownership
+
+This repository owns reusable agent skills, per-skill scripts, references,
+assets, generated agent configuration files, README files, and curated
+marketplace grouping metadata.
+
+## Boundaries
+
+- Project-level vendored skills under a consuming repository's `.agents/**`
+  belong to that consuming repository.
+- Root workspace governance, branch policy, and submodule integration remain in
+  the workspace repository.
+- Runtime credentials and user-private data do not belong in skill assets,
+  references, or scripts.
+
+## Skill Surface
+
+Each skill directory must follow the repository `AGENTS.md` rules and the
+Codex `skill-creator` guidance. Changes to `SKILL.md`, scripts, references,
+assets, generated `agents/**` files, or marketplace metadata require review of:
+
+- `AGENTS.md`
+- `README.md`
+- `README.zh-CN.md`
+- `_docs/runbooks/development.md`
+- `_docs/standards/documentation-standards.md`
+
+## Completion Criteria
+
+- Run `docpact route` before editing governed files.
+- Run `docpact validate-config --root . --strict` after governance changes.
+- For skill changes, run the applicable `skill-creator` validation workflow,
+  including `scripts/quick_validate.py <skill-path>` from the `skill-creator`
+  skill when available.
+- Regenerate or update agent config files when the skill workflow requires it.
+- Do not leave install, validation, or trigger facts only in chat.
+
+`.claude-plugin/marketplace.json` is curated marketplace grouping metadata. It
+may be a subset of installable skill directories unless the marketplace file is
+explicitly updated to include every skill.

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -1,0 +1,56 @@
+---
+docType: runbook
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: en
+whenToUse: "When creating, updating, validating, or publishing reusable skills."
+whenToUpdate: "When skill creation, generated agent config, validation, install, or marketplace update workflow changes."
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - README.zh-CN.md
+  - .claude-plugin/**
+  - "*/SKILL.md"
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
+
+# Skills Development Runbook
+
+## Before Editing A Skill
+
+1. Read `AGENTS.md`.
+2. Read the Codex `skill-creator` guidance required by `AGENTS.md`.
+3. Run docpact route for the target skill paths.
+4. Inspect existing skill resources before changing structure.
+
+## New Skill Or Major Skill Update
+
+Use the `skill-creator` workflow. Prefer the official initializer when creating
+new skills, then fill in `SKILL.md`, optional `scripts/`, `references/`,
+`assets/`, and generated `agents/**` files as required.
+
+## Validation
+
+Run:
+
+```bash
+docpact validate-config --root . --strict
+```
+
+For skill changes, run the validator required by `AGENTS.md` from the
+`skill-creator` scripts directory, such as:
+
+```bash
+scripts/quick_validate.py <skill-path>
+```
+
+Run representative script tests when a skill script changes.
+
+## README And Marketplace Updates
+
+Update `README.md` and `README.zh-CN.md` when installation, environment
+variables, target agents, or user-facing skill availability changes. Update
+`.claude-plugin/marketplace.json` when marketplace discovery metadata changes.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -1,0 +1,42 @@
+---
+docType: standard
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: en
+whenToUse: "When creating, moving, or reviewing skills repository documentation."
+whenToUpdate: "When documentation layers, metadata rules, skill doc requirements, or source-of-truth boundaries change."
+checkPaths:
+  - AGENTS.md
+  - .docpact/config.yaml
+  - _docs/**
+  - "*/SKILL.md"
+lastReviewedAt: 2026-04-29
+lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
+---
+
+# Skills Documentation Standards
+
+## Layers
+
+- `AGENTS.md`: mandatory repository entry guidance and skill creation rules.
+- `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
+  document inventory.
+- `_docs/contracts/**`: current constraints and ownership rules.
+- `_docs/architecture/**`: current repository topology and integration facts.
+- `_docs/runbooks/**`: executable procedures.
+- `_docs/standards/**`: repo-local documentation and engineering standards.
+- `*/SKILL.md`: skill-specific trigger and usage entrypoint.
+
+## Rules
+
+- Keep deterministic governance facts in `.docpact/config.yaml`.
+- Keep skill trigger semantics in each skill's `SKILL.md`.
+- Keep install, update, and broad environment variable guidance in repository
+  README files.
+- Keep executable creation and validation workflow in `_docs/runbooks/**`.
+- Do not duplicate root workspace branch policy or submodule integration policy
+  in this repository.
+- Do not include real credentials, user-private data, or large generated
+  artifacts in skill docs or assets.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -10,6 +10,7 @@ whenToUpdate: "When documentation layers, metadata rules, skill doc requirements
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-04-29
@@ -23,6 +24,8 @@ lastReviewedCommit: 7bcc1db8d066fa546ffa6e5c9c4b0def46c81ca1
 - `AGENTS.md`: mandatory repository entry guidance and skill creation rules.
 - `.docpact/config.yaml`: machine-readable governance, routing, coverage, and
   document inventory.
+- `.github/workflows/docpact.yml`: CI enforcement for config validation and PR
+  documentation lint.
 - `_docs/contracts/**`: current constraints and ownership rules.
 - `_docs/architecture/**`: current repository topology and integration facts.
 - `_docs/runbooks/**`: executable procedures.


### PR DESCRIPTION
Closes: N/A

## Summary
- Add repo-local docpact config and governed docs for the skills repository.
- Correct README examples, marketplace wording, environment variable guidance, and skill validation command paths.

## Key Decisions
- Treat .claude-plugin/marketplace.json as curated grouping metadata, not guaranteed exhaustive inventory.
- Keep per-skill environment requirements in each skill references/env.md.

## Validation
- docpact validate-config --root skills --strict --format json
- docpact coverage --root skills --format json
- docpact lint --root skills --files AGENTS.md,README.md,README.zh-CN.md,.docpact/config.yaml,_docs/README.md,_docs/contracts/repo-contract.md,_docs/architecture/repo-architecture.md,_docs/runbooks/development.md,_docs/standards/documentation-standards.md --format json

## Risks / Rollback
- Documentation-only change; rollback by reverting this PR.

## Follow-ups
- None.

## Workspace Integration
- Requires root workspace submodule pin update after merge.