### PR TITLE
chore(skills): pin Tiangong AI CLI to 0.0.19

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "bf2b7e84d8913a5bb602bab51330ae0e59e40f2d"
+lastReviewedAt: "2026-07-22"
+lastReviewedCommit: "65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: bf2b7e84d8913a5bb602bab51330ae0e59e40f2d
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 65aa9a05ecb4d9eb18e52d83d58a5567fbbbe33c
 ---
 
 # Skills Documentation Standards

--- a/tiangong-kb-course-fulltext-fetch/SKILL.md
+++ b/tiangong-kb-course-fulltext-fetch/SKILL.md
@@ -13,7 +13,7 @@ and needs the full processed text for that document.
 Always call the Tiangong AI CLI:
 
 ```bash
-npx @tiangong-ai/cli@latest kb course fulltext --document-id <document_id> --tags <tags>
+npx @tiangong-ai/cli@0.0.19 kb course fulltext --document-id <document_id> --tags <tags>
 ```
 
 Do not call S3, NAS, Supabase, Pinecone, or OpenSearch directly from the skill.
@@ -22,7 +22,7 @@ handling.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint.
 - AWS credentials must already be available in the environment through the AWS
@@ -47,7 +47,7 @@ Pass the course `document_id` and `tags`:
 The wrapper calls:
 
 ```bash
-npx @tiangong-ai/cli@latest kb course fulltext --document-id <document_id> --tags <tags>
+npx @tiangong-ai/cli@0.0.19 kb course fulltext --document-id <document_id> --tags <tags>
 ```
 
 To save the full text:

--- a/tiangong-kb-course-fulltext-fetch/scripts/course_fulltext_fetch.sh
+++ b/tiangong-kb-course-fulltext-fetch/scripts/course_fulltext_fetch.sh
@@ -16,7 +16,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-course-search/SKILL.md
+++ b/tiangong-kb-course-search/SKILL.md
@@ -10,7 +10,7 @@ single-source: always search `course`, never `all`, `edu`, or `textbook`.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint.
 - Course search should use bearer auth. Pass `bearer_token`; if only `api_key`
@@ -39,7 +39,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest education search --query <query> --sources course --json
+npx @tiangong-ai/cli@0.0.19 education search --query <query> --sources course --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:
@@ -54,7 +54,7 @@ For exact edge-function payloads, provide `request_file` or `input_file`:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest education search --input <request.json> --sources course --json
+npx @tiangong-ai/cli@0.0.19 education search --input <request.json> --sources course --json
 ```
 
 ## Raw Payload Filters

--- a/tiangong-kb-course-search/scripts/course_search.sh
+++ b/tiangong-kb-course-search/scripts/course_search.sh
@@ -12,7 +12,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-edu-search/SKILL.md
+++ b/tiangong-kb-edu-search/SKILL.md
@@ -11,7 +11,7 @@ intentionally single-source: always search `edu`, never `all`, `course`, or
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint.
 - Set the authentication environment variables expected by `tiangong-ai`.
@@ -37,7 +37,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest education search --query <query> --sources edu --json
+npx @tiangong-ai/cli@0.0.19 education search --query <query> --sources edu --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-edu-search/scripts/edu_search.sh
+++ b/tiangong-kb-edu-search/scripts/edu_search.sh
@@ -12,7 +12,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-esg-search/SKILL.md
+++ b/tiangong-kb-esg-search/SKILL.md
@@ -11,7 +11,7 @@ multi-source preset.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint. Native ESG search requires
   `@tiangong-ai/cli@0.0.19` or later.
@@ -40,7 +40,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest research search --sources esg --query <query> --json
+npx @tiangong-ai/cli@0.0.19 research search --sources esg --query <query> --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-esg-search/scripts/esg_search.sh
+++ b/tiangong-kb-esg-search/scripts/esg_search.sh
@@ -12,7 +12,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-ingest/SKILL.md
+++ b/tiangong-kb-ingest/SKILL.md
@@ -7,7 +7,7 @@ description: Upload local files or folders into Tiangong KB through the Tiangong
 
 ## Boundary
 
-Use the Tiangong AI CLI for execution through `npx @tiangong-ai/cli@latest` by default, so users do not need a preinstalled CLI. The agent may orchestrate CLI schema, scan, metadata dry-run, and bulk commands, but it must not call backend databases or storage systems directly.
+Use the Tiangong AI CLI for execution through `npx @tiangong-ai/cli@0.0.19` by default, so users do not need a preinstalled CLI. The agent may orchestrate CLI schema, scan, metadata dry-run, and bulk commands, but it must not call backend databases or storage systems directly.
 
 CLI-owned behavior:
 
@@ -42,15 +42,15 @@ Skill-owned behavior:
    - for a folder, read `.env` from that folder
    - loaded dotenv values fill only unset environment variables; explicit user
      inputs passed as CLI flags take precedence
-4. For a first check, run `npx @tiangong-ai/cli@latest kb collections list --json`.
+4. For a first check, run `npx @tiangong-ai/cli@0.0.19 kb collections list --json`.
 5. For bulk/upload runs without `--metadata-map`, generate `metadata-map.yaml`:
    - call CLI collection schema through the Tiangong KB ingest API
    - call CLI bulk scan for folder structure
    - write a layered metadata map with base filesystem fields plus conservative domain/detector rules
    - run CLI metadata dry-run against the generated map
-6. Ingest with `npx @tiangong-ai/cli@latest kb ingest bulk <path> --json`; pass `--metadata-map metadata-map.yaml` unless a metadata map is already provided or the user explicitly asks to skip metadata-map generation.
+6. Ingest with `npx @tiangong-ai/cli@0.0.19 kb ingest bulk <path> --json`; pass `--metadata-map metadata-map.yaml` unless a metadata map is already provided or the user explicitly asks to skip metadata-map generation.
 7. For long runs, tune `--window-size`, `--top-up-max`, `--upload-concurrency`, `--retries`, and `--state`; do not add `--max-polls` unless the user explicitly wants a bounded monitoring run.
-8. If the user asks to verify later state, use `npx @tiangong-ai/cli@latest kb ingest status <document-id-or-job-id> --json`.
+8. If the user asks to verify later state, use `npx @tiangong-ai/cli@0.0.19 kb ingest status <document-id-or-job-id> --json`.
 9. Report only current CLI output and backend response fields. Do not infer success from direct database queries.
 
 ## Metadata Map Minimum
@@ -95,9 +95,9 @@ value, `0` for numbers, `false` for booleans, `1970-01-01` for dates, and
 Validate before upload:
 
 ```bash
