### PR TITLE
Use tiangong-ai CLI binary in KB ingest skill

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-08"
-lastReviewedCommit: "2d822a0dc241355a22d6205525c09e23a02359cc"
+lastReviewedCommit: "b89ec9277b0c671846474b56dff1e369279128d1"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 2d822a0dc241355a22d6205525c09e23a02359cc
+lastReviewedCommit: b89ec9277b0c671846474b56dff1e369279128d1
 ---
 
 # Skills Documentation Standards

--- a/tiangong-kb-ingest/SKILL.md
+++ b/tiangong-kb-ingest/SKILL.md
@@ -11,9 +11,9 @@ Use the Tiangong AI CLI for execution. The skill only decides when to use the CL
 
 CLI-owned behavior:
 
-- `tiangong kb ingest upload`
-- `tiangong kb ingest status`
-- `tiangong kb collections list`
+- `tiangong-ai kb ingest upload`
+- `tiangong-ai kb ingest status`
+- `tiangong-ai kb collections list`
 - manifest/checkpoint
 - concurrency/retry
 - JSON output

--- a/tiangong-kb-ingest/references/env.md
+++ b/tiangong-kb-ingest/references/env.md
@@ -29,7 +29,7 @@ TIANGONG_KB_UPLOAD_RETRIES=3
 TIANGONG_KB_POLL_INTERVAL=2
 TIANGONG_KB_TIMEOUT=300
 TIANGONG_KB_WAIT_TIMEOUT=300
-TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong
+TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong-ai
 ```
 
 `TIANGONG_KB_API_BASE_URL` is optional because the CLI defaults to `https://thuenv.tiangong.world:7300`. Set it only for local, staging, or another compatible deployment.
@@ -38,7 +38,7 @@ TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong
 
 `TIANGONG_KB_API_KEY` is accepted as a fallback alias for `TIANGONG_AI_API_KEY`.
 
-`TIANGONG_AI_CLI_BIN` is optional. Set it only when `tiangong` is not on PATH
+`TIANGONG_AI_CLI_BIN` is optional. Set it only when `tiangong-ai` is not on PATH
 and the skill is not running inside the workspace checkout that contains
 `tiangong-ai-cli`.
 

--- a/tiangong-kb-ingest/scripts/run_kb_ingest.mjs
+++ b/tiangong-kb-ingest/scripts/run_kb_ingest.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const skillDir = resolve(scriptDir, "..");
-const workspaceCli = resolve(skillDir, "..", "..", "tiangong-ai-cli", "bin", "tiangong.js");
+const workspaceCli = resolve(skillDir, "..", "..", "tiangong-ai-cli", "bin", "tiangong-ai.js");
 
 function isExecutable(path) {
   try {
@@ -59,12 +59,12 @@ if (isExecutable(workspaceCli)) {
   run(process.execPath, [workspaceCli, ...normalizedArgs]);
 }
 
-run("tiangong", normalizedArgs);
+run("tiangong-ai", normalizedArgs);
 
 process.stderr.write(
   [
     "Unable to execute the Tiangong AI CLI.",
-    "Install @tiangong-ai/cli, add tiangong to PATH, or set TIANGONG_AI_CLI_BIN.",
+    "Install @tiangong-ai/cli, add tiangong-ai to PATH, or set TIANGONG_AI_CLI_BIN.",
     "",
   ].join("\n"),
 );


### PR DESCRIPTION
## Summary
- update Tiangong KB ingest skill docs to reference `tiangong-ai`
- update the skill wrapper to use `bin/tiangong-ai.js` in workspace checkouts and `tiangong-ai` on PATH
- record required docpact review evidence for the skill change

## Validation
- skill quick_validate.py for tiangong-kb-ingest
- node ./tiangong-kb-ingest/scripts/run_kb_ingest.mjs --help
- docpact validate-config --root . --strict
- docpact lint --root . --worktree --mode enforce
