### PR TITLE
feat(auto-research): add external evidence Skill readiness

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-06"
-lastReviewedCommit: "0d660c7401e5e307f742571dda7854500b38d9af"
+lastReviewedAt: "2026-08-07"
+lastReviewedCommit: "7814e2116f80df37e40419643b44803d8595ee85"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -78,3 +78,22 @@ npm i skills -g
 
 Environment requirements live with each skill. Before using a skill that calls
 an external service, read that skill's `references/env.md` when present.
+
+## Auto Research External Evidence
+
+`tiangong-auto-research` coordinates external evidence Skills; this repository
+is not itself the production evidence-provider catalog. From the intended
+workspace, inspect the pinned recommendations, installation plan, provider
+requirements, and current status with:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
+  --path /absolute/path/to/workspace --json
+```
+
+The default `internet-research` profile requires the external `web-search` and
+`news-search` Skills plus an owner-held Brave Search API key. Enhanced context
+and media profiles are explicit and provider-plan dependent. Owner-authorized
+databases are imported individually from external, immutable Skill definitions.
+See `tiangong-auto-research/references/external-skills.md`; the research runtime
+never installs these dependencies automatically.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -78,3 +78,20 @@ npm i skills -g
 
 环境变量要求由各 skill 自己维护。使用会调用外部服务的 skill 前，优先阅读该
 skill 的 `references/env.md`（如存在）。
+
+## Auto Research 外部证据能力
+
+`tiangong-auto-research` 负责协调外生的证据 Skills；本仓库本身不是生产研究的
+证据提供者目录。在目标 workspace 中，用以下命令查看精确锁定的推荐项、安装
+计划、服务商要求和当前状态：
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
+  --path /absolute/path/to/workspace --json
+```
+
+默认 `internet-research` profile 需要外部 `web-search`、`news-search` Skills，
+以及用户持有的 Brave Search API key。增强上下文和媒体 profile 必须显式选择，
+并受服务商套餐约束。用户有权访问的数据库通过外部、不可变的 Skill 定义逐个
+导入。完整流程见 `tiangong-auto-research/references/external-skills.md`；研究
+runtime 不会自动安装这些依赖。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-07
+lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-auto-research
-description: Run smoke-test or production Tiangong research workspaces with explicit evidence requirements, immutable inputs and broker evidence, capability locks, pre-call budgets, isolated producer execution, independent review, and mechanical closure. Use when a user asks to plan, initialize, configure, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
+description: Run smoke-test or production Tiangong research workspaces with explicit evidence requirements, external evidence Skills for the public internet and owner-whitelisted databases, immutable inputs and broker evidence, pre-call budgets, isolated producer execution, independent review, and mechanical closure. Use when a user asks to plan, initialize, configure, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
 ---
 
 # Tiangong Auto Research
@@ -8,32 +8,38 @@ description: Run smoke-test or production Tiangong research workspaces with expl
 Use the pinned CLI for every workspace operation:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research --help
+npx --yes @tiangong-ai/cli@0.0.23 research --help
 ```
 
-The CLI is the only authority for output schemas, coverage gates, scheduling,
-budget accounting, retries, evidence promotion, review, and closure. Do not
-reimplement those rules in this skill or a coordinating agent.
+The CLI is the authority for the external capability catalog, output schemas,
+coverage gates, scheduling, budgets, retries, evidence promotion, review, and
+closure. Do not reimplement those rules in this skill or a coordinating agent.
 
 ## Choose the mode first
 
-- Use `smoke-test` only for routing checks, deterministic mocks, workflow demos,
+- Use `smoke-test` only for deterministic mocks, routing checks, workflow demos,
   or a low-cost canary the user explicitly accepts.
-- Use `production-research` for conclusions the user intends to rely on. Never
-  present a minimal Crossref/search capability as production coverage.
+- Use `production-research` for conclusions the user intends to rely on.
+  Production must include a locked external public-internet capability; local
+  inputs alone cannot represent internet coverage.
 
-Read [references/production-research.md](references/production-research.md)
-before initializing or resuming production work, configuring broker HTTP,
-recovering a project, or interpreting a blocked run. Read
-[references/env.md](references/env.md) before configuring credentials or agent
-authentication or an agent wrapper.
+Load the detailed references only when needed:
+
+- Read [references/external-skills.md](references/external-skills.md) for a new
+  or clean workspace, profile selection, external Skill installation, status
+  interpretation, provider checks, or an owner-whitelisted database.
+- Read [references/production-research.md](references/production-research.md)
+  before initializing or resuming production work, configuring broker HTTP,
+  recovering a project, or interpreting a blocked run.
+- Read [references/env.md](references/env.md) before configuring credentials,
+  agent authentication, or an agent wrapper.
 
 ## Inspect before mutation
 
 Resolve workspace and input paths to absolute paths, then run:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research context inspect \
+npx --yes @tiangong-ai/cli@0.0.23 research context inspect \
   --path /absolute/path/to/workspace --json
 ```
 
