### PR TITLE
feat: add production auto-research workflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-04"
-lastReviewedCommit: "3469296a63234dd5451f1c3fcd5172ce396bf33e"
+lastReviewedAt: "2026-08-06"
+lastReviewedCommit: "0d660c7401e5e307f742571dda7854500b38d9af"
 
 repo:
   id: skills

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.pyc
 **/assets/config.env
+.docpact/runs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-04
-lastReviewedCommit: 3469296a63234dd5451f1c3fcd5172ce396bf33e
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 2432b091ba4d56ba4c3dcbec0e6870ed1b689cf4
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-07-23
-lastReviewedCommit: 2432b091ba4d56ba4c3dcbec0e6870ed1b689cf4
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-04
-lastReviewedCommit: 3469296a63234dd5451f1c3fcd5172ce396bf33e
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-04
-lastReviewedCommit: 3469296a63234dd5451f1c3fcd5172ce396bf33e
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-04
-lastReviewedCommit: 3469296a63234dd5451f1c3fcd5172ce396bf33e
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-04
-lastReviewedCommit: 3469296a63234dd5451f1c3fcd5172ce396bf33e
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-04
-lastReviewedCommit: 3469296a63234dd5451f1c3fcd5172ce396bf33e
+lastReviewedAt: 2026-08-06
+lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-auto-research
-description: Run bounded, multi-stage research through a Tiangong research workspace with immutable inputs, capability-locked method skills, hard budgets, isolated producer execution, independent review, provenance, and mechanical closure. Use when a user asks to initialize, configure, execute, resume, inspect, or close a traceable research project, or asks how to configure its research environment and capabilities. Do not use for a single Tiangong edge-search request.
+description: Run smoke-test or production Tiangong research workspaces with explicit evidence requirements, immutable inputs and broker evidence, capability locks, pre-call budgets, isolated producer execution, independent review, and mechanical closure. Use when a user asks to plan, initialize, configure, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
 ---
 
 # Tiangong Auto Research
@@ -8,123 +8,162 @@ description: Run bounded, multi-stage research through a Tiangong research works
 Use the pinned CLI for every workspace operation:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.20 research --help
+npx --yes @tiangong-ai/cli@0.0.21 research --help
 ```
 
-Do not reproduce scheduling, evidence collection, review, or closure in the
-coordinating agent. The CLI runtime owns those actions.
+The CLI is the only authority for output schemas, coverage gates, scheduling,
+budget accounting, retries, evidence promotion, review, and closure. Do not
+reimplement those rules in this skill or a coordinating agent.
 
-## Route the request
+## Choose the mode first
 
-1. Resolve every workspace and input path to an absolute path.
-2. Inspect before mutation:
+- Use `smoke-test` only for routing checks, deterministic mocks, workflow demos,
+  or a low-cost canary the user explicitly accepts.
+- Use `production-research` for conclusions the user intends to rely on. Never
+  present a minimal Crossref/search capability as production coverage.
 
-   ```bash
-   npx --yes @tiangong-ai/cli@0.0.20 research context inspect \
-     --path /absolute/path/to/workspace --json
-   ```
+Read [references/production-research.md](references/production-research.md)
+before initializing or resuming production work, configuring broker HTTP,
+recovering a project, or interpreting a blocked run. Read
+[references/env.md](references/env.md) before configuring credentials or agent
+authentication or an agent wrapper.
 
-3. Follow the returned role and `allowedOperations` exactly:
-   - `unmanaged`: initialize only when the user wants a new workspace.
-   - `workspace`: continue with workspace commands.
-   - `invalid`: stop and report the violations. Do not repair state by hand.
+## Inspect before mutation
 
-## Initialize a workspace
+Resolve workspace and input paths to absolute paths, then run:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.20 research workspace init \
-  /absolute/path/to/workspace --name "Research name" --json
+npx --yes @tiangong-ai/cli@0.0.21 research context inspect \
+  --path /absolute/path/to/workspace --json
 ```
 
-Use the generated defaults unless the user requests different budgets or agent
-routes. When editing `.tiangong-research/config.json`, preserve schema version
-1, keep all budgets positive, and use different agent families for `producer`
-and `reviewer`. A binary must be the exact agent name or an absolute path.
+Follow `role` and `allowedOperations` exactly:
 