-npx @tiangong-ai/cli@latest kb ingest bulk scan /path/to/folder --json
-npx @tiangong-ai/cli@latest kb collections schema --collection-key course/thu_humanities --json
-npx @tiangong-ai/cli@latest kb ingest metadata dry-run /path/to/folder --metadata-map metadata-map.yaml --json
+npx @tiangong-ai/cli@0.0.19 kb ingest bulk scan /path/to/folder --json
+npx @tiangong-ai/cli@0.0.19 kb collections schema --collection-key course/thu_humanities --json
+npx @tiangong-ai/cli@0.0.19 kb ingest metadata dry-run /path/to/folder --metadata-map metadata-map.yaml --json
 ```
 
 For offline validation with a captured schema, pass
@@ -108,43 +108,43 @@ For offline validation with a captured schema, pass
 Upload one file:
 
 ```bash
-npx @tiangong-ai/cli@latest kb ingest bulk /path/to/document.pdf --json
+npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/document.pdf --json
 ```
 
 Upload a folder:
 
 ```bash
-npx @tiangong-ai/cli@latest kb ingest bulk /path/to/folder --upload-concurrency 3 --retries 3 --json
+npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/folder --upload-concurrency 3 --retries 3 --json
 ```
 
 Use an existing metadata map:
 
 ```bash
-npx @tiangong-ai/cli@latest kb ingest bulk /path/to/folder --metadata-map metadata-map.yaml --json
+npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/folder --metadata-map metadata-map.yaml --json
 ```
 
 Use a metadata map saved at a specific path:
 
 ```bash
-npx @tiangong-ai/cli@latest kb ingest bulk /path/to/folder --metadata-map course-map.yaml --json
+npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/folder --metadata-map course-map.yaml --json
 ```
 
 List uploadable collections:
 
 ```bash
-npx @tiangong-ai/cli@latest kb collections list --capability upload --json
+npx @tiangong-ai/cli@0.0.19 kb collections list --capability upload --json
 ```
 
 Read a collection schema through the API:
 
 ```bash
-npx @tiangong-ai/cli@latest kb collections schema --collection-key course/thu_humanities --json
+npx @tiangong-ai/cli@0.0.19 kb collections schema --collection-key course/thu_humanities --json
 ```
 
 Check document status:
 
 ```bash