@@ -43,127 +49,135 @@ Follow `role` and `allowedOperations` exactly:
 - `workspace`: continue through CLI commands.
 - `invalid`: stop and report the violations; never repair state by hand.
 
-## Initialize and preflight
+## Prepare external evidence capabilities
+
+For production, inspect the complete external recommendation and status catalog
+before project initialization:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research workspace init \
-  /absolute/path/to/workspace --name "Research name" \
-  --mode production-research --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
+  --path /absolute/path/to/workspace --json
 ```
 
-Before project initialization, prepare an evidence-requirements JSON object
-with `dimensions`, `sourceTypes`, `minSources`, `minFullTextSources`,
-`minDatedSources`, and nullable `publicationDateFrom` / `publicationDateTo`
-boundaries. For large local sources, also prepare one immutable input plan with
-bounded `contextPath` or `contextRanges` entries as described in the production
-reference. Then generate the required evidence/capability/gap/cost checklist:
+Show the user the recommended, enhanced, conditional, and evaluated-but-not-
+selected Skills, their provider/key requirements, and current installation
+status. Run only the exact pinned project installation plan the catalog returns,
+outside the research runtime and after the user has selected a profile. Never
+install dependencies from an agent package or silently substitute a provider.
+
+Initialize the workspace, configure the explicit profile, store the logical
+credential from an owner environment variable, and test the selected endpoints:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research project preflight \
+npx --yes @tiangong-ai/cli@0.0.23 research workspace init \
+  /absolute/path/to/workspace --name "Research name" \
+  --mode production-research --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability configure \
+  --profile internet-research \
+  --skill-root /absolute/path/to/workspace/.agents/skills \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
+  --id brave.search.api-key --from-env BRAVE_SEARCH_API_KEY \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability doctor --live \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Stop on a missing Skill, missing key, unsupported subscription endpoint, drift,
+or failed live check. Do not downgrade a selected profile without telling the
+user. Import an owner-whitelisted database only from its reviewed external
+definition, then rerun credential setup and live doctor as described in the
+external-Skills reference.
+
+## Preflight before project creation
+
+Prepare evidence requirements with `dimensions`, `sourceTypes`, `minSources`,
+`minFullTextSources`, `minDatedSources`, and nullable `publicationDateFrom` /
+`publicationDateTo`. For large local sources, also prepare one immutable input
+plan with bounded `contextPath` or `contextRanges` entries.
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research project preflight \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json --json
 ```
 
-Stop when production requirements are missing, the capability/input plan
-cannot cover them, or the projected budget needs confirmation. Pass
-`--confirm-budget` only after the user explicitly accepts the threshold.
-Omit `--input-plan` only when locked broker capabilities alone provide the
-declared acquisition plan; otherwise pass the identical verified plan to
-preflight and `project init`.
+Stop when production requirements are missing, the capability/input plan cannot
+cover them, or the projected budget needs confirmation. Pass `--confirm-budget`
+only after the user explicitly accepts the threshold. Omit `--input-plan` only
+when locked broker capabilities alone provide the declared acquisition plan.
 
 Never edit `workspace.json`, `runtime-lock.json`, `journal.jsonl`, evidence
 objects/receipts, project state, run records, locks, or outputs directly.
 
-## Admit and freeze capabilities
+## Freeze capabilities and register the project
 