-Never edit `workspace.json`, `runtime-lock.json`, `journal.jsonl`, project state,
-run receipts, locks, or outputs directly.
+- `unmanaged`: initialize only when the user wants a new workspace.
+- `workspace`: continue through CLI commands.
+- `invalid`: stop and report the violations; never repair state by hand.
 
-## Admit method capabilities
-
-Method skills remain external and are admitted through
-`.tiangong-research/capabilities.json`. Each `skillPath` must be absolute and
-contain a valid `SKILL.md` whose name matches its directory.
-
-Use only current permissions: `project-read`, `candidate-write`,
-`brokered-network`, and `controlled-command`. A `brokered-network` capability
-must declare exact HTTPS hosts in `allowedHosts`. Credential host scopes must be
-subsets of the capability host scope.
-
-After any declaration change, freeze and verify both the skill tree and policy:
+## Initialize and preflight
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.20 research capability lock \
-  --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.20 research capability verify \
-  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.21 research workspace init \
+  /absolute/path/to/workspace --name "Research name" \
+  --mode production-research --json
 ```
 
-Read [references/env.md](references/env.md) before configuring credentials.
-
-## Register projects and inputs
-
-Use one stable lowercase project ID per research question:
+Before project initialization, prepare an evidence-requirements JSON object
+with `dimensions`, `sourceTypes`, `minSources`, `minFullTextSources`,
+`minDatedSources`, and nullable `publicationDateFrom` / `publicationDateTo`
+boundaries. For large local sources, also prepare one immutable input plan with
+bounded `contextPath` or `contextRanges` entries as described in the production
+reference. Then generate the required evidence/capability/gap/cost checklist:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.20 research project init gpu-resource-impact \
+npx --yes @tiangong-ai/cli@0.0.21 research project preflight \
   --workspace /absolute/path/to/workspace \
-  --question "How do advanced GPU process nodes change environmental resource burdens?" \
-  --json
+  --question "Research question" \
+  --requirements /absolute/path/to/evidence-requirements.json \
+  --input-plan /absolute/path/to/input-plan.json --json
 ```
 
-Admit existing local evidence through the CLI so its digest becomes immutable:
+Stop when production requirements are missing, the capability/input plan
+cannot cover them, or the projected budget needs confirmation. Pass
+`--confirm-budget` only after the user explicitly accepts the threshold.
+Omit `--input-plan` only when locked broker capabilities alone provide the
+declared acquisition plan; otherwise pass the identical verified plan to
+preflight and `project init`.
+
+Never edit `workspace.json`, `runtime-lock.json`, `journal.jsonl`, evidence
+objects/receipts, project state, run records, locks, or outputs directly.
+
+## Admit and freeze capabilities
+
+Method skills remain external and use absolute `skillPath` declarations.
+Current permissions are `project-read`, `candidate-write`,
+`brokered-network`, and `controlled-command`.
+
+For brokered HTTP, declare exact `allowedHosts` and one `http` policy with an
+exact `accept`, allowed content types, maximum response bytes, and maximum
+items. Declare capability `coverage` when preflight should match dimensions,
+source types, full-text access, or publication dates. Workspace config applies
+an additional estimated-token cap to staged broker context. Credential scopes
+must be subsets of capability hosts. Lock after every tree or policy change:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.20 research project input add gpu-resource-impact \
-  --workspace /absolute/path/to/workspace \
-  --path /absolute/path/to/inventory.csv \
-  --role primary --json
+npx --yes @tiangong-ai/cli@0.0.21 research capability lock \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.21 research capability verify \
+  --workspace /absolute/path/to/workspace --json
 ```
 
-Use `primary` for direct evidence, `reference` for contextual material, and
-`replication` for reproducibility inputs. Do not copy unregistered files into
-the control directory.
+## Register the project and inputs
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.21 research project init gpu-resource-impact \
+  --workspace /absolute/path/to/workspace \
+  --question "Research question" \
+  --requirements /absolute/path/to/evidence-requirements.json \
+  --input-plan /absolute/path/to/input-plan.json \
+  --confirm-budget --json
+
+npx --yes @tiangong-ai/cli@0.0.21 research project input add gpu-resource-impact \
+  --workspace /absolute/path/to/workspace \
+  --path /absolute/path/to/inventory.csv --role primary --json
+```
+
+Use `primary` for direct evidence, `reference` for context, and `replication`
+for reproducibility material. Use `project input add` only for an additional
+small source that should be exposed in full; use the verified input plan when
+producer context must be bounded. Do not copy unregistered files into the
+control directory.
 
 ## Validate and run
 