-npx @tiangong-ai/cli@latest kb ingest status <document-id> --json
+npx @tiangong-ai/cli@0.0.19 kb ingest status <document-id> --json
 ```
 
 ## Result Interpretation

--- a/tiangong-kb-ingest/references/env.md
+++ b/tiangong-kb-ingest/references/env.md
@@ -1,6 +1,6 @@
 # Environment
 
-The skill invokes the Tiangong AI CLI with `npx @tiangong-ai/cli@latest` by default. The CLI calls the Tiangong KB ingest API and authenticates with an API key sent as `Authorization: Bearer <token>`.
+The skill invokes the Tiangong AI CLI with `npx @tiangong-ai/cli@0.0.19` by default. The CLI calls the Tiangong KB ingest API and authenticates with an API key sent as `Authorization: Bearer <token>`.
 
 For local file or folder uploads, load dotenv defaults from the target path
 directory before invoking the CLI: use the parent directory for a file and the
@@ -43,7 +43,7 @@ TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong-ai
 `TIANGONG_KB_API_KEY` is accepted as a fallback alias for `TIANGONG_AI_API_KEY`.
 
 `TIANGONG_AI_CLI_BIN` is optional. Set it only when intentionally overriding the
-default `npx @tiangong-ai/cli@latest` entrypoint with a local or pinned
+default `npx @tiangong-ai/cli@0.0.19` entrypoint with a local or pinned
 `tiangong-ai` executable.
 
 Bulk ingest stores local checkpoint state in SQLite under the CLI app-data job

--- a/tiangong-kb-patent-search/SKILL.md
+++ b/tiangong-kb-patent-search/SKILL.md
@@ -10,7 +10,7 @@ single-source: always search `patent`, never `all`, `sci`, or `report`.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint.
 - Set the authentication environment variables expected by `tiangong-ai`, or
@@ -37,7 +37,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest research search --query <query> --sources patent --json
+npx @tiangong-ai/cli@0.0.19 research search --query <query> --sources patent --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-patent-search/scripts/patent_search.sh
+++ b/tiangong-kb-patent-search/scripts/patent_search.sh
@@ -12,7 +12,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-report-search/SKILL.md
+++ b/tiangong-kb-report-search/SKILL.md
@@ -10,7 +10,7 @@ single-source: always search `report`, never `all`, `sci`, or `patent`.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint.
 - Set the authentication environment variables expected by `tiangong-ai`, or
@@ -37,7 +37,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest research search --query <query> --sources report --json
+npx @tiangong-ai/cli@0.0.19 research search --query <query> --sources report --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-report-search/scripts/report_search.sh
+++ b/tiangong-kb-report-search/scripts/report_search.sh
@@ -12,7 +12,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-sci-search/SKILL.md
+++ b/tiangong-kb-sci-search/SKILL.md
@@ -10,7 +10,7 @@ single-source: always search `sci`, never `all`, `report`, or `patent`.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint.
 - Set the authentication environment variables expected by `tiangong-ai`, or
@@ -38,7 +38,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest research search --query <query> --sources sci --json
+npx @tiangong-ai/cli@0.0.19 research search --query <query> --sources sci --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-sci-search/scripts/sci_search.sh
+++ b/tiangong-kb-sci-search/scripts/sci_search.sh
@@ -12,7 +12,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-textbook-search/SKILL.md
+++ b/tiangong-kb-textbook-search/SKILL.md
@@ -10,7 +10,7 @@ single-source: always search `textbook`, never `all`, `course`, or `edu`.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@latest`; users do not need a
+- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
   override the CLI entrypoint.
 - Set the authentication environment variables expected by `tiangong-ai`.
@@ -36,7 +36,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@latest education search --query <query> --sources textbook --json
+npx @tiangong-ai/cli@0.0.19 education search --query <query> --sources textbook --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-textbook-search/scripts/textbook_search.sh
+++ b/tiangong-kb-textbook-search/scripts/textbook_search.sh
@@ -12,7 +12,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@latest)
+    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
 fi
 
 if [ -z "$JSON_INPUT" ]; then


### PR DESCRIPTION
Closes tiangong-ai/skills#36

@linancn Please review this CLI version pin.

## Summary
- Pin every `@tiangong-ai/cli@latest` invocation in the 9 affected CLI-backed skills to `@tiangong-ai/cli@0.0.19`.
- Keep runtime behavior reproducible and require explicit review for future CLI upgrades.

## Key Decisions
- Use the npm registry `latest` version verified on 2026-07-22: `0.0.19`.
- Limit functional changes to 18 files containing CLI invocation pins.
- Record docpact review evidence as metadata-only updates in 9 governed documents.
- Explicitly exclude `academic-paper-download`, unrelated documentation content, marketplace metadata, and other working-tree changes.

## Validation
- All 9 affected skills pass `quick_validate.py`.
- All affected shell wrappers pass `bash -n`.
- `npx --yes @tiangong-ai/cli@0.0.19 --help` succeeds.
- No `@tiangong-ai/cli@latest` occurrences remain in the scoped skills.
- `git diff --check` passes.
- `docpact validate-config --root . --strict` passes.
- `docpact lint --root . --base origin/main --head HEAD` passes with 0 active diagnostics.

## Risks / Rollback
- Future CLI releases will not be adopted automatically.
- Roll back by reverting these commits, or update the pin in a reviewed follow-up.

## Follow-ups
- Update the pinned version explicitly when a newer CLI release is reviewed.

## Workspace Integration
- The root workspace pins the `skills` repository. After this child PR merges, adopt the exact merged commit through a separate root workspace integration change if required.