-Method skills remain external and use absolute `skillPath` declarations.
-Current permissions are `project-read`, `candidate-write`,
-`brokered-network`, and `controlled-command`.
-
-For brokered HTTP, declare exact `allowedHosts` and one `http` policy with an
-exact `accept`, allowed content types, maximum response bytes, and maximum
-items. Declare capability `coverage` when preflight should match dimensions,
-source types, full-text access, or publication dates. Workspace config applies
-an additional estimated-token cap to staged broker context. Credential scopes
-must be subsets of capability hosts. Lock after every tree or policy change:
+After every external tree or policy change, verify the content lock:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research capability lock \
+npx --yes @tiangong-ai/cli@0.0.23 research capability lock \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.21 research capability verify \
+npx --yes @tiangong-ai/cli@0.0.23 research capability verify \
   --workspace /absolute/path/to/workspace --json
 ```
 
-## Register the project and inputs
+Register the project with the same verified requirements and input plan used by
+preflight:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research project init gpu-resource-impact \
+npx --yes @tiangong-ai/cli@0.0.23 research project init PROJECT \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json \
   --confirm-budget --json
-
-npx --yes @tiangong-ai/cli@0.0.21 research project input add gpu-resource-impact \
-  --workspace /absolute/path/to/workspace \
-  --path /absolute/path/to/inventory.csv --role primary --json
 ```
 
-Use `primary` for direct evidence, `reference` for context, and `replication`
-for reproducibility material. Use `project input add` only for an additional
-small source that should be exposed in full; use the verified input plan when
-producer context must be bounded. Do not copy unregistered files into the
-control directory.
+Use `project input add` only for an additional small source that may be exposed
+in full. Use `primary` for direct evidence, `reference` for context, and
+`replication` for reproducibility material. Do not copy unregistered files into
+the control directory.
 
 ## Validate and run
 
-Production work requires the real producer and reviewer capsule smoke:
+Configure explicit producer/reviewer models and pricing in the generated
+workspace config. Production requires different agent families and both real
+capsule and provider-capability smokes:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research workspace doctor \
-  --workspace /absolute/path/to/workspace --agent-smoke --json
-```
-
-Proceed only when status is `ready`. Preview scheduling, then expose the JSONL
-progress stream for long runs:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.21 research run \
+npx --yes @tiangong-ai/cli@0.0.23 research workspace doctor \
+  --workspace /absolute/path/to/workspace \
+  --agent-smoke --capability-smoke --json
+npx --yes @tiangong-ai/cli@0.0.23 research run \
   --workspace /absolute/path/to/workspace --project PROJECT --dry-run --json
-npx --yes @tiangong-ai/cli@0.0.21 research run \
+npx --yes @tiangong-ai/cli@0.0.23 research run \
   --workspace /absolute/path/to/workspace --project PROJECT \
   --max-cycles 20 --progress-jsonl --json
 ```
 