-Run the doctor before execution:
+Production work requires the real producer and reviewer capsule smoke:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.20 research workspace doctor \
+npx --yes @tiangong-ai/cli@0.0.21 research workspace doctor \
+  --workspace /absolute/path/to/workspace --agent-smoke --json
+```
+
+Proceed only when status is `ready`. Preview scheduling, then expose the JSONL
+progress stream for long runs:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.21 research run \
+  --workspace /absolute/path/to/workspace --project PROJECT --dry-run --json
+npx --yes @tiangong-ai/cli@0.0.21 research run \
+  --workspace /absolute/path/to/workspace --project PROJECT \
+  --max-cycles 20 --progress-jsonl --json
+```
+
+Prefer an explicit `--project` for a single-project task. It scopes production
+budget confirmation, scheduling, result summaries, progress events, and exit
+status to that project, so older blocked siblings remain auditable without
+contaminating the current run. Omit it only for an intentional workspace-wide
+batch.
+
+Do not bypass the runtime with direct agents or web calls. When evidence
+coverage is insufficient, report the gaps and stop; do not spend analyze,
+synthesize, or review budget. The production smoke attestation is valid for 24
+hours and is bound to config, capabilities, schemas, and resolved runtimes;
+rerun doctor after expiry or any drift instead of bypassing it.
+
+## Inspect, recover, and hand off
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.21 research status \
   --workspace /absolute/path/to/workspace --json
 ```
 
-Proceed only when status is `ready`. Preview scheduling when useful, then run:
+Report the package, classified failure, retry time, split token usage, cost,
+sanitized provider diagnostics, and limitations. Use `research project retry`
+or `research project fork` only with explicit user direction; these commands
+preserve promoted artifacts and append management events. Never reset state or
+delete capsules/evidence by hand.
 
-```bash
-npx --yes @tiangong-ai/cli@0.0.20 research run \
-  --workspace /absolute/path/to/workspace --dry-run --json
-npx --yes @tiangong-ai/cli@0.0.20 research run \
-  --workspace /absolute/path/to/workspace \
-  --max-parallel 2 --max-cycles 20 --json
-```
-
-The runtime executes at most one ready package per project per cycle. Separate
-projects may run concurrently. Do not bypass the runtime with direct agent or
-web calls.
-
-## Inspect and hand off
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.20 research status \
-  --workspace /absolute/path/to/workspace --json
-```
-
-If a project is blocked, report the failed package, bounded error, attempts,
-and recorded usage. Do not reset package state or budgets without explicit user
-direction. A complete project must have a passing independent review and
-`outputs/closure.json`.
-
-Return the project status, artifact paths, usage totals, review decision, and
-material limitations. Treat `outputs/report.md` as the research deliverable and
-`outputs/closure.json` as the completion receipt.
+A complete project must contain passing independent review and
+`outputs/closure.json`. Return the status, artifact paths, permanent evidence
+receipts, content-addressed review packet/context locators, usage, review
+decision, and material limitations. Treat `outputs/report.md` as the
+deliverable and `outputs/closure.json` as its mechanical completion receipt.

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Run bounded Tiangong research workspaces"
-  default_prompt: "Use $tiangong-auto-research to set up or continue a bounded Tiangong research workspace."
+  short_description: "Run production-ready Tiangong research"
+  default_prompt: "Use $tiangong-auto-research to preflight and run a traceable smoke-test or production research workspace."

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -3,7 +3,7 @@
 ## Runtime prerequisites
 
 - Node.js 24.
-- `npx` access to `@tiangong-ai/cli@0.0.20`.
+- `npx` access to `@tiangong-ai/cli@0.0.21`.
 - Authenticated `codex` and `claude` executables, unless absolute binary paths
   are selected in `.tiangong-research/config.json`.
 - macOS with `/usr/bin/sandbox-exec`, or Linux with Bubblewrap available as
@@ -12,6 +12,48 @@
 Authenticate the agent CLIs through their standard local login before running a
 project. Capability service credentials use the workspace contract below and
 are never agent environment variables.
