### PR TITLE
Use bulk mode for Tiangong KB ingest skill

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-13"
-lastReviewedCommit: "e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8"
+lastReviewedCommit: "aa07f97c39610a662d3901ed4445976385f4b662"
 
 repo:
   id: skills

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-10"
-lastReviewedCommit: "a15204707143e80e361b3d95326bc5f1cdbcab98"
+lastReviewedAt: "2026-05-13"
+lastReviewedCommit: "e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # Tiangong AI Skills

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # 天工 AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # Skills Documentation

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # Skills Repository Architecture

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # Skills Repository Contract

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # Skills Development Runbook

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-05-13
-lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
+lastReviewedCommit: aa07f97c39610a662d3901ed4445976385f4b662
 ---
 
 # Skills Documentation Standards

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-05-10
-lastReviewedCommit: a15204707143e80e361b3d95326bc5f1cdbcab98
+lastReviewedAt: 2026-05-13
+lastReviewedCommit: e76c3a6246979a7a0a7f4fe4a4cea054f5aa80b8
 ---
 
 # Skills Documentation Standards

--- a/tiangong-kb-ingest/SKILL.md
+++ b/tiangong-kb-ingest/SKILL.md
@@ -34,7 +34,7 @@ Skill-owned behavior:
    - use `--collection-key`, `--collection-path`, or `--collection-id` only when the user provides an exact selector
 3. For a first check, run `node scripts/run_kb_ingest.mjs collections list --json`.
 4. Ingest with `node scripts/run_kb_ingest.mjs bulk <path> --json`.
-5. For long runs, tune `--window-size`, `--top-up-max`, `--upload-concurrency`, `--retries`, and `--state`; the wrapper defaults `--max-polls` to `120` unless the user passes a value.
+5. For long runs, tune `--window-size`, `--top-up-max`, `--upload-concurrency`, `--retries`, and `--state`; do not add `--max-polls` unless the user explicitly wants a bounded monitoring run.
 6. If the user asks to verify later state, use `node scripts/run_kb_ingest.mjs status <document-id-or-job-id> --json`.
 7. Report only current CLI output and backend response fields. Do not infer success from direct database queries.
 

--- a/tiangong-kb-ingest/SKILL.md
+++ b/tiangong-kb-ingest/SKILL.md
@@ -11,10 +11,10 @@ Use the Tiangong AI CLI for execution. The skill only decides when to use the CL
 
 CLI-owned behavior:
 
-- `tiangong-ai kb ingest upload`
+- `tiangong-ai kb ingest bulk`
 - `tiangong-ai kb ingest status`
 - `tiangong-ai kb collections list`
-- manifest/checkpoint
+- SQLite checkpoint and resume
 - concurrency/retry
 - JSON output
 - API key and env handling
@@ -33,9 +33,9 @@ Skill-owned behavior:
    - prefer `--collection-name` or `TIANGONG_KB_DEFAULT_COLLECTION_NAME` when the user gives a unique display name
    - use `--collection-key`, `--collection-path`, or `--collection-id` only when the user provides an exact selector
 3. For a first check, run `node scripts/run_kb_ingest.mjs collections list --json`.
-4. Upload with `node scripts/run_kb_ingest.mjs upload <path> --json`.
-5. For folders or long runs, add `--recursive`, `--concurrency`, `--retries`, and optionally `--manifest`.
-6. If the user asks to wait or verify later state, use `--wait` on upload or `node scripts/run_kb_ingest.mjs status <document-id> --json`.
+4. Ingest with `node scripts/run_kb_ingest.mjs bulk <path> --json`.
+5. For long runs, tune `--window-size`, `--top-up-max`, `--upload-concurrency`, `--retries`, and `--state`; the wrapper defaults `--max-polls` to `120` unless the user passes a value.
+6. If the user asks to verify later state, use `node scripts/run_kb_ingest.mjs status <document-id-or-job-id> --json`.
 7. Report only current CLI output and backend response fields. Do not infer success from direct database queries.
 
 ## Examples
@@ -43,13 +43,13 @@ Skill-owned behavior:
 Upload one file:
 
 ```bash
-node scripts/run_kb_ingest.mjs upload /path/to/document.pdf --json
+node scripts/run_kb_ingest.mjs bulk /path/to/document.pdf --json
 ```
 
-Upload a folder recursively:
+Upload a folder:
 
 ```bash
-node scripts/run_kb_ingest.mjs upload /path/to/folder --recursive --concurrency 3 --retries 3 --json
+node scripts/run_kb_ingest.mjs bulk /path/to/folder --upload-concurrency 3 --retries 3 --json
 ```
 
 List uploadable collections:
@@ -70,7 +70,7 @@ node scripts/run_kb_ingest.mjs status <document-id> --json
 - `duplicate: false` or missing: do not claim dedupe was checked unless the backend response says so.
 - `documentId`: use this id for follow-up status checks.
 - `status`: explain it as backend state. Terminal states are success/failure/deleted according to the API response; nonterminal states mean processing is still underway.
-- `jobId`, `requestId`, `idempotencyKey`, `rawUri`: include them when present because they help support/debugging.
+- `jobId`, `statePath`, `requestId`, `idempotencyKey`, `rawUri`: include them when present because they help support/debugging.
 
 ## Safety Boundary
 

--- a/tiangong-kb-ingest/agents/openai.yaml
+++ b/tiangong-kb-ingest/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong KB Ingest"
-  short_description: "Upload files to Tiangong KB with an API key"
-  default_prompt: "Use $tiangong-kb-ingest to upload local files into a Tiangong KB collection with a bearer API key and poll ingest status."
+  short_description: "Bulk ingest files to Tiangong KB with an API key"
+  default_prompt: "Use $tiangong-kb-ingest to bulk ingest local files into a Tiangong KB collection with a bearer API key and poll ingest status."

--- a/tiangong-kb-ingest/references/env.md
+++ b/tiangong-kb-ingest/references/env.md
@@ -25,7 +25,6 @@ TIANGONG_KB_DEFAULT_COLLECTION_KEY=course/thu_humanities
 TIANGONG_KB_DEFAULT_COLLECTION_PATH=/course/thu_humanities
 TIANGONG_KB_UPLOAD_CONCURRENCY=4
 TIANGONG_KB_UPLOAD_RETRIES=3
-TIANGONG_KB_BULK_MAX_POLLS=120
 TIANGONG_KB_BULK_POLL_INTERVAL=30
 TIANGONG_KB_TIMEOUT=300
 TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong-ai
@@ -42,9 +41,10 @@ and the skill is not running inside the workspace checkout that contains
 `tiangong-ai-cli`.
 
 Bulk ingest stores local checkpoint state in SQLite under the CLI app-data job
-directory unless `--state` is provided. The wrapper defaults `--max-polls` to
-`TIANGONG_KB_BULK_MAX_POLLS` or `120`; use `--max-polls 0` only for operator
-runs that should wait without a client-side polling limit.
+directory unless `--state` is provided. It has no client-side polling limit by
+default, so the CLI can keep topping up the sliding upload window. Set
+`TIANGONG_KB_BULK_MAX_POLLS` or pass `--max-polls <n>` only for bounded
+operator runs.
 
 ## Do Not Configure
 

--- a/tiangong-kb-ingest/references/env.md
+++ b/tiangong-kb-ingest/references/env.md
@@ -23,12 +23,11 @@ TIANGONG_KB_API_BASE_URL=https://thuenv.tiangong.world:7300
 TIANGONG_KB_API_PATH_PREFIX=/api/v1/kb
 TIANGONG_KB_DEFAULT_COLLECTION_KEY=course/thu_humanities
 TIANGONG_KB_DEFAULT_COLLECTION_PATH=/course/thu_humanities
-TIANGONG_KB_MANIFEST_PATH=.tiangong-kb-ingest-manifest.jsonl
-TIANGONG_KB_UPLOAD_CONCURRENCY=3
+TIANGONG_KB_UPLOAD_CONCURRENCY=4
 TIANGONG_KB_UPLOAD_RETRIES=3
-TIANGONG_KB_POLL_INTERVAL=2
+TIANGONG_KB_BULK_MAX_POLLS=120
+TIANGONG_KB_BULK_POLL_INTERVAL=30
 TIANGONG_KB_TIMEOUT=300
-TIANGONG_KB_WAIT_TIMEOUT=300
 TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong-ai
 ```
 
@@ -42,7 +41,10 @@ TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong-ai
 and the skill is not running inside the workspace checkout that contains
 `tiangong-ai-cli`.
 
-For large uploads, the manifest is append-only JSONL. Rerunning the same command with the same manifest skips files whose latest checkpoint status is `succeeded`; use `--force` to upload them again. The current per-file checkpoint key includes `sha256` and file size.
+Bulk ingest stores local checkpoint state in SQLite under the CLI app-data job
+directory unless `--state` is provided. The wrapper defaults `--max-polls` to
+`TIANGONG_KB_BULK_MAX_POLLS` or `120`; use `--max-polls 0` only for operator
+runs that should wait without a client-side polling limit.
 
 ## Do Not Configure
 

--- a/tiangong-kb-ingest/scripts/run_kb_ingest.mjs
+++ b/tiangong-kb-ingest/scripts/run_kb_ingest.mjs
@@ -36,8 +36,26 @@ const subcommand = args[0] ?? "";
 const nested = args[1] ?? "";
 let normalizedArgs;
 
+function hasFlag(items, name) {
+  return items.some((item) => item === name || item.startsWith(`${name}=`));
+}
+
+function withDefaultMaxPolls(items) {
+  if (hasFlag(items, "--max-polls")) return items;
+  return [...items, "--max-polls", process.env.TIANGONG_KB_BULK_MAX_POLLS?.trim() || "120"];
+}
+
+function withDefaultBulkRunMaxPolls(items) {
+  if (["scan", "preflight", "dry-run", "resume", "export"].includes(items[0] ?? "")) {
+    return items;
+  }
+  return withDefaultMaxPolls(items);
+}
+
 if (subcommand === "upload") {
-  normalizedArgs = ["kb", "ingest", "upload", ...args.slice(1)];
+  normalizedArgs = ["kb", "ingest", "bulk", ...withDefaultBulkRunMaxPolls(args.slice(1))];
+} else if (subcommand === "bulk") {
+  normalizedArgs = ["kb", "ingest", "bulk", ...withDefaultBulkRunMaxPolls(args.slice(1))];
 } else if (subcommand === "status") {
   normalizedArgs = ["kb", "ingest", "status", ...args.slice(1)];
 } else if (subcommand === "collections" && nested === "list") {

--- a/tiangong-kb-ingest/scripts/run_kb_ingest.mjs
+++ b/tiangong-kb-ingest/scripts/run_kb_ingest.mjs
@@ -36,26 +36,10 @@ const subcommand = args[0] ?? "";
 const nested = args[1] ?? "";
 let normalizedArgs;
 
-function hasFlag(items, name) {
-  return items.some((item) => item === name || item.startsWith(`${name}=`));
-}
-
-function withDefaultMaxPolls(items) {
-  if (hasFlag(items, "--max-polls")) return items;
-  return [...items, "--max-polls", process.env.TIANGONG_KB_BULK_MAX_POLLS?.trim() || "120"];
-}
-
-function withDefaultBulkRunMaxPolls(items) {
-  if (["scan", "preflight", "dry-run", "resume", "export"].includes(items[0] ?? "")) {
-    return items;
-  }
-  return withDefaultMaxPolls(items);
-}
-
 if (subcommand === "upload") {
-  normalizedArgs = ["kb", "ingest", "bulk", ...withDefaultBulkRunMaxPolls(args.slice(1))];
+  normalizedArgs = ["kb", "ingest", "bulk", ...args.slice(1)];
 } else if (subcommand === "bulk") {
-  normalizedArgs = ["kb", "ingest", "bulk", ...withDefaultBulkRunMaxPolls(args.slice(1))];
+  normalizedArgs = ["kb", "ingest", "bulk", ...args.slice(1)];
 } else if (subcommand === "status") {
   normalizedArgs = ["kb", "ingest", "status", ...args.slice(1)];
 } else if (subcommand === "collections" && nested === "list") {


### PR DESCRIPTION
## Summary
- Update `tiangong-kb-ingest` to use `kb ingest bulk` as the client mode.
- Remove JSONL manifest guidance and wrapper behavior.
- Stop injecting a default `--max-polls`; long bulk runs now follow CLI 0.0.9's unbounded default unless explicitly bounded.

## Validation
- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/jing/projects/ai-workspace/skills/tiangong-kb-ingest`
- Wrapper dry check confirmed no implicit `--max-polls` injection.
- `docpact lint --root /Users/jing/projects/ai-workspace/skills --worktree --mode enforce`

## Runtime Sync
- Updated local installed skill at `/Users/jing/.agents/skills/tiangong-kb-ingest`.
- Updated remote skill at `DELLw3425-new-remote-openclaw:/home/david/.agents/skills/tiangong-kb-ingest`.