-Prefer an explicit `--project` for a single-project task. It scopes production
-budget confirmation, scheduling, result summaries, progress events, and exit
-status to that project, so older blocked siblings remain auditable without
-contaminating the current run. Omit it only for an intentional workspace-wide
-batch.
-
-Do not bypass the runtime with direct agents or web calls. When evidence
-coverage is insufficient, report the gaps and stop; do not spend analyze,
-synthesize, or review budget. The production smoke attestation is valid for 24
-hours and is bound to config, capabilities, schemas, and resolved runtimes;
-rerun doctor after expiry or any drift instead of bypassing it.
+Proceed only when doctor reports `ready`. Prefer an explicit `--project`; omit
+it only for an intentional workspace-wide batch. The runtime embeds locked
+external Skill instructions and lets discovery call only the scoped broker.
+Do not bypass it with direct agents, shell commands, or unbrokered web calls.
+When coverage is insufficient, report the gaps and stop before downstream
+packages consume budget.
 
 ## Inspect, recover, and hand off
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research status \
-  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.23 research status \
+  --workspace /absolute/path/to/workspace --project PROJECT --json
 ```
 
 Report the package, classified failure, retry time, split token usage, cost,
 sanitized provider diagnostics, and limitations. Use `research project retry`
-or `research project fork` only with explicit user direction; these commands
-preserve promoted artifacts and append management events. Never reset state or
-delete capsules/evidence by hand.
+or `research project fork` only with explicit user direction; never reset state
+or delete capsules/evidence by hand.
 
-A complete project must contain passing independent review and
-`outputs/closure.json`. Return the status, artifact paths, permanent evidence
-receipts, content-addressed review packet/context locators, usage, review
-decision, and material limitations. Treat `outputs/report.md` as the
-deliverable and `outputs/closure.json` as its mechanical completion receipt.
+A complete project has passing independent review and
+`outputs/closure.json`. Return the report path, permanent evidence receipts,
+content-addressed review packet/context locators, usage, review decision, and
+material limitations. Treat `outputs/report.md` as the deliverable and
+`outputs/closure.json` as its mechanical completion receipt.

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Run production-ready Tiangong research"
-  default_prompt: "Use $tiangong-auto-research to preflight and run a traceable smoke-test or production research workspace."
+  short_description: "Run traceable research with external evidence"
+  default_prompt: "Use $tiangong-auto-research to inspect and configure external evidence Skills, preflight coverage and budget, and run a traceable production research workspace."

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -3,11 +3,17 @@
 ## Runtime prerequisites
 
 - Node.js 24.
-- `npx` access to `@tiangong-ai/cli@0.0.21`.
+- `npx` access to `@tiangong-ai/cli@0.0.23`.
+- `git` plus pinned `skills@1.5.22` access for the explicit external-Skill
+  installation plan returned by `research capability catalog`.
 - Authenticated `codex` and `claude` executables, unless absolute binary paths
   are selected in `.tiangong-research/config.json`.
 - macOS with `/usr/bin/sandbox-exec`, or Linux with Bubblewrap available as
   `bwrap`.
+- For the baseline `internet-research` profile, an owner-held Brave Search API
+  key and provider-plan access to Web and News Search. LLM Context, image, and
+  video endpoints require their selected profile and may require additional
+  provider-plan access.
 
 Authenticate the agent CLIs through their standard local login before running a
 project. Capability service credentials use the workspace contract below and
@@ -55,6 +61,12 @@ capability, schema, binary, or wrapper drift. Sanitized provider transport
 diagnostics may appear in doctor details even when the provider subsequently
 falls back and succeeds; use the final check status as the readiness decision.
 
+The outer `sandbox-exec`/Bubblewrap capsule is the execution boundary. Codex is
+started without a nested sandbox because nested macOS Seatbelt can cancel MCP
+calls. This does not grant shell access: discovery has shell, unified-exec,
+filesystem, and undeclared integrations disabled and can call only the scoped
+broker. Analyze, synthesize, and review are tool-free.
+
 ## Capability credentials
 
 The only accepted key in `.tiangong-research/.env` is:
@@ -79,6 +91,21 @@ Requirements:
 
 Do not place agent login tokens, cloud credentials, or unrelated service keys
 in this file.
+
+For a recommended internet profile, configure the shared logical credential
+without putting its value in a command argument:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
+  --id brave.search.api-key --from-env BRAVE_SEARCH_API_KEY \
+  --workspace /absolute/path/to/workspace --json
+```
+
+For an owner-whitelisted database, use the logical ID declared in that external
+capability and an explicit owner environment variable, for example
+`--id database.owner-source.api-key --from-env OWNER_DATABASE_API_KEY`. Never
+reuse a browser cookie, Authorization header dump, session token, or agent API
+key as a capability credential.
 
 ## Capability declaration example
 