+
+If doctor reports that Claude is not logged in, start Claude interactively
+outside the research workspace, complete its normal `/login` flow, then rerun
+doctor. Do not copy tokens from keychains, browser profiles, or another agent
+HOME into the workspace. If a custom agent wrapper is selected, use an absolute
+path, keep the wrapper immutable for the run, and let doctor record and verify
+its hash; do not add undocumented transport or authentication flags.
+
+The tested macOS/Linux template is
+`scripts/agent-wrapper-posix.sh`; validate it with
+`scripts/test-agent-wrapper-posix.sh`. Configure the route explicitly:
+
+```json
+{
+  "agent": "codex",
+  "binary": "/absolute/path/to/agent-wrapper-posix.sh",
+  "wrapperTargetBinary": "/absolute/path/to/codex",
+  "model": "explicit-model-id",
+  "effort": "low",
+  "verbosity": "low"
+}
+```
+
+The runtime sets `TIANGONG_RESEARCH_AGENT_BINARY` to the resolved target; do not
+set or forward that variable yourself. The target, wrapper, and internal
+adapter hashes are attested independently, and target drift stops execution.
+
+The CLI creates a dedicated HOME for every capsule. It copies only the
+supported minimal agent credential file when one exists (for example Codex
+`auth.json`), never a complete Chrome/agent profile. For Claude, an owner-only
+user `settings.json` is not copied: the runtime extracts only
+`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and a
+credential-free HTTPS `ANTHROPIC_BASE_URL` from its `env` object. Permissions,
+hooks, extra directories, and other settings are excluded. On macOS,
+credentials held by the system keychain remain in the keychain. Production
+doctor must be run with `--agent-smoke` to detect a missing login, first-launch
+gate, unwritable state database, or sandbox incompatibility before an expensive
+package starts.
+The successful attestation lasts 24 hours and must be regenerated after config,
+capability, schema, binary, or wrapper drift. Sanitized provider transport
+diagnostics may appear in doctor details even when the provider subsequently
+falls back and succeeds; use the final check status as the readiness decision.
 
 ## Capability credentials
 
@@ -49,6 +91,18 @@ in this file.
       "skillPath": "/absolute/path/to/public-source-skill",
       "permissions": ["project-read", "candidate-write", "brokered-network"],
       "allowedHosts": ["api.example.org"],
+      "http": {
+        "accept": "application/json",
+        "allowedContentTypes": ["application/json"],
+        "maxResponseBytes": 524288,
+        "maxItems": 100
+      },
+      "coverage": {
+        "dimensions": ["research-question"],
+        "sourceTypes": ["primary"],
+        "fullText": true,
+        "publicationDates": true
+      },
       "credentials": [
         {
           "id": "source.example.api",

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -1,0 +1,265 @@
+# Production research workflow
+
+Load this reference for production initialization, a resumed/blocked project,
+broker configuration, or recovery. The CLI remains authoritative when this
+reference and runtime output differ.
+
+## Production admission checklist
+
+Before `project init`, record and show the user:
+
+1. The research question and evidence dimensions.
+2. Required source types, minimum sources, minimum full-text sources, and any
+   date/applicability boundaries.
+3. Available immutable inputs and locked capabilities that can satisfy each
+   requirement.
+4. Gaps that would block the post-discovery coverage gate.
+5. Package token reservations, configured price basis, maximum cost, and
+   whether the confirmation threshold is crossed.
+
+Use `research project preflight`; do not calculate a competing checklist in the
+skill. Production `project init` requires its evidence-requirements file and,
+when the configured threshold is crossed, explicit `--confirm-budget`.
+
+## Reproducible route configuration
+
+Production mode requires different agent families, explicit model IDs, and
+explicit pricing for producer and reviewer. `binary` must be the exact agent
+name or an absolute executable path. Prefer the exact `codex` / `claude`
+routes. If an explicit wrapper is required, set its absolute path in `binary`
+and the underlying absolute agent path in `wrapperTargetBinary`; never use a
+wrapper with an unpinned PATH lookup. The runtime separately records the target
+binary, route launcher/wrapper, and internal adapter SHA-256 values, plus the
+reported version, actual/configured model, OS, and architecture.
+`workspace doctor --agent-smoke` executes both routes in real capsules and
+writes a 24-hour attestation bound to those runtime fingerprints, workspace
+config, capability lock, and doctor schema. Expiry or drift blocks execution
+before the next agent invocation.
+
+The budget includes:
+
+- total tokens, cost, and wall time;
+- a token reservation for every agent stage;
+- maximum structured-output and repair tokens;
+- output file count/bytes and attempts;
+- broker response bytes, context items, and estimated context tokens;
+- the cost-confirmation threshold.
+
+The CLI will not start a package unless its full token and conservative price
+reservation fits. Immediately before each call it accounts for prompt and
+schema bytes at three bytes per token, agent-specific protocol overhead,
+input repeated for every permitted API turn, primary output, and a possible
+isolated repair's input and output. The provider cost cap is derived from that
+package reservation, not the project's remaining global allowance. Tool-free
+primary stages allow two protocol turns because Claude's schema output uses
+`StructuredOutput` followed by its result; external tools remain disabled. The
+repair path omits the provider schema tool, requests plain JSON in one turn,
+and still passes through the same CLI validators.
+Current Codex and Claude CLI adapters expose final output usage only after the
+call. Preflight therefore reports `outputTokenLimitEnforcement` as
+`post-execution`: captured bytes bound the process, and an over-limit result is
+rejected without promotion, but the limit is not a provider-side hard stop.
+Reserve enough output for the discover schema and enough input context for the
+embedded prior-stage artifacts; preflight reports both gaps mechanically.
+It also reports per-stage `maxTurns` and route-specific
+`turnLimitEnforcement`. Claude receives its cap from the provider CLI. The
+current Codex CLI has no turn-limit flag, so its value is a conservative
+reservation assumption followed by actual-usage rejection; do not describe it
+as a provider hard stop.
+
+## Bounded local evidence
+
+Use the same absolute `--input-plan` for preflight and project initialization.
+Each entry registers the exact full source plus evidence dimensions, source
+type, full-text claim, publication date, and either:
+
+- `contextPath`: a separate regular, non-symlink excerpt whose own SHA-256 is
+  admitted; or
+- `contextRanges`: sorted, non-overlapping, one-based inclusive line ranges
+  from a UTF-8 source.
+
+```json
+{
+  "schemaVersion": 1,
+  "inputs": [
+    {
+      "path": "/absolute/path/to/source.txt",
+      "contextRanges": [{ "startLine": 20, "endLine": 80 }],
+      "role": "primary",
+      "dimensions": ["energy", "water"],
+      "sourceType": "peer-reviewed",
+      "fullText": true,
+      "publicationDate": "2024-01-15"
+    }
+  ]
+}
+```
+
+The producer receives only the derived bounded context. The full, hash-verified
+source is withheld until independent review and is then listed in the review
+packet. The CLI rejects symlinks, duplicate source content, overlapping or
+out-of-range slices, changed hashes, and aggregate context above
+`maxInputContextTokens`. Declaring `fullText: true` means the exact full file is
+registered for review; it does not expose that entire file to discovery.
+
+## Authoritative output contracts
+
+Inspect, but never copy or fork, a current contract with:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.21 research schema show discover --json
+npx --yes @tiangong-ai/cli@0.0.21 research schema show analyze --json
+npx --yes @tiangong-ai/cli@0.0.21 research schema show review --json
+```
+
+Evidence sources include stable ID/title/locator/provenance, URL or DOI when
+safe and available, source type, publication/retrieval dates, full-text status,
+an excerpt or JSON Pointer, quality rationale, applicability, and covered
+dimensions. The CLI verifies input locators and every broker object. Findings
+may cite only admitted source IDs.
+
+Codex receives `--output-schema`; Claude receives `--json-schema`. The CLI
+validates the final object and materializes it atomically. Invalid syntax or
+schema, or a mechanically diagnosed invalid provenance/finding binding, gets
+one low-budget formatting-only repair with no broker access or research tools.
+The repair may not add facts. A second failure stops the package instead of
+repeating the research call.
+
+## Broker evidence
+
+A `brokered-network` capability has exact hosts plus an HTTP policy:
+
+```json
+{
+  "id": "method.public-source",
+  "skillPath": "/absolute/path/to/public-source-skill",
+  "permissions": ["project-read", "candidate-write", "brokered-network"],
+  "allowedHosts": ["api.example.org"],
+  "http": {
+    "accept": "application/json",
+    "allowedContentTypes": ["application/json"],
+    "maxResponseBytes": 524288,
+    "maxItems": 100
+  },
+  "coverage": {
+    "dimensions": ["research-question"],
+    "sourceTypes": ["primary"],
+    "fullText": true,
+    "publicationDates": true
+  },
+  "credentials": []
+}
+```
+
+Each successful body is written to the immutable content-addressed evidence
+store before its capsule is deleted. A receipt binds the response hash/size,
+content type, hashed final URL, raw locator, bounded context locator, retrieval
+time, and cache status. Review packets enumerate and hash these permanent
+objects.
+
+The review capsule merges the registered local bounded contexts and every
+cited broker receipt's exact bounded view. That merged context and the complete
+review packet are themselves stored by content hash under the project's
+`review/contexts/` and `review/packets/` directories. The packet enumerates raw
+broker objects and full local-file hashes; the model reads only the merged
+bounded views. Mechanical closure checks that the packet, merged context,
+broker objects, and local input/context hashes still exist and match before it
+records their safe locators.
+
+Use `json_pointer` and `max_items` for a bounded JSON view. The workspace's
+`maxBrokerContextTokens` limit additionally caps the staged view using a
+conservative `ceil(contextBytes / 3)` estimate while retaining the exact raw
+object. For a collection, continue within that object by sending the returned
+`contextNextOffset` as `item_offset`; each view has its own receipt and context
+object, while the raw response is reused without another upstream fetch.
+Follow upstream pagination only through its next admitted HTTPS URL so each
+upstream response receives its own permanent receipt. Public requests default
+to the persistent cache; pass `cache_mode=bypass` for a fresh request.
+Credentialed requests always require bypass to avoid replaying scoped content
+under changed authorization.
+
+The broker sends the capability's exact `Accept`, checks every redirect host,
+screens credential-like response material, and rejects undeclared content
+types or oversized bodies. Non-2xx results include only status, a sanitized
+short response, safe request ID, and parsed `Retry-After`.
+
+## Coverage, retry, and recovery
+
+Discovery output is promoted for diagnosis, then checked mechanically. The CLI
+derives local full-text availability, source types, source counts, dated counts,
+date range, per-dimension source IDs, and the pass/insufficient decision from
+admitted sources and declared minimums. `partial` is usable but incomplete;
+`missing` or any unmet source/full-text/date minimum blocks all downstream
+packages. Model-provided qualitative gaps remain visible but cannot override
+those derived fields.
+
+Only broker-enabled discovery receives the strictly read-only workspace tools
+and broker. Analyze embeds the admitted evidence object; synthesize embeds
+admitted evidence and analysis. Both stages run with tools disabled. Review is
+also tool-free and embeds the immutable packet, generated artifacts, and exact
+bounded local/broker evidence views within two structured-output protocol
+turns. Full files and raw
+objects remain hash-bound for later human/mechanical audit; never report that
+the model read beyond the embedded views. Run records, journal usage, and JSONL
+progress include sanitized event/item counts, provider turns, tool calls,
+reasoning-token counts, and bounded provider errors.
+
+Failures are classified:
+
+- configuration/authentication/deterministic 4xx, coverage, and review failures
+  stop immediately;
+- structured-output failures use only the repair path;
+- 429 may retry after its recorded delay;
+- bounded transient/5xx failures may retry while attempts and budget remain.
+
+Use an explicit management command instead of editing state:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.21 research project retry PROJECT \
+  --package PACKAGE --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.21 research project fork SOURCE \
+  --to TARGET --resume-through analyze \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Retry grants one auditable extra attempt and resets downstream scheduling while
+preserving promoted files. Fork starts a new budget/accounting history and may
+inherit only verified completed discovery/analysis/synthesis artifacts; review
+and closure always run again.
+
+Run one recovered or canary project with an explicit scope:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.21 research run \
+  --project PROJECT --workspace /absolute/path/to/workspace \
+  --progress-jsonl --json
+```
+
+The top-level result and run-level JSONL events then carry that `projectId`, and
+historical blocked siblings do not change its exit code. Omit `--project` only
+when the operator intends to schedule and summarize the whole workspace.
+
+## Standard zero-cost eval before a real canary
+
+Confirm the owning CLI release passed deterministic mock coverage for:
+
+- routing and smoke/production mode boundaries;
+- discover → analyze → synthesize → review → close;
+- permanent evidence and review-packet hash verification;
+- persistent bounded review-context verification and packet/context tamper
+  rejection before closure;
+- malformed JSON repair and a second-failure stop;
+- invalid provenance/finding binding repair without repeating research;
+- 429, deterministic 4xx/422, 5xx, redirect, oversized response, cache, and
+  bounded offset extraction with raw-object reuse;
+- capsule HOME/sandbox startup and evidence/journal recovery;
+- bounded local producer context with full-source reviewer staging;
+- discovery-only tools and tool-free analyze/synthesize/review stages;
+- capability drift and evidence tampering;
+- insufficient evidence blocking closure;
+- secret redaction across output, provider telemetry, errors, progress,
+  journal, and manifests.
+- project-scoped execution in a workspace containing historical blockers.
+
+Only then run a real-model canary with low package reservations. Do not infer
+production readiness from a Crossref-only or single-source smoke test.

--- a/tiangong-auto-research/scripts/agent-wrapper-posix.sh
+++ b/tiangong-auto-research/scripts/agent-wrapper-posix.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+target=${TIANGONG_RESEARCH_AGENT_BINARY:-}
+case "$target" in
+  /*) ;;
+  *)
+    printf '%s\n' "TIANGONG_RESEARCH_AGENT_BINARY must be an absolute path." >&2
+    exit 64
+    ;;
+esac
+
+if [ ! -f "$target" ] || [ ! -x "$target" ]; then
+  printf '%s\n' "Configured research agent binary is not an executable regular file." >&2
+  exit 69
+fi
+
+unset TIANGONG_RESEARCH_AGENT_BINARY
+exec "$target" "$@"

--- a/tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
+++ b/tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+wrapper="$script_dir/agent-wrapper-posix.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/tiangong-agent-wrapper.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+target="$test_root/fake-agent"
+
+printf '%s\n' \
+  '#!/bin/sh' \
+  'if [ -n "${TIANGONG_RESEARCH_AGENT_BINARY:-}" ]; then exit 65; fi' \
+  'printf "%s|%s\n" "$1" "$2"' >"$target"
+chmod 700 "$target"
+
+actual=$(TIANGONG_RESEARCH_AGENT_BINARY="$target" "$wrapper" alpha "two words")
+if [ "$actual" != "alpha|two words" ]; then
+  printf '%s\n' "wrapper did not preserve arguments" >&2
+  exit 1
+fi
+
+if TIANGONG_RESEARCH_AGENT_BINARY=relative/path "$wrapper" alpha beta >/dev/null 2>&1; then
+  printf '%s\n' "wrapper accepted a relative target" >&2
+  exit 1
+fi
+
+printf '%s\n' "POSIX agent wrapper test passed."


### PR DESCRIPTION
Closes tiangong-ai/skills#41

## Summary
- Separate `tiangong-auto-research` smoke-test and production-research modes.
- Add a focused production reference, tested POSIX agent wrappers, budget/coverage preflight guidance, recovery semantics, and persistent evidence/review documentation.
- Keep the skill concise while treating the CLI schemas and runtime checks as authoritative.

## Key Decisions
- `SKILL.md` routes users and agents; production details live in `references/production-research.md`.
- Skills do not duplicate CLI output schemas, scheduler, budget, provenance, review, or closure logic.
- Wrapper, target, and adapter identities are independently fingerprinted.
- Authentication examples remain whitelisted and owner-only; no credentials or private session material are stored.
- Provider turn-limit differences and cost-confirmation thresholds are explicit.

## Validation
- `python3.13 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py tiangong-auto-research`
- `bash tiangong-auto-research/scripts/test-agent-wrapper-posix.sh`
- `docpact validate-config --root . --strict`
- `docpact lint --root . --worktree --format json --output .docpact/runs/latest.json` — 0 findings
- `git diff --check`

## Risks / Rollback
- Production mode requires the corresponding hardened CLI release; older CLIs may not expose the documented preflight, recovery, or packet semantics.
- Roll back by reverting this PR and pinning the previous skills commit; no user credentials or mutable runtime state are migrated by this repository.

## Follow-ups
- None beyond the root integration and CLI 0.0.21 release tracked below.

## Workspace Integration
- Pending: merge the CLI runtime PR, pin both exact merge commits in `tiangong-ai/workspace`, update the repo graph and release manifest, and mark Project integration complete.