--- a/tiangong-auto-research/references/external-skills.md
+++ b/tiangong-auto-research/references/external-skills.md
@@ -1,0 +1,260 @@
+# External evidence Skills
+
+Use this reference when starting from a clean directory, selecting an internet
+profile, installing or diagnosing recommended Skills, or admitting a database
+the workspace owner is authorized to query.
+
+## Contents
+
+- [Boundary and source of truth](#boundary-and-source-of-truth)
+- [Clean-directory setup](#clean-directory-setup)
+- [Profiles and recommended Skills](#profiles-and-recommended-skills)
+- [Credentials and live checks](#credentials-and-live-checks)
+- [Status interpretation](#status-interpretation)
+- [Owner-whitelisted databases](#owner-whitelisted-databases)
+- [Evaluated alternatives](#evaluated-alternatives)
+- [Failure rules](#failure-rules)
+
+## Boundary and source of truth
+
+Research method implementations are external to Tiangong Auto Research and the
+Tiangong Skills repository. The CLI catalog records which external Skills were
+reviewed, their immutable source commit and whole-tree hash, why each is or is
+not recommended, and how the current workspace is configured.
+
+Use the machine-readable catalog as the authority:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
+  --path /absolute/path/to/workspace --json
+```
+
+The runtime never installs dependencies. Installation happens as an explicit
+owner action before capability configuration. A Skill only documents how to
+query a source; the broker separately enforces exact HTTPS hosts, GET-only
+request policy, response bounds, logical credentials, and permanent evidence
+receipts.
+
+The goal is broad, best-effort coverage across every source the owner has
+selected and is authorized to use. It is not a claim that any provider indexes
+the entire internet or that an unavailable subscription can be bypassed.
+
+## Clean-directory setup
+
+Prerequisites:
+
+- Node.js 24, `git`, and `npx`;
+- authenticated Codex and Claude CLIs for the producer/reviewer routes;
+- macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`);
+- a Brave Search API key and a plan that exposes Web and News Search for the
+  baseline internet profile;
+- any owner database credentials required by explicitly imported capabilities.
+
+From the empty directory, verify the pinned CLI and inspect the plan before
+creating research state:
+
+```bash
+cd /absolute/path/to/workspace
+npx --yes @tiangong-ai/cli@0.0.23 --version
+npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
+  --path /absolute/path/to/workspace --json
+```
+
+For the baseline profile, the catalog's `installer.projectPlan.commands`
+performs this exact sequence with absolute paths:
+
+```bash
+git init --quiet /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6
+git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 remote add origin https://github.com/brave/brave-search-skills.git
+git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 fetch --depth 1 origin 3e088af66eb61f1c207c22b2be0278ca8744d1d1
+git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 checkout --detach FETCH_HEAD
+test "$(git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 rev-parse HEAD)" = 3e088af66eb61f1c207c22b2be0278ca8744d1d1
+npx --yes skills@1.5.22 add /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 \
+  --skill web-search news-search --agent codex --yes --copy
+```
+
+Do not copy this example with a different workspace path by guesswork. Prefer
+the absolute commands returned for the current directory, review them, and run
+them one at a time. Do not pipe catalog output into a shell. The checkout
+directory must not already exist; an existing directory is a state to inspect,
+not permission to overwrite it.
+
+For enhanced or media profiles, use each selected entry's
+`install.projectPlan`, or the catalog's `allRecommendedProjectPlan` to install
+all five reviewed recommendations. The CLI verifies every selected installed
+tree before writing a lock, so merely seeing a directory is not success.
+
+Then initialize and configure the project-local copy:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research workspace init \
+  /absolute/path/to/workspace --mode production-research --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability configure \
+  --profile internet-research \
+  --skill-root /absolute/path/to/workspace/.agents/skills \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Never treat an unpinned globally installed copy as a substitute for the
+project-local plan when reproducibility matters.
+
+## Profiles and recommended Skills
+
+Choose one profile explicitly:
+
+| Profile | Selected Skills | Use |
+| --- | --- | --- |
+| `internet-research` | `web-search`, `news-search` | Default public-internet discovery; both are required. |
+| `internet-research-with-context` | baseline plus `llm-context` | Use only when the provider plan exposes LLM Context and extracted page context materially improves the study. |
+| `internet-research-with-media` | context profile plus `images-search`, `videos-search` | Use when visual or audiovisual sources are material evidence. |
+
+All current recommendations come from external repository
+`brave/brave-search-skills` at commit
+`3e088af66eb61f1c207c22b2be0278ca8744d1d1` under MIT:
+
+| Skill | Tier | Expected whole-tree SHA-256 |
+| --- | --- | --- |
+| `web-search` | required | `0432f4eb084766046a2feeb146f0b3917850d138eb4182c23fc000a058fbe123` |
+| `news-search` | required | `80f8dcb7c78209cce5315e507f0aba21e3f654f42f6a414c177de644bcd07773` |
+| `llm-context` | enhanced, plan-dependent | `5abba551d0498a80eba4e64207f483974f5a312cda5b263c1cc2b7f99d81c4a3` |
+| `images-search` | conditional | `467a9afae0e959b482cb6b2236a57a327959b28985871f88c202dc70b10a7c84` |
+| `videos-search` | conditional | `ff3a2e2291efc27f3f09847b7e0b20e77d229f6a44a1a64e562964c820eb9719` |
+
+Do not silently fall back from a profile when one selected endpoint is missing
+or unavailable. Report the endpoint/plan failure and ask the user to either fix
+access or explicitly select a different profile.
+
+## Credentials and live checks
+
+The five Brave Skills share logical credential ID `brave.search.api-key`.
+Obtain the owner key through the provider's normal account flow and expose it
+to the configuration process as `BRAVE_SEARCH_API_KEY`. Do not place the value
+in a command argument, document, capability definition, or chat message.
+
+Store it through the non-echoing logical-credential command:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
+  --id brave.search.api-key --from-env BRAVE_SEARCH_API_KEY \
+  --workspace /absolute/path/to/workspace --json
+```
+
+The command writes only the owner-only workspace credential store and never
+returns the value. Agent processes do not receive it; the broker injects it for
+the declared host only.
+
+Run both static and live verification before production preflight:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability verify \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability doctor --live \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.23 research workspace doctor \
+  --workspace /absolute/path/to/workspace \
+  --agent-smoke --capability-smoke --json
+```
+
+`llm-context`, image, and video access may differ by provider plan. A key that
+passes Web Search does not prove every selected endpoint is enabled.
+
+## Status interpretation
+
+Call catalog again with the workspace to obtain one complete status view:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
+  --path /absolute/path/to/workspace \
+  --workspace /absolute/path/to/workspace \
+  --skill-root /absolute/path/to/workspace/.agents/skills --json
+```
+
+Interpret the machine fields rather than directory presence:
+
+- `installation.status=missing`: run the returned pinned plan.
+- `installation.status=drifted`: the discovered tree does not match the
+  catalog hash; restore the exact source instead of re-locking it.
+- `installation.status=ambiguous`: more than one exact candidate is visible;
+  select one explicit project root.
+- `installation.status=installed`: exactly one safe tree matches.
+- `status.configured=false`: the Skill is installed but not declared in this
+  workspace.
+- `status.locked=false`: configuration and verified content lock disagree.
+- `status.credential=not-configured`: the Skill is not selected in this
+  workspace; `missing` means it is selected but its logical value is absent;
+  `configured` means the value is present; `not-required` means the capability
+  declares no credential; `blocked` means credential inspection itself failed.
+  A `missing` or `blocked` state authorizes no provider request.
+- a live doctor failure means package execution must not start. Authentication,
+  subscription, deterministic 4xx, unsafe content type, and drift failures stop
+  immediately; one bounded 429 retry is the only automatic live-check retry.
+
+Catalog output also includes actionable installation commands, provider-plan
+text, exact hosts, credential IDs, summary counts, and evaluated alternatives.
+Show these statuses to the user before spending model budget.
+
+## Owner-whitelisted databases
+
+An owner-authorized database is another external capability; it is not ambient
+agent access. Start from `customExternalCapabilities.brokeredEvidenceDefinitionTemplate`
+in catalog output and create an external JSON definition containing:
+
+- an absolute path to the separately installed external Skill;
+- a top-level `SKILL.md` containing the complete bounded GET endpoint and
+  response-shape instructions needed for discovery. The runtime embeds that
+  file and the capability manifest; discovery has no filesystem tool with which
+  to follow additional reference links;
+- external source identity, full immutable git commit/exact registry version or
+  local content reference, license, and expected whole-tree SHA-256;
+- exact HTTPS hosts and a bounded GET response policy;
+- a safe health check;
+- coverage dimensions, source types, discovery scopes, full-text/date claims;
+- logical credential IDs and exact host/header scopes, never credential values;
+- `requiredForDiscovery: true` when the study must query that database.
+
+Import, configure the declared key, and probe the real endpoint:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.23 research capability import \
+  --definition /absolute/path/to/external-capability.json \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
+  --id database.owner-source.api-key --from-env OWNER_DATABASE_API_KEY \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.23 research capability doctor --live \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Do not import a Tiangong project-owned Skill as an evidence provider, import a
+symlinked tree, broaden hosts with wildcards, authorize POST through the current
+GET broker, or convert a login/session cookie into a reusable database key.
+
+## Evaluated alternatives
+
+The catalog records all other Skills reviewed from the pinned Brave source:
+
+- `answers`: not admitted because it synthesizes through POST and is not raw
+  evidence under the GET broker.
+- `bx`: not admitted because it delegates to another executable and credential
+  store outside the broker boundary.
+- `local-descriptions` and `local-pois`: install and explicitly import only for
+  a research question with a material place/POI dimension.
+- `spellcheck` and `suggest`: query helpers, not independently reviewable
+  evidence sources.
+
+These dispositions are explicit review results, not hidden automatic choices.
+
+## Failure rules
+
+- Missing package, Skill, key, provider plan, or binary: return the structured
+  catalog/doctor error and its minimum user action; do not install at runtime.
+- Tree/source drift or ambiguity: stop before lock or execution.
+- Authentication, authorization, subscription, or database access failure:
+  stop and report; never bypass it.
+- Local-only production plan: stop. A locked external public-internet
+  capability is mandatory, and every capability marked `requiredForDiscovery`
+  must produce its own receipt.
+- Secret-like URL parameters, Authorization/Cookie headers, API keys, and
+  tokens must not appear in output, events, journal, evidence, or manifests.
+- Successful live checks prove endpoint connectivity only. The post-discovery
+  coverage gate still decides whether the collected evidence is sufficient.

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -12,7 +12,8 @@ Before `project init`, record and show the user:
 2. Required source types, minimum sources, minimum full-text sources, and any
    date/applicability boundaries.
 3. Available immutable inputs and locked capabilities that can satisfy each
-   requirement.
+   requirement, including the selected external internet profile and every
+   owner-whitelisted database marked required for discovery.
 4. Gaps that would block the post-discovery coverage gate.
 5. Package token reservations, configured price basis, maximum cost, and
    whether the confirmation threshold is crossed.
@@ -45,12 +46,18 @@ The budget includes:
 - broker response bytes, context items, and estimated context tokens;
 - the cost-confirmation threshold.
 
+New workspaces default to 500,000 total tokens, with 200,000 reserved as the
+discovery package ceiling; analyze, synthesize, and review default to 55,000,
+60,000, and 120,000. These values are admission ceilings, not a target spend.
+Lower them only when preflight proves every complete reservation still fits.
+
 The CLI will not start a package unless its full token and conservative price
 reservation fits. Immediately before each call it accounts for prompt and
 schema bytes at three bytes per token, agent-specific protocol overhead,
-input repeated for every permitted API turn, primary output, and a possible
-isolated repair's input and output. The provider cost cap is derived from that
-package reservation, not the project's remaining global allowance. Tool-free
+input repeated for every permitted API turn, the maximum bounded broker context
+for every permitted discovery turn, primary output, and a possible isolated
+repair's input and output. The provider cost cap is derived from that package
+reservation, not the project's remaining global allowance. Tool-free
 primary stages allow two protocol turns because Claude's schema output uses
 `StructuredOutput` followed by its result; external tools remain disabled. The
 repair path omits the provider schema tool, requests plain JSON in one turn,
@@ -59,6 +66,8 @@ Current Codex and Claude CLI adapters expose final output usage only after the
 call. Preflight therefore reports `outputTokenLimitEnforcement` as
 `post-execution`: captured bytes bound the process, and an over-limit result is
 rejected without promotion, but the limit is not a provider-side hard stop.
+Discovery capture allowance includes bounded broker tool-result events as well
+as the requested final output.
 Reserve enough output for the discover schema and enough input context for the
 embedded prior-stage artifacts; preflight reports both gaps mechanically.
 It also reports per-stage `maxTurns` and route-specific
@@ -107,9 +116,9 @@ registered for review; it does not expose that entire file to discovery.
 Inspect, but never copy or fork, a current contract with:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research schema show discover --json
-npx --yes @tiangong-ai/cli@0.0.21 research schema show analyze --json
-npx --yes @tiangong-ai/cli@0.0.21 research schema show review --json
+npx --yes @tiangong-ai/cli@0.0.23 research schema show discover --json
+npx --yes @tiangong-ai/cli@0.0.23 research schema show analyze --json
+npx --yes @tiangong-ai/cli@0.0.23 research schema show review --json
 ```
 
 Evidence sources include stable ID/title/locator/provenance, URL or DOI when
@@ -193,12 +202,14 @@ admitted sources and declared minimums. `partial` is usable but incomplete;
 packages. Model-provided qualitative gaps remain visible but cannot override
 those derived fields.
 
-Only broker-enabled discovery receives the strictly read-only workspace tools
-and broker. Analyze embeds the admitted evidence object; synthesize embeds
-admitted evidence and analysis. Both stages run with tools disabled. Review is
-also tool-free and embeds the immutable packet, generated artifacts, and exact
-bounded local/broker evidence views within two structured-output protocol
-turns. Full files and raw
+Discovery receives no shell or filesystem tools. The CLI embeds the locked
+capability manifest and each staged external Skill's top-level `SKILL.md`, and
+the scoped broker is its only execution tool. Broker results include the exact
+bounded view inline with the receipt. Analyze embeds the admitted evidence
+object; synthesize embeds admitted evidence and analysis. Both stages run with
+tools disabled. Review is also tool-free and embeds the immutable packet,
+generated artifacts, and exact bounded local/broker evidence views within two
+structured-output protocol turns. Full files and raw
 objects remain hash-bound for later human/mechanical audit; never report that
 the model read beyond the embedded views. Run records, journal usage, and JSONL
 progress include sanitized event/item counts, provider turns, tool calls,
@@ -215,9 +226,9 @@ Failures are classified:
 Use an explicit management command instead of editing state:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research project retry PROJECT \
+npx --yes @tiangong-ai/cli@0.0.23 research project retry PROJECT \
   --package PACKAGE --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.21 research project fork SOURCE \
+npx --yes @tiangong-ai/cli@0.0.23 research project fork SOURCE \
   --to TARGET --resume-through analyze \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -230,7 +241,7 @@ and closure always run again.
 Run one recovered or canary project with an explicit scope:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.21 research run \
+npx --yes @tiangong-ai/cli@0.0.23 research run \
   --project PROJECT --workspace /absolute/path/to/workspace \
   --progress-jsonl --json
 ```
@@ -243,6 +254,12 @@ when the operator intends to schedule and summarize the whole workspace.
 
 Confirm the owning CLI release passed deterministic mock coverage for:
 
+- a clean empty directory, pinned external installer plan, and explicit
+  installed/configured/locked/credential/live statuses;
+- missing external Skills, missing credentials, unavailable provider plans,
+  symlinked or drifting trees, and actionable structured failures;
+- explicit owner-database import, required-discovery receipt enforcement, and
+  local-only production rejection;
 - routing and smoke/production mode boundaries;
 - discover → analyze → synthesize → review → close;
 - permanent evidence and review-packet hash verification;
@@ -254,12 +271,15 @@ Confirm the owning CLI release passed deterministic mock coverage for:
   bounded offset extraction with raw-object reuse;
 - capsule HOME/sandbox startup and evidence/journal recovery;
 - bounded local producer context with full-source reviewer staging;
-- discovery-only tools and tool-free analyze/synthesize/review stages;
+- broker-only discovery with embedded locked Skill documentation and tool-free
+  analyze/synthesize/review stages;
+- a broker result larger than the historical 64 KiB capture floor;
 - capability drift and evidence tampering;
 - insufficient evidence blocking closure;
 - secret redaction across output, provider telemetry, errors, progress,
   journal, and manifests.
 - project-scoped execution in a workspace containing historical blockers.
 
-Only then run a real-model canary with low package reservations. Do not infer
-production readiness from a Crossref-only or single-source smoke test.
+Only then run a bounded real-model canary with reservations that pass preflight.
+Do not infer production readiness from a Crossref-only or single-source smoke
+test.


### PR DESCRIPTION
## Summary

- make production research depend on explicitly selected external evidence Skills instead of local-only evidence
- document three internet profiles, five pinned recommendations, six evaluated alternatives, and owner-whitelisted database admission
- add clean-directory installation, logical credential, machine-readable status, provider doctor, and failure guidance
- pin all examples to the published @tiangong-ai/cli 0.0.23 catalog and runtime contracts

## Validation

- published CLI 0.0.23 clean-directory version and catalog check
- pinned Brave source install at commit 3e088af66eb61f1c207c22b2be0278ca8744d1d1
- project-local Web and News whole-tree locks verified
- missing-key doctor blocked structurally; configured live doctor passed both endpoints with HTTP 200
- tiangong-auto-research quick_validate and POSIX wrapper test
- academic-paper-download quick_validate
- isolated Python 3.12 install from exact requirements plus pip check
- academic-paper-download unittest: 71 passed
- docpact staged lint: 0 findings
- git diff --check

## Integration

Root workspace submodule integration remains pending until this PR is merged.

Closes #43