### PR TITLE
feat(auto-research): add guarded external Skill setup guidance

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-07"
-lastReviewedCommit: "7814e2116f80df37e40419643b44803d8595ee85"
+lastReviewedAt: "2026-08-08"
+lastReviewedCommit: "0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # Tiangong AI Skills
@@ -79,21 +79,23 @@ npm i skills -g
 Environment requirements live with each skill. Before using a skill that calls
 an external service, read that skill's `references/env.md` when present.
 
-## Auto Research External Evidence
+## Auto Research External Skill Setup
 
-`tiangong-auto-research` coordinates external evidence Skills; this repository
-is not itself the production evidence-provider catalog. From the intended
-workspace, inspect the pinned recommendations, installation plan, provider
-requirements, and current status with:
+Use `npx skills` directly for ordinary Skill management. For an Auto Research
+workspace, prefer the CLI's guarded setup layer: it still uses the exact pinned
+`skills` CLI underneath, while also binding source commits, tree hashes,
+destinations, license choices, credential names, and audit state. Start with the
+read-only catalog or the guided Wizard:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
-  --path /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.24 research setup \
+  --workspace /absolute/path/to/workspace --json
 ```
 
-The default `internet-research` profile requires the external `web-search` and
-`news-search` Skills plus an owner-held Brave Search API key. Enhanced context
-and media profiles are explicit and provider-plan dependent. Owner-authorized
-databases are imported individually from external, immutable Skill definitions.
-See `tiangong-auto-research/references/external-skills.md`; the research runtime
-never installs these dependencies automatically.
+The catalog includes Brave internet evidence, optional Tiangong SCI/document/
+paper companions, and optional Anthropic or PPT Master post-closure authoring
+Skills. Every entry is external, separately licensed, pinned, and user-selected;
+nothing is bundled or installed by a research package. See
+`tiangong-auto-research/references/setup.md` and `external-skills.md`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0d660c7401e5e307f742571dda7854500b38d9af
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # 天工 AI Skills
@@ -79,19 +79,21 @@ npm i skills -g
 环境变量要求由各 skill 自己维护。使用会调用外部服务的 skill 前，优先阅读该
 skill 的 `references/env.md`（如存在）。
 
-## Auto Research 外部证据能力
+## Auto Research 外部 Skill 配置
 
-`tiangong-auto-research` 负责协调外生的证据 Skills；本仓库本身不是生产研究的
-证据提供者目录。在目标 workspace 中，用以下命令查看精确锁定的推荐项、安装
-计划、服务商要求和当前状态：
+普通 Skill 管理可以直接使用 `npx skills`。Auto Research workspace 应优先使用
+CLI 的防呆 setup 层：底层仍调用精确锁定的 `skills` CLI，同时额外绑定来源
+commit、Skill tree hash、目标目录、许可证选择、凭据名称和审计状态。先查看只读
+目录，或启动交互式 Wizard：
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
-  --path /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.24 research setup \
+  --workspace /absolute/path/to/workspace --json
 ```
 
-默认 `internet-research` profile 需要外部 `web-search`、`news-search` Skills，
-以及用户持有的 Brave Search API key。增强上下文和媒体 profile 必须显式选择，
-并受服务商套餐约束。用户有权访问的数据库通过外部、不可变的 Skill 定义逐个
-导入。完整流程见 `tiangong-auto-research/references/external-skills.md`；研究
-runtime 不会自动安装这些依赖。
+目录包含 Brave 互联网证据能力、可选的 Tiangong SCI/文档解析/论文获取 companion，
+以及可选的 Anthropic 或 PPT Master 闭环后创作 Skills。所有条目都是外生、独立
+授权、精确锁定且由用户选择；研究 package 不会捆绑或安装它们。完整流程见
+`tiangong-auto-research/references/setup.md` 和 `external-skills.md`。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: 7814e2116f80df37e40419643b44803d8595ee85
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,133 +1,99 @@
 ---
 name: tiangong-auto-research
-description: Run smoke-test or production Tiangong research workspaces with explicit evidence requirements, external evidence Skills for the public internet and owner-whitelisted databases, immutable inputs and broker evidence, pre-call budgets, isolated producer execution, independent review, and mechanical closure. Use when a user asks to plan, initialize, configure, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
+description: Run or set up smoke-test and production Tiangong research workspaces with an explicit, user-selected external Skill ecosystem; public-internet and owner-whitelisted broker evidence; immutable inputs and evidence; pre-call budgets; isolated producers; independent review; and mechanical closure. Use when a user asks to configure, plan, initialize, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
 ---
 
 # Tiangong Auto Research
 
-Use the pinned CLI for every workspace operation:
+Use the exact CLI release for all workspace operations:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research --help
+npx --yes @tiangong-ai/cli@0.0.24 research --help
 ```
 
-The CLI is the authority for the external capability catalog, output schemas,
-coverage gates, scheduling, budgets, retries, evidence promotion, review, and
-closure. Do not reimplement those rules in this skill or a coordinating agent.
+The CLI owns the setup catalog, immutable setup plan, capability policy, output
+schemas, coverage gates, budgets, retries, evidence promotion, review, and
+closure. Do not reproduce those contracts in an agent prompt or edit control
+files by hand.
 
-## Choose the mode first
+## Route to the right reference
 
-- Use `smoke-test` only for deterministic mocks, routing checks, workflow demos,
-  or a low-cost canary the user explicitly accepts.
-- Use `production-research` for conclusions the user intends to rely on.
-  Production must include a locked external public-internet capability; local
-  inputs alone cannot represent internet coverage.
-
-Load the detailed references only when needed:
-
-- Read [references/external-skills.md](references/external-skills.md) for a new
-  or clean workspace, profile selection, external Skill installation, status
-  interpretation, provider checks, or an owner-whitelisted database.
-- Read [references/production-research.md](references/production-research.md)
-  before initializing or resuming production work, configuring broker HTTP,
-  recovering a project, or interpreting a blocked run.
+- Read [references/setup.md](references/setup.md) for a new or clean directory,
+  the guided Wizard, non-interactive setup, updates, or recovery.
+- Read [references/external-skills.md](references/external-skills.md) before
+  selecting a recommended external Skill, provider, license, or execution role.
 - Read [references/env.md](references/env.md) before configuring credentials,
-  agent authentication, or an agent wrapper.
+  agent authentication, provider checks, or wrappers.
+- Read [references/production-research.md](references/production-research.md)
+  before production preflight, execution, recovery, or closure.
+
+## Choose the mode before spending budget
+
+- `smoke-test` is for deterministic mocks, routing/eval checks, workflow demos,
+  and explicitly accepted low-cost canaries.
+- `production-research` is for conclusions a user may rely on. It requires a
+  locked independent public-internet evidence profile. Local evidence and an
+  owner database can supplement that profile but cannot replace it.
 
 ## Inspect before mutation
 
-Resolve workspace and input paths to absolute paths, then run:
+Resolve paths to absolute paths, then inspect the directory:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research context inspect \
+npx --yes @tiangong-ai/cli@0.0.24 research context inspect \
   --path /absolute/path/to/workspace --json
 ```
 
-Follow `role` and `allowedOperations` exactly:
+Follow `role` and `allowedOperations`. Stop on `invalid`; never repair immutable
+state, locks, journal events, evidence objects, receipts, or outputs manually.
 
-- `unmanaged`: initialize only when the user wants a new workspace.
-- `workspace`: continue through CLI commands.
-- `invalid`: stop and report the violations; never repair state by hand.
-
-## Prepare external evidence capabilities
-
-For production, inspect the complete external recommendation and status catalog
-before project initialization:
+For a clean directory, show the read-only ecosystem catalog and run the guided
+setup only after the user asks to configure it:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
-  --path /absolute/path/to/workspace --json
-```
-
-Show the user the recommended, enhanced, conditional, and evaluated-but-not-
-selected Skills, their provider/key requirements, and current installation
-status. Run only the exact pinned project installation plan the catalog returns,
-outside the research runtime and after the user has selected a profile. Never
-install dependencies from an agent package or silently substitute a provider.
-
-Initialize the workspace, configure the explicit profile, store the logical
-credential from an owner environment variable, and test the selected endpoints:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research workspace init \
-  /absolute/path/to/workspace --name "Research name" \
-  --mode production-research --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability configure \
-  --profile internet-research \
-  --skill-root /absolute/path/to/workspace/.agents/skills \
+npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
-  --id brave.search.api-key --from-env BRAVE_SEARCH_API_KEY \
-  --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability doctor --live \
+npx --yes @tiangong-ai/cli@0.0.24 research setup \
   --workspace /absolute/path/to/workspace --json
 ```
 
-Stop on a missing Skill, missing key, unsupported subscription endpoint, drift,
-or failed live check. Do not downgrade a selected profile without telling the
-user. Import an owner-whitelisted database only from its reviewed external
-definition, then rerun credential setup and live doctor as described in the
-external-Skills reference.
+The user must choose every external source and accept its pinned license. The
+Wizard may create a plan without applying it. Never silently install a Skill,
+write globally, substitute a provider, downgrade a profile, or accept a
+license. Missing required credentials must block before any source download.
 
-## Preflight before project creation
+## Preserve execution boundaries
+
+- Brave and Tiangong SCI are `evidence-capability` Skills. Discovery calls them
+  only through the scoped broker and the locked manifest method. Never execute
+  their shell examples from an agent capsule or expose their credentials to an
+  agent.
+- `document-granular-decompose` is an `input-preprocessor`. Run it explicitly
+  through `research setup companion run`, then admit the exact hash-bound output
+  as a project input. Its output is not evidence merely because parsing worked.
+- `academic-paper-download` is an `acquisition-adapter`. Its automatic OA order
+  remains Unpaywall, Semantic Scholar OA, then arXiv. If all are exhausted, the
+  CLI reports an explicit browser handoff; it never launches or chooses a
+  browser automatically.
+- Document/PDF/spreadsheet/presentation Skills are `post-closure-authoring`.
+  They may format a closed report but cannot produce or alter admitted evidence,
+  analysis, review, or closure.
+
+## Preflight and initialize a project
 
 Prepare evidence requirements with `dimensions`, `sourceTypes`, `minSources`,
-`minFullTextSources`, `minDatedSources`, and nullable `publicationDateFrom` /
-`publicationDateTo`. For large local sources, also prepare one immutable input
-plan with bounded `contextPath` or `contextRanges` entries.
+`minFullTextSources`, `minDatedSources`, and nullable date bounds. For large
+local sources, create an immutable input plan with bounded context files or
+ranges.
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research project preflight \
+npx --yes @tiangong-ai/cli@0.0.24 research project preflight \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json --json
-```
 
-Stop when production requirements are missing, the capability/input plan cannot
-cover them, or the projected budget needs confirmation. Pass `--confirm-budget`
-only after the user explicitly accepts the threshold. Omit `--input-plan` only
-when locked broker capabilities alone provide the declared acquisition plan.
-
-Never edit `workspace.json`, `runtime-lock.json`, `journal.jsonl`, evidence
-objects/receipts, project state, run records, locks, or outputs directly.
-
-## Freeze capabilities and register the project
-
-After every external tree or policy change, verify the content lock:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability lock \
-  --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability verify \
-  --workspace /absolute/path/to/workspace --json
-```
-
-Register the project with the same verified requirements and input plan used by
-preflight:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research project init PROJECT \
+npx --yes @tiangong-ai/cli@0.0.24 research project init PROJECT \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
@@ -135,49 +101,35 @@ npx --yes @tiangong-ai/cli@0.0.23 research project init PROJECT \
   --confirm-budget --json
 ```
 
-Use `project input add` only for an additional small source that may be exposed
-in full. Use `primary` for direct evidence, `reference` for context, and
-`replication` for reproducibility material. Do not copy unregistered files into
-the control directory.
+Stop when capability/input coverage is insufficient or the projected cost has
+not been accepted. Use the same requirements and input plan for preflight and
+initialization.
 
-## Validate and run
+## Validate, run, and recover
 
-Configure explicit producer/reviewer models and pricing in the generated
-workspace config. Production requires different agent families and both real
-capsule and provider-capability smokes:
+Production requires explicit models/prices, different producer and reviewer
+agent families, a current setup doctor report, and real capsule/provider smoke
+attestations:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research workspace doctor \
+npx --yes @tiangong-ai/cli@0.0.24 research setup doctor \
+  --workspace /absolute/path/to/workspace --live --json
+npx --yes @tiangong-ai/cli@0.0.24 research workspace doctor \
   --workspace /absolute/path/to/workspace \
   --agent-smoke --capability-smoke --json
-npx --yes @tiangong-ai/cli@0.0.23 research run \
+npx --yes @tiangong-ai/cli@0.0.24 research run \
   --workspace /absolute/path/to/workspace --project PROJECT --dry-run --json
-npx --yes @tiangong-ai/cli@0.0.23 research run \
+npx --yes @tiangong-ai/cli@0.0.24 research run \
   --workspace /absolute/path/to/workspace --project PROJECT \
   --max-cycles 20 --progress-jsonl --json
 ```
 
-Proceed only when doctor reports `ready`. Prefer an explicit `--project`; omit
-it only for an intentional workspace-wide batch. The runtime embeds locked
-external Skill instructions and lets discovery call only the scoped broker.
-Do not bypass it with direct agents, shell commands, or unbrokered web calls.
-When coverage is insufficient, report the gaps and stop before downstream
-packages consume budget.
+Proceed only when doctor reports ready. Discovery uses only locked broker
+capabilities; later stages are tool-free. An evidence-coverage failure must stop
+analysis and synthesis rather than spend more budget.
 
-## Inspect, recover, and hand off
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research status \
-  --workspace /absolute/path/to/workspace --project PROJECT --json
-```
-
-Report the package, classified failure, retry time, split token usage, cost,
-sanitized provider diagnostics, and limitations. Use `research project retry`
-or `research project fork` only with explicit user direction; never reset state
-or delete capsules/evidence by hand.
-
-A complete project has passing independent review and
-`outputs/closure.json`. Return the report path, permanent evidence receipts,
-content-addressed review packet/context locators, usage, review decision, and
-material limitations. Treat `outputs/report.md` as the deliverable and
-`outputs/closure.json` as its mechanical completion receipt.
+Inspect state with `research status`. Use `research project retry` or
+`research project fork` only with explicit user direction; do not reset or
+delete state. A complete project has a passing independent review,
+`outputs/report.md`, and `outputs/closure.json`. Return the permanent evidence
+locators, review-packet binding, usage/cost, decision, and material limitations.

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Run traceable research with external evidence"
-  default_prompt: "Use $tiangong-auto-research to inspect and configure external evidence Skills, preflight coverage and budget, and run a traceable production research workspace."
+  short_description: "Set up and run auditable internet research"
+  default_prompt: "Use $tiangong-auto-research to guide me through external Skill setup, verify evidence coverage and budget, and run a traceable production research workspace."

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -1,34 +1,106 @@
-# Research environment
+# Research setup and runtime environment
 
-## Runtime prerequisites
+## Base prerequisites
 
-- Node.js 24.
-- `npx` access to `@tiangong-ai/cli@0.0.23`.
-- `git` plus pinned `skills@1.5.22` access for the explicit external-Skill
-  installation plan returned by `research capability catalog`.
-- Authenticated `codex` and `claude` executables, unless absolute binary paths
-  are selected in `.tiangong-research/config.json`.
-- macOS with `/usr/bin/sandbox-exec`, or Linux with Bubblewrap available as
-  `bwrap`.
-- For the baseline `internet-research` profile, an owner-held Brave Search API
-  key and provider-plan access to Web and News Search. LLM Context, image, and
-  video endpoints require their selected profile and may require additional
-  provider-plan access.
+- Node.js 24, `git`, and `npx` access to
+  `@tiangong-ai/cli@0.0.24` and the exact setup-pinned `skills@1.5.22` package.
+- Authenticated `codex` and `claude` executables for the configured producer and
+  reviewer routes.
+- macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`).
+- Python 3.10+ only for selected Python-based companions. Setup reports missing
+  Python dependencies but never installs them.
 
-Authenticate the agent CLIs through their standard local login before running a
-project. Capability service credentials use the workspace contract below and
-are never agent environment variables.
+Authenticate agent CLIs through their normal interactive login outside the
+research workspace. Do not copy browser profiles, keychains, full agent HOME
+directories, cookies, passwords, or session tokens into a workspace. The
+runtime creates a capsule HOME and copies/extracts only its documented minimal
+agent authentication material.
 
-If doctor reports that Claude is not logged in, start Claude interactively
-outside the research workspace, complete its normal `/login` flow, then rerun
-doctor. Do not copy tokens from keychains, browser profiles, or another agent
-HOME into the workspace. If a custom agent wrapper is selected, use an absolute
-path, keep the wrapper immutable for the run, and let doctor record and verify
-its hash; do not add undocumented transport or authentication flags.
+Production doctor must run real agent and capability smokes before a costly
+package. These checks may use quota and therefore require explicit flags and
+cost confirmation.
+
+## Setup credential variables
+
+The Wizard asks for an environment variable *name*, never a secret value. The
+recommended defaults are:
+
+| Variable | Logical ID | Requirement |
+| --- | --- | --- |
+| `BRAVE_API_KEY` | `brave.search.api-key` | Required for a selected Brave public-internet profile. |
+| `TIANGONG_SCI_APIKEY` | `tiangong.sci.api-key` | Required only when the owner-authorized Tiangong SCI capability is selected. |
+| `UNSTRUCTURED_AUTH_TOKEN` | `tiangong.unstructure.auth-token` | Required only when document preprocessing is selected. |
+| `SEMANTIC_SCHOLAR_API_KEY` | `semantic-scholar.api-key` | Optional for academic paper acquisition. |
+
+The variable name can differ, but it must be explicitly bound in the immutable
+plan. Values must be non-trivial and remain in the owner process environment
+only until setup stores them. Do not put values in setup JSON files, CLI
+arguments, shell history, Skill files, capability declarations, or chat.
+
+Broker credentials are written to the owner-only
+`.tiangong-research/.env` logical credential store. Adapter credentials are
+written separately to owner-only `.tiangong-research/setup-adapters.env`.
+Neither file supports arbitrary dotenv keys or shell interpolation. Both reject
+symlinks, duplicate/undeclared entries, malformed JSON, and group/other access.
+
+Use the supported command to rotate one selected credential:
+
+```bash
+export OWNER_NEW_BRAVE_KEY='new owner value'
+npx --yes @tiangong-ai/cli@0.0.24 research setup credential set \
+  --id brave.search.api-key --from-env OWNER_NEW_BRAVE_KEY \
+  --workspace /absolute/path/to/workspace --json
+```
+
+The value is never echoed. Journal events record only the logical ID, storage
+class, and a hash of the environment variable name.
+
+## Non-secret settings
+
+- `tiangong.sci.endpoint`: exact HTTPS SCI endpoint.
+- `tiangong.sci.region`: safe region header.
+- `tiangong.unstructure.base-url`: exact HTTPS base URL.
+- `tiangong.unstructure.provider` and `.model`: optional identifiers.
+- `unpaywall.contact-email`: optional real contact email.
+
+Settings are frozen in the setup plan and may be printed. Never embed a token,
+username/password, signed query parameter, or proxy password in a setting URL.
+
+## Companion child environments
+
+`research setup companion run` constructs a minimal environment. It keeps only
+basic process/network/TLS/Python routing variables and injects the exact selected
+adapter variables:
+
+- document preprocessing: `UNSTRUCTURED_AUTH_TOKEN`,
+  `UNSTRUCTURED_API_BASE_URL`, and optional provider/model;
+- paper acquisition: optional `SEMANTIC_SCHOLAR_API_KEY` and
+  `UNPAYWALL_EMAIL`.
+
+The owner variable used during setup is not forwarded under its original name,
+and unrelated Authorization, Cookie, API-key, token, or session variables are
+excluded.
+
+## Direct Tiangong SCI Skill use
+
+Outside Auto Research, the separately installed `tiangong-kb-sci-search`
+wrapper uses the existing Tiangong CLI variables
+`TIANGONG_SCI_APIKEY` (preferred source-specific key) or
+`TIANGONG_AI_APIKEY` (fallback). Its optional dotenv file must be a regular
+owner-only file and only documented Tiangong endpoint/key/region/timeout names
+are loaded. Credentials are forbidden in wrapper JSON and request files.
+
+Inside Auto Research, never run that wrapper. Setup maps the owner variable to
+logical ID `tiangong.sci.api-key`; discovery sends a non-secret POST
+`request_body` to the broker, which injects `x-api-key` for the exact host.
+
+## Agent wrappers and capsule authentication
 
 The tested macOS/Linux template is
 `scripts/agent-wrapper-posix.sh`; validate it with
-`scripts/test-agent-wrapper-posix.sh`. Configure the route explicitly:
+`scripts/test-agent-wrapper-posix.sh`. A custom route must use absolute paths,
+an immutable wrapper for the run, explicit model ID and prices, and the real
+target binary:
 
 ```json
 {
@@ -41,109 +113,16 @@ The tested macOS/Linux template is
 }
 ```
 
-The runtime sets `TIANGONG_RESEARCH_AGENT_BINARY` to the resolved target; do not
-set or forward that variable yourself. The target, wrapper, and internal
-adapter hashes are attested independently, and target drift stops execution.
+The CLI sets `TIANGONG_RESEARCH_AGENT_BINARY`; do not set or forward it
+yourself. Doctor attests target, wrapper, internal adapter, OS, and architecture
+and invalidates the attestation after relevant drift.
 
-The CLI creates a dedicated HOME for every capsule. It copies only the
-supported minimal agent credential file when one exists (for example Codex
-`auth.json`), never a complete Chrome/agent profile. For Claude, an owner-only
-user `settings.json` is not copied: the runtime extracts only
-`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, and a
-credential-free HTTPS `ANTHROPIC_BASE_URL` from its `env` object. Permissions,
-hooks, extra directories, and other settings are excluded. On macOS,
-credentials held by the system keychain remain in the keychain. Production
-doctor must be run with `--agent-smoke` to detect a missing login, first-launch
-gate, unwritable state database, or sandbox incompatibility before an expensive
-package starts.
-The successful attestation lasts 24 hours and must be regenerated after config,
-capability, schema, binary, or wrapper drift. Sanitized provider transport
-diagnostics may appear in doctor details even when the provider subsequently
-falls back and succeeds; use the final check status as the readiness decision.
+For Claude, the runtime does not copy an owner `settings.json`. It extracts only
+documented authentication values and a credential-free HTTPS base URL from the
+supported environment object; hooks, permissions, extra directories, and other
+settings are excluded. On macOS, credentials held in the system keychain stay
+in the keychain.
 
-The outer `sandbox-exec`/Bubblewrap capsule is the execution boundary. Codex is
-started without a nested sandbox because nested macOS Seatbelt can cancel MCP
-calls. This does not grant shell access: discovery has shell, unified-exec,
-filesystem, and undeclared integrations disabled and can call only the scoped
-broker. Analyze, synthesize, and review are tool-free.
-
-## Capability credentials
-
-The only accepted key in `.tiangong-research/.env` is:
-
-```bash
-TIANGONG_RESEARCH_CAPABILITY_CREDENTIALS_JSON={"source.example.api":"owner-provided-value"}
-```
-
-Requirements:
-
-- The value is one JSON object on one line.
-- Every key is a logical credential ID declared in
-  `.tiangong-research/capabilities.json`.
-- Every value is a non-trivial string of at least eight UTF-8 bytes.
-- No shell interpolation syntax is supported.
-- Duplicate assignments and undeclared IDs are rejected.
-- On POSIX systems, set owner-only permissions:
-
-  ```bash
-  chmod 600 /absolute/path/to/workspace/.tiangong-research/.env
-  ```
-
-Do not place agent login tokens, cloud credentials, or unrelated service keys
-in this file.
-
-For a recommended internet profile, configure the shared logical credential
-without putting its value in a command argument:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
-  --id brave.search.api-key --from-env BRAVE_SEARCH_API_KEY \
-  --workspace /absolute/path/to/workspace --json
-```
-
-For an owner-whitelisted database, use the logical ID declared in that external
-capability and an explicit owner environment variable, for example
-`--id database.owner-source.api-key --from-env OWNER_DATABASE_API_KEY`. Never
-reuse a browser cookie, Authorization header dump, session token, or agent API
-key as a capability credential.
-
-## Capability declaration example
-
-```json
-{
-  "schemaVersion": 1,
-  "capabilities": [
-    {
-      "id": "method.public-source",
-      "skillPath": "/absolute/path/to/public-source-skill",
-      "permissions": ["project-read", "candidate-write", "brokered-network"],
-      "allowedHosts": ["api.example.org"],
-      "http": {
-        "accept": "application/json",
-        "allowedContentTypes": ["application/json"],
-        "maxResponseBytes": 524288,
-        "maxItems": 100
-      },
-      "coverage": {
-        "dimensions": ["research-question"],
-        "sourceTypes": ["primary"],
-        "fullText": true,
-        "publicationDates": true
-      },
-      "credentials": [
-        {
-          "id": "source.example.api",
-          "allowedHosts": ["api.example.org"],
-          "headerName": "Authorization",
-          "prefix": "Bearer "
-        }
-      ]
-    }
-  ]
-}
-```
-
-Hosts are exact and may include an explicit port. Wildcards, paths, embedded
-credentials, and non-HTTPS targets are rejected. The broker checks every
-redirect before sending the next request and never returns credential values in
-receipts.
+The outer sandbox is the execution boundary. Discovery has no shell or ambient
+filesystem/network access and can call only the scoped broker. Analyze,
+synthesize, and review are tool-free.

--- a/tiangong-auto-research/references/external-skills.md
+++ b/tiangong-auto-research/references/external-skills.md
@@ -1,260 +1,140 @@
-# External evidence Skills
+# Recommended external Skills
 
-Use this reference when starting from a clean directory, selecting an internet
-profile, installing or diagnosing recommended Skills, or admitting a database
-the workspace owner is authorized to query.
-
-## Contents
-
-- [Boundary and source of truth](#boundary-and-source-of-truth)
-- [Clean-directory setup](#clean-directory-setup)
-- [Profiles and recommended Skills](#profiles-and-recommended-skills)
-- [Credentials and live checks](#credentials-and-live-checks)
-- [Status interpretation](#status-interpretation)
-- [Owner-whitelisted databases](#owner-whitelisted-databases)
-- [Evaluated alternatives](#evaluated-alternatives)
-- [Failure rules](#failure-rules)
-
-## Boundary and source of truth
-
-Research method implementations are external to Tiangong Auto Research and the
-Tiangong Skills repository. The CLI catalog records which external Skills were
-reviewed, their immutable source commit and whole-tree hash, why each is or is
-not recommended, and how the current workspace is configured.
-
-Use the machine-readable catalog as the authority:
+Use this reference to explain what Auto Research recommends, what each Skill is
+allowed to do, which credentials it needs, and how installation is governed.
+The live machine-readable source of truth is:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
-  --path /absolute/path/to/workspace --json
-```
-
-The runtime never installs dependencies. Installation happens as an explicit
-owner action before capability configuration. A Skill only documents how to
-query a source; the broker separately enforces exact HTTPS hosts, GET-only
-request policy, response bounds, logical credentials, and permanent evidence
-receipts.
-
-The goal is broad, best-effort coverage across every source the owner has
-selected and is authorized to use. It is not a claim that any provider indexes
-the entire internet or that an unavailable subscription can be bypassed.
-
-## Clean-directory setup
-
-Prerequisites:
-
-- Node.js 24, `git`, and `npx`;
-- authenticated Codex and Claude CLIs for the producer/reviewer routes;
-- macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`);
-- a Brave Search API key and a plan that exposes Web and News Search for the
-  baseline internet profile;
-- any owner database credentials required by explicitly imported capabilities.
-
-From the empty directory, verify the pinned CLI and inspect the plan before
-creating research state:
-
-```bash
-cd /absolute/path/to/workspace
-npx --yes @tiangong-ai/cli@0.0.23 --version
-npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
-  --path /absolute/path/to/workspace --json
-```
-
-For the baseline profile, the catalog's `installer.projectPlan.commands`
-performs this exact sequence with absolute paths:
-
-```bash
-git init --quiet /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6
-git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 remote add origin https://github.com/brave/brave-search-skills.git
-git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 fetch --depth 1 origin 3e088af66eb61f1c207c22b2be0278ca8744d1d1
-git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 checkout --detach FETCH_HEAD
-test "$(git -C /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 rev-parse HEAD)" = 3e088af66eb61f1c207c22b2be0278ca8744d1d1
-npx --yes skills@1.5.22 add /absolute/path/to/workspace/.tiangong-external-skills/sources/brave-search-skills-3e088af66eb6 \
-  --skill web-search news-search --agent codex --yes --copy
-```
-
-Do not copy this example with a different workspace path by guesswork. Prefer
-the absolute commands returned for the current directory, review them, and run
-them one at a time. Do not pipe catalog output into a shell. The checkout
-directory must not already exist; an existing directory is a state to inspect,
-not permission to overwrite it.
-
-For enhanced or media profiles, use each selected entry's
-`install.projectPlan`, or the catalog's `allRecommendedProjectPlan` to install
-all five reviewed recommendations. The CLI verifies every selected installed
-tree before writing a lock, so merely seeing a directory is not success.
-
-Then initialize and configure the project-local copy:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research workspace init \
-  /absolute/path/to/workspace --mode production-research --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability configure \
-  --profile internet-research \
-  --skill-root /absolute/path/to/workspace/.agents/skills \
+npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
   --workspace /absolute/path/to/workspace --json
 ```
 
-Never treat an unpinned globally installed copy as a substitute for the
-project-local plan when reproducibility matters.
+Every entry is external to the Auto Research runtime. It is separately sourced,
+never bundled, never installed at runtime, and selected only by the user. The
+catalog binds an immutable git commit and whole-tree SHA-256 for every Skill.
 
-## Profiles and recommended Skills
+## Why setup manages `npx skills`
 
-Choose one profile explicitly:
+The underlying cross-agent installer is `skills@1.5.22`, invoked as
+`npx --yes skills@1.5.22 add ... --copy`. Users can use `npx skills` directly for
+general Skill management, but Auto Research should use `research setup` because
+it additionally freezes and verifies:
 
-| Profile | Selected Skills | Use |
+- npm integrity/shasum/git head for the installer;
+- exact source repository and commit;
+- selected subdirectory and expected tree hash;
+- project/global destination and target agent;
+- license acceptance, credential names, settings, checks, and mutations;
+- installed-byte status and an append-only audit trail.
+
+Setup does not trust a directory merely because it exists and never silently
+adopts or overwrites a drifted copy. Project-local `.agents/skills` or
+`.claude/skills` copy mode is the reproducible default. Global scope is an
+explicit operator choice.
+
+## Evidence capabilities
+
+These Skills can contribute candidate evidence only through the locked HTTP
+broker during discovery:
+
+| Catalog IDs | Source | Role and selection rule | Credential |
+| --- | --- | --- | --- |
+| `brave.web-search`, `brave.news-search` | `brave/brave-search-skills` | Baseline public-internet profile; both required for production. | `brave.search.api-key` from an owner variable such as `BRAVE_API_KEY` |
+| `brave.llm-context` | same | Enhanced bounded page context when the provider plan supports it. | same Brave key |
+| `brave.images-search`, `brave.videos-search` | same | Conditional visual/audiovisual discovery only when material to the question. | same Brave key |
+| `tiangong.kb-sci-search` | `tiangong-ai/skills` | Optional owner-whitelisted academic database. It supplements, but never satisfies, the production public-internet gate. | `tiangong.sci.api-key` from `TIANGONG_SCI_APIKEY` or another explicitly named owner variable |
+
+Brave capabilities use their manifest-declared GET endpoints. Tiangong SCI uses
+the exact declared JSON POST endpoint, `x-region`, and `x-api-key` credential
+injection. The discovery agent supplies only non-secret `request_body` fields;
+the broker rejects credential-like fields, persists only the request-body hash,
+refuses POST redirects, bounds the response, and promotes the exact response to
+the permanent evidence store.
+
+Do not run a staged Skill's shell/curl examples inside a research capsule. Agent
+processes never receive provider credentials. Authentication, authorization,
+subscription, deterministic 4xx, unsafe response type, and source drift stop
+execution; no source or login barrier may be bypassed.
+
+## Input preprocessing and acquisition
+
+These are installed companions, not `PaperTransport` implementations and not
+broker evidence capabilities:
+
+| Catalog ID | Role | Configuration | Boundary |
+| --- | --- | --- | --- |
+| `tiangong.document-granular-decompose` | `input-preprocessor` | Required `tiangong.unstructure.auth-token`; required HTTPS base URL; optional provider/model. | Explicit upload outside research execution. The CLI hash-binds input/output and atomically commits a new output. Admit that output separately. |
+| `tiangong.academic-paper-download` | `acquisition-adapter` | Optional Semantic Scholar API key and optional Unpaywall contact email; Python 3.10+ and `pypdf==6.14.2`. | Automatic legal OA order stays Unpaywall → Semantic Scholar OA → arXiv → explicit browser handoff. It preserves its own PDF/size/hash/manifest finalization. |
+
+The paper adapter never substitutes CloakBrowser for Chrome, never silently
+switches browser backends, and never uses a browser to replace Crossref,
+Unpaywall, Semantic Scholar, or arXiv requests. Browser handoff remains a
+separate user-authorized workflow in that Skill. CloakBrowser is an optional,
+separately pinned dependency with its own persistent profile; it is not installed
+by research setup and must not import Chrome profiles, cookies, passwords,
+tokens, or API keys.
+
+## Post-closure authoring
+
+The following may be selected only for optional artifact work after mechanical
+research closure. They cannot act as evidence providers or mutate admitted
+research artifacts:
+
+| Catalog IDs | Source | License/configuration note |
 | --- | --- | --- |
-| `internet-research` | `web-search`, `news-search` | Default public-internet discovery; both are required. |
-| `internet-research-with-context` | baseline plus `llm-context` | Use only when the provider plan exposes LLM Context and extracted page context materially improves the study. |
-| `internet-research-with-media` | context profile plus `images-search`, `videos-search` | Use when visual or audiovisual sources are material evidence. |
+| `anthropic.doc-coauthoring` | `anthropics/skills` | No API key. The pinned Skill tree has no per-Skill license file; catalog reports `NOASSERTION`, so the user must review and explicitly accept the notice. |
+| `anthropic.docx`, `anthropic.pdf`, `anthropic.pptx`, `anthropic.xlsx` | `anthropics/skills` | No API key. Source-available Anthropic document terms are not open source; nothing is bundled and installation is opt-in. |
+| `hugohe3.ppt-master` | `hugohe3/ppt-master` | MIT, no API key. Upstream Python requirements contain ranges; setup refuses to resolve/install them until the user creates and reviews an exact isolated lock. |
 
-All current recommendations come from external repository
-`brave/brave-search-skills` at commit
-`3e088af66eb61f1c207c22b2be0278ca8744d1d1` under MIT:
+`anthropic.pptx` and `hugohe3.ppt-master` are mutually exclusive in one setup
+plan to avoid ambiguous presentation routing. Choose one or use separate plans.
 
-| Skill | Tier | Expected whole-tree SHA-256 |
+## Credential and setting matrix
+
+| Logical configuration | Required when | How to obtain/configure |
 | --- | --- | --- |
-| `web-search` | required | `0432f4eb084766046a2feeb146f0b3917850d138eb4182c23fc000a058fbe123` |
-| `news-search` | required | `80f8dcb7c78209cce5315e507f0aba21e3f654f42f6a414c177de644bcd07773` |
-| `llm-context` | enhanced, plan-dependent | `5abba551d0498a80eba4e64207f483974f5a312cda5b263c1cc2b7f99d81c4a3` |
-| `images-search` | conditional | `467a9afae0e959b482cb6b2236a57a327959b28985871f88c202dc70b10a7c84` |
-| `videos-search` | conditional | `ff3a2e2291efc27f3f09847b7e0b20e77d229f6a44a1a64e562964c820eb9719` |
+| `brave.search.api-key` | Any Brave profile | Create a key through the normal Brave Search API account flow; give setup only the environment variable name. |
+| `tiangong.sci.api-key` | Tiangong SCI selected | Ask the owner of the authorized deployment; do not reuse browser/session credentials. |
+| `tiangong.sci.endpoint`, `tiangong.sci.region` | Tiangong SCI selected | Review the exact HTTPS endpoint and non-secret region shown by the Wizard. |
+| `tiangong.unstructure.auth-token` | Document preprocessing selected | Ask the deployment owner; stored only in the adapter credential store. |
+| `tiangong.unstructure.base-url` | Document preprocessing selected | Exact HTTPS service base URL; provider/model overrides are optional non-secret settings. |
+| `semantic-scholar.api-key` | Optional | Obtain from Semantic Scholar's normal API application flow; anonymous access remains supported by the paper Skill. |
+| `unpaywall.contact-email` | Optional | A real contact email, stored as a non-secret setting. |
 
-Do not silently fall back from a profile when one selected endpoint is missing
-or unavailable. Report the endpoint/plan failure and ask the user to either fix
-access or explicitly select a different profile.
+No key is accepted as a command argument, JSON request field, manifest value, or
+chat value. Setup's `credential set` command reads a named owner environment
+variable and returns only the logical ID and storage class.
 
-## Credentials and live checks
+## Status and live checks
 
-The five Brave Skills share logical credential ID `brave.search.api-key`.
-Obtain the owner key through the provider's normal account flow and expose it
-to the configuration process as `BRAVE_SEARCH_API_KEY`. Do not place the value
-in a command argument, document, capability definition, or chat message.
+Interpret `research setup status` and `research setup doctor`, not directory
+presence:
 
-Store it through the non-echoing logical-credential command:
+- `missing`: the reviewed tree is absent;
+- `installed`: exact bytes match;
+- `drifted`: bytes differ; do not re-lock or overwrite them;
+- `blocked`: path, symlink, permissions, dependency, credential, or check
+  policy failed;
+- `READY`: every selected required static/live check passed;
+- `PARTIALLY_READY`: deferred optional/cost/network checks remain;
+- `BLOCKED`: a selected required capability or dependency is unusable.
 
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
-  --id brave.search.api-key --from-env BRAVE_SEARCH_API_KEY \
-  --workspace /absolute/path/to/workspace --json
-```
+Live checks are explicit because they use network/quota. A key that passes one
+Brave endpoint does not prove that LLM Context, image, or video access is
+included in the provider plan. The Unstructure live check uploads a generated
+one-page PDF only with its separate confirmation. Agent smoke is separately
+cost-confirmed.
 
-The command writes only the owner-only workspace credential store and never
-returns the value. Agent processes do not receive it; the broker injects it for
-the declared host only.
+## Custom owner-whitelisted databases
 
-Run both static and live verification before production preflight:
+A source not in the recommendation catalog must be imported explicitly as an
+external capability definition. Bind its absolute non-symlink Skill tree,
+immutable source identity/hash/license, exact HTTPS hosts, GET or bounded JSON
+POST policy, safe health check, coverage claims, logical credential scope, and
+`requiredForDiscovery` decision. Never place a credential value in the
+definition.
 
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability verify \
-  --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability doctor --live \
-  --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research workspace doctor \
-  --workspace /absolute/path/to/workspace \
-  --agent-smoke --capability-smoke --json
-```
-
-`llm-context`, image, and video access may differ by provider plan. A key that
-passes Web Search does not prove every selected endpoint is enabled.
-
-## Status interpretation
-
-Call catalog again with the workspace to obtain one complete status view:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability catalog \
-  --path /absolute/path/to/workspace \
-  --workspace /absolute/path/to/workspace \
-  --skill-root /absolute/path/to/workspace/.agents/skills --json
-```
-
-Interpret the machine fields rather than directory presence:
-
-- `installation.status=missing`: run the returned pinned plan.
-- `installation.status=drifted`: the discovered tree does not match the
-  catalog hash; restore the exact source instead of re-locking it.
-- `installation.status=ambiguous`: more than one exact candidate is visible;
-  select one explicit project root.
-- `installation.status=installed`: exactly one safe tree matches.
-- `status.configured=false`: the Skill is installed but not declared in this
-  workspace.
-- `status.locked=false`: configuration and verified content lock disagree.
-- `status.credential=not-configured`: the Skill is not selected in this
-  workspace; `missing` means it is selected but its logical value is absent;
-  `configured` means the value is present; `not-required` means the capability
-  declares no credential; `blocked` means credential inspection itself failed.
-  A `missing` or `blocked` state authorizes no provider request.
-- a live doctor failure means package execution must not start. Authentication,
-  subscription, deterministic 4xx, unsafe content type, and drift failures stop
-  immediately; one bounded 429 retry is the only automatic live-check retry.
-
-Catalog output also includes actionable installation commands, provider-plan
-text, exact hosts, credential IDs, summary counts, and evaluated alternatives.
-Show these statuses to the user before spending model budget.
-
-## Owner-whitelisted databases
-
-An owner-authorized database is another external capability; it is not ambient
-agent access. Start from `customExternalCapabilities.brokeredEvidenceDefinitionTemplate`
-in catalog output and create an external JSON definition containing:
-
-- an absolute path to the separately installed external Skill;
-- a top-level `SKILL.md` containing the complete bounded GET endpoint and
-  response-shape instructions needed for discovery. The runtime embeds that
-  file and the capability manifest; discovery has no filesystem tool with which
-  to follow additional reference links;
-- external source identity, full immutable git commit/exact registry version or
-  local content reference, license, and expected whole-tree SHA-256;
-- exact HTTPS hosts and a bounded GET response policy;
-- a safe health check;
-- coverage dimensions, source types, discovery scopes, full-text/date claims;
-- logical credential IDs and exact host/header scopes, never credential values;
-- `requiredForDiscovery: true` when the study must query that database.
-
-Import, configure the declared key, and probe the real endpoint:
-
-```bash
-npx --yes @tiangong-ai/cli@0.0.23 research capability import \
-  --definition /absolute/path/to/external-capability.json \
-  --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability credential set \
-  --id database.owner-source.api-key --from-env OWNER_DATABASE_API_KEY \
-  --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research capability doctor --live \
-  --workspace /absolute/path/to/workspace --json
-```
-
-Do not import a Tiangong project-owned Skill as an evidence provider, import a
-symlinked tree, broaden hosts with wildcards, authorize POST through the current
-GET broker, or convert a login/session cookie into a reusable database key.
-
-## Evaluated alternatives
-
-The catalog records all other Skills reviewed from the pinned Brave source:
-
-- `answers`: not admitted because it synthesizes through POST and is not raw
-  evidence under the GET broker.
-- `bx`: not admitted because it delegates to another executable and credential
-  store outside the broker boundary.
-- `local-descriptions` and `local-pois`: install and explicitly import only for
-  a research question with a material place/POI dimension.
-- `spellcheck` and `suggest`: query helpers, not independently reviewable
-  evidence sources.
-
-These dispositions are explicit review results, not hidden automatic choices.
-
-## Failure rules
-
-- Missing package, Skill, key, provider plan, or binary: return the structured
-  catalog/doctor error and its minimum user action; do not install at runtime.
-- Tree/source drift or ambiguity: stop before lock or execution.
-- Authentication, authorization, subscription, or database access failure:
-  stop and report; never bypass it.
-- Local-only production plan: stop. A locked external public-internet
-  capability is mandatory, and every capability marked `requiredForDiscovery`
-  must produce its own receipt.
-- Secret-like URL parameters, Authorization/Cookie headers, API keys, and
-  tokens must not appear in output, events, journal, evidence, or manifests.
-- Successful live checks prove endpoint connectivity only. The post-discovery
-  coverage gate still decides whether the collected evidence is sufficient.
+An owner database can broaden authorized coverage but cannot be described as
+the entire internet and cannot replace the independent public-internet gate.
+If access, subscription, VPN, SSO, MFA, or entitlement is unavailable, stop and
+report the minimum legitimate user action.

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -116,9 +116,9 @@ registered for review; it does not expose that entire file to discovery.
 Inspect, but never copy or fork, a current contract with:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research schema show discover --json
-npx --yes @tiangong-ai/cli@0.0.23 research schema show analyze --json
-npx --yes @tiangong-ai/cli@0.0.23 research schema show review --json
+npx --yes @tiangong-ai/cli@0.0.24 research schema show discover --json
+npx --yes @tiangong-ai/cli@0.0.24 research schema show analyze --json
+npx --yes @tiangong-ai/cli@0.0.24 research schema show review --json
 ```
 
 Evidence sources include stable ID/title/locator/provenance, URL or DOI when
@@ -145,8 +145,11 @@ A `brokered-network` capability has exact hosts plus an HTTP policy:
   "permissions": ["project-read", "candidate-write", "brokered-network"],
   "allowedHosts": ["api.example.org"],
   "http": {
+    "method": "GET",
     "accept": "application/json",
     "allowedContentTypes": ["application/json"],
+    "staticHeaders": {},
+    "maxRequestBytes": 0,
     "maxResponseBytes": 524288,
     "maxItems": 100
   },
@@ -192,6 +195,13 @@ screens credential-like response material, and rejects undeclared content
 types or oversized bodies. Non-2xx results include only status, a sanitized
 short response, safe request ID, and parsed `Retry-After`.
 
+Capabilities may instead declare bounded JSON `POST`, an exact safe static
+header map, and a positive `maxRequestBytes`. Discovery then supplies only the
+documented non-secret `request_body`; credential-like keys are rejected, the
+credential is injected by the broker, POST redirects are refused, and the
+journal/cache metadata records only the canonical body SHA-256 rather than the
+body. GET remains the default for existing imported definitions.
+
 ## Coverage, retry, and recovery
 
 Discovery output is promoted for diagnosis, then checked mechanically. The CLI
@@ -226,9 +236,9 @@ Failures are classified:
 Use an explicit management command instead of editing state:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research project retry PROJECT \
+npx --yes @tiangong-ai/cli@0.0.24 research project retry PROJECT \
   --package PACKAGE --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.23 research project fork SOURCE \
+npx --yes @tiangong-ai/cli@0.0.24 research project fork SOURCE \
   --to TARGET --resume-through analyze \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -241,7 +251,7 @@ and closure always run again.
 Run one recovered or canary project with an explicit scope:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.23 research run \
+npx --yes @tiangong-ai/cli@0.0.24 research run \
   --project PROJECT --workspace /absolute/path/to/workspace \
   --progress-jsonl --json
 ```

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -1,0 +1,184 @@
+# External Skill setup
+
+Use this reference to configure Tiangong Auto Research in a clean directory or
+to inspect, resume, update, or replace an existing setup generation.
+
+## Safety model
+
+Setup is a separate owner operation, not part of a research package. No
+recommended Skill is bundled with the CLI or installed implicitly. The CLI:
+
+1. shows the complete recommendation catalog without writing files;
+2. records exact source commits, Skill tree hashes, installer version and npm
+   integrity, destinations, settings, credential environment names, licenses,
+   checks, and mutations in an immutable plan;
+3. checks required credentials before it downloads an installer or source;
+4. copies only the selected pinned trees, verifies the installed bytes, and
+   configures their declared execution role;
+5. stores broker and adapter credentials in separate owner-only stores without
+   printing values;
+6. writes a sanitized doctor report and append-only journal events.
+
+Project-local copy mode is the default. Global installation needs a separate
+confirmation and exact targets are frozen into the plan. Setup never installs
+system packages or Python packages, never runs `pip install`, never follows a
+Skill destination symlink, and never performs a floating update.
+
+## Clean-directory Wizard
+
+Prerequisites are Node.js 24, `git`, `npx`, an agent-compatible sandbox
+(`/usr/bin/sandbox-exec` on macOS or `bwrap` on Linux), and normal Codex/Claude
+CLI authentication for the routes you intend to use. Create or choose the
+directory, export only the credentials for sources you may select, and start
+the Wizard:
+
+```bash
+mkdir -p /absolute/path/to/research-workspace
+cd /absolute/path/to/research-workspace
+
+# Required only when the corresponding source is selected.
+export BRAVE_API_KEY='owner Brave Search key'
+export TIANGONG_SCI_APIKEY='owner-authorized Tiangong SCI key'
+export UNSTRUCTURED_AUTH_TOKEN='owner Unstructure bearer token'
+
+# Optional; academic-paper-download can use Semantic Scholar anonymously.
+export SEMANTIC_SCHOLAR_API_KEY='optional Semantic Scholar key'
+
+npx --yes @tiangong-ai/cli@0.0.24 --version
+npx --yes @tiangong-ai/cli@0.0.24 research setup \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+Do not paste a secret when the Wizard asks for an environment variable name.
+It displays only whether the named variable is present. It then guides the
+user through:
+
+- smoke-test versus production mode;
+- public-internet profile;
+- optional Tiangong companions and post-closure authoring Skills;
+- Codex/Claude install targets and project/global scope;
+- non-secret endpoints/settings;
+- credential environment names;
+- each pinned source/license notice and explicit acceptance;
+- optional model IDs and reviewed token prices;
+- live provider checks, a separately authorized synthetic Unstructure upload,
+  and separately authorized paid agent smoke checks;
+- a full plan preview, network confirmation, immutable plan creation, and
+  optional apply.
+
+If a required key is absent, the plan may be saved but apply stops before any
+network download. Set the named variable and resume the exact plan; do not
+recreate the plan merely to bypass preflight.
+
+## Read-only inspection and automation
+
+The catalog command never creates workspace files:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+  --workspace /absolute/path/to/research-workspace \
+  --scope project --agents codex --json
+```
+
+For non-interactive automation, first write JSON files containing only
+non-secret mappings/settings. For example, `credential-env.json` contains
+environment variable names, not values:
+
+```json
+{
+  "brave.search.api-key": "BRAVE_API_KEY"
+}
+```
+
+Create and review a minimal production plan, then apply its exact path:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.24 research setup plan \
+  --workspace /absolute/path/to/research-workspace \
+  --mode production-research \
+  --evidence-profile brave-context \
+  --agents codex --scope project \
+  --credential-env /absolute/path/to/credential-env.json \
+  --accept-license brave-search-skills:MIT \
+  --confirm-network-downloads --json
+
+npx --yes @tiangong-ai/cli@0.0.24 research setup apply \
+  --plan /absolute/path/to/research-workspace/.tiangong-research/setup-plan.json \
+  --json
+```
+
+Add `--skills` IDs, settings, credential mappings, and matching license IDs only
+after reviewing `setup catalog`. Do not manufacture pins or hashes from this
+document; the CLI catalog is authoritative.
+
+## Status, doctor, and recovery
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.24 research setup status \
+  --workspace /absolute/path/to/research-workspace --json
+npx --yes @tiangong-ai/cli@0.0.24 research setup doctor \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+Static doctor checks installed tree hashes, required settings, owner-only
+credential stores, Node/git/npx, sandbox, agent CLIs, Python, and pinned Python
+requirements. `--live` uses provider network/quota. A synthetic document upload
+also requires `--allow-synthetic-unstructure-upload`; model-agent smoke requires
+`--agent-smoke --confirm-agent-smoke-cost`.
+
+On a blocked apply, use the exact `retryCommand` in setup state. Clear a stale
+lock only with both stale-lock flags after confirming no setup process owns it.
+Do not delete plan/state/source-cache directories or overwrite installed trees.
+
+## Update without version drift
+
+`update --check` is read-only. The currently installed generation stays pinned:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.24 research setup update --check \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+An upgrade is a new immutable plan, never an in-place floating update. Review
+new licenses and pins, then apply the newly generated plan:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.24 research setup upgrade \
+  --plan --confirm-upgrade \
+  --accept-license <every-selected-current-license-id> \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+The previous plan/state/report/config generation is archived under
+`.tiangong-research/setup-history/<plan-sha256>/` for audit and recovery.
+
+## Run selected companion adapters
+
+Companions execute outside immutable research packages with a minimal child
+environment and verified Skill tree. Document output uses a unique temporary
+file and a no-overwrite atomic commit:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.24 research setup companion run \
+  --id tiangong.document-granular-decompose \
+  --input /absolute/path/to/source.pdf \
+  --output /absolute/path/to/source.fulltext.md \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+Paper acquisition binds only the precise adapter result and manifest; it never
+chooses the newest PDF in a directory:
+
+```bash
+mkdir -p /absolute/path/to/papers
+npx --yes @tiangong-ai/cli@0.0.24 research setup companion run \
+  --id tiangong.academic-paper-download \
+  --doi 10.1234/example --out /absolute/path/to/papers \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+The adapter must complete its PDF header/EOF/pypdf/size/SHA-256/atomic manifest
+pipeline before the CLI reports success. If automatic OA sources are exhausted,
+the result is `browser-handoff-required` with no committed artifact. Follow the
+installed Skill's browser-handoff reference manually; setup never launches a
+browser or turns a browser into an evidence capability.

--- a/tiangong-kb-sci-search/SKILL.md
+++ b/tiangong-kb-sci-search/SKILL.md
@@ -1,33 +1,44 @@
 ---
 name: tiangong-kb-sci-search
-description: "Search Tiangong knowledge-base SCI sources through the Tiangong AI CLI. Use for academic papers, scientific journal evidence, literature support, and research claims. This skill searches only the sci source, not report or patent."
+description: Search the owner-authorized Tiangong knowledge-base SCI source for academic papers, journal evidence, literature support, and research claims. Use directly through the Tiangong CLI wrapper, or as a locked JSON POST evidence capability in Tiangong Auto Research. Searches only `sci`, never report or patent sources.
 ---
 
 # Tiangong KB SCI Search
 
-Use this skill for Tiangong SCI-source retrieval. It is intentionally
-single-source: always search `sci`, never `all`, `report`, or `patent`.
+This Skill is deliberately single-source. Search `sci` only; never broaden to
+`all`, `report`, or `patent`. Access requires the deployment owner's normal key
+and entitlement. Stop on authentication, authorization, subscription, VPN, or
+service failure; do not try to bypass it.
 
-## Prerequisites
+## Choose the execution mode
 
-- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
-  preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
-  override the CLI entrypoint.
-- Set the authentication environment variables expected by `tiangong-ai`, or
-  pass `api_key` / `sci_api_key` to the wrapper script.
-- When `request_file` / `input_file` is provided, the wrapper loads `.env` from
-  that file's directory by default. `env_file` can point to a different dotenv
-  file. Loaded dotenv values only fill unset environment variables; explicit
-  JSON fields such as `api_key`, `sci_api_key`, and `api_base_url` are passed as
-  CLI flags and take precedence.
-- Optionally set `TIANGONG_AI_API_BASE_URL`; the CLI accepts a Supabase project
-  root, `/functions/v1`, or `/rest/v1` and derives Functions URLs.
+- For a direct standalone search, use `scripts/sci_search.sh` as described
+  below.
+- Inside a Tiangong Auto Research discovery package, do **not** execute this
+  script or its CLI/curl examples. Use locked capability ID
+  `database.tiangong.sci-search` through `fetch_candidate_source`. The broker
+  owns the exact POST method, endpoint, region header, credential injection,
+  response bounds, sanitization, and permanent evidence receipt.
 
-## Search
+## Direct-search prerequisites
 
-For normal searches, pass a query:
+- The wrapper defaults to
+  `npx --yes @tiangong-ai/cli@0.0.24`. Set `TIANGONG_AI_CLI_BIN` to one exact
+  executable path, or `TIANGONG_AI_CLI` to an explicitly reviewed command, only
+  when overriding it intentionally.
+- Put the source-specific key in `TIANGONG_SCI_APIKEY`, or use
+  `TIANGONG_AI_APIKEY` as the common fallback. Credentials are never accepted in
+  wrapper JSON, a request file, or CLI arguments.
+- `jq` is required by the wrapper.
+- Optional endpoint variables are `TIANGONG_SCI_SEARCH_URL`,
+  `TIANGONG_RESEARCH_API_BASE_URL`, `TIANGONG_AI_SEARCH_API_BASE_URL`, or
+  `TIANGONG_AI_API_BASE_URL`; `TIANGONG_REGION` and
+  `TIANGONG_RESEARCH_TIMEOUT` are also supported.
+
+## Direct query
 
 ```bash
+export TIANGONG_SCI_APIKEY='owner-authorized key'
 ./scripts/sci_search.sh '{
   "query": "mechanical recycling reduces lifecycle emissions",
   "top_k": 5,
@@ -35,26 +46,21 @@ For normal searches, pass a query:
 }'
 ```
 
-The script calls:
+The wrapper invokes the pinned CLI equivalent of:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 research search --query <query> --sources sci --json
+npx --yes @tiangong-ai/cli@0.0.24 research search \
+  --query <query> --sources sci --json
 ```
 
-For exact edge-function payloads, provide `request_file` or `input_file`:
+To write a result, pass one explicit output path as the second argument. The
+wrapper writes a unique temporary file and renames it only after the CLI exits
+successfully; it never reports success based on file existence alone.
 
-```bash
-./scripts/sci_search.sh '{
-  "request_file": "./sci-request.json",
-  "dry_run": true
-}'
-```
+## Exact request payload
 
-## Raw Payload Filters
-
-Wrapper JSON can include inline raw `sci_search` fields; the wrapper will
-forward them through the CLI `--input` path. The same payload can also be put in
-`request_file` / `input_file`:
+Inline supported edge-function fields are converted to a temporary request
+file:
 
 ```json
 {
@@ -71,24 +77,65 @@ forward them through the CLI `--input` path. The same payload can also be put in
 }
 ```
 
-- `filter`: metadata term filters, shaped as `{ "field": ["value"] }`.
-- `datefilter`: numeric range filters, shaped as
-  `{ "field": { "gte"?: number, "lte"?: number } }`, for indexed numeric/date
-  metadata fields.
-- `getMeta`: when true, returns paper metadata for matched DOI records.
-- `topK`, `extK`: raw edge-function names for result count and adjacent chunk
-  expansion.
+Or reference an existing regular non-symlink JSON file:
 
-## Input Fields
+```bash
+./scripts/sci_search.sh '{
+  "request_file": "/absolute/path/to/sci-request.json",
+  "dry_run": true
+}'
+```
 
-- `query`, `input`, or `claim`: convenience query text.
-- `request_file` or `input_file`: JSON body forwarded unchanged.
-- `env_file`: optional dotenv file. Without it, `request_file` /
-  `input_file` causes the wrapper to load `.env` from that file's directory.
-- `filter`, `datefilter`, `topK`, `extK`, `getMeta`: optional inline raw
-  payload fields for SCI search.
-- `sources`: optional compatibility field; only `sci` or `default` is accepted.
-- `dry_run`: true to return the exact request plan with masked credentials.
-- `api_base_url`, `api_key`, `sci_api_key`.
-- `sci_url`, `region`, `timeout`.
-- `top_k`, `ext_k`, `get_meta`: only used in query mode.
+`filter` accepts metadata term arrays. `datefilter` accepts numeric `gte`/`lte`
+ranges. `topK`, `extK`, and `getMeta` are the raw service names; `top_k`,
+`ext_k`, and `get_meta` are convenience query-mode names.
+
+## Optional dotenv loading
+
+An explicit `env_file` must exist, be a regular non-symlink file, and have
+owner-only permissions (`chmod 600`). If `request_file` is supplied without an
+explicit env file, a same-directory `.env` is loaded only when it exists and
+passes the same checks. Existing process variables win.
+
+The parser does not execute shell syntax and loads only documented Tiangong
+key, endpoint, region, and timeout names. All other keys are ignored. Never put
+an agent key, browser cookie, Authorization header, session token, proxy
+password, or unrelated secret in this file.
+
+## Accepted wrapper fields
+
+- `query`, `input`, or `claim`;
+- `request_file` or `input_file`;
+- `env_file`;
+- `filter`, `datefilter`, `topK`, `extK`, `getMeta`;
+- `top_k`, `ext_k`, `get_meta` in query mode;
+- `sources`, only `sci` or `default`;
+- `api_base_url`, `sci_url`, `region`, `timeout` as non-secret routing values;
+- `dry_run`.
+
+Any key that looks like an API key, token, Authorization, Cookie, password,
+credential, secret, or session is rejected recursively before the CLI starts.
+The wrapper does not echo rejected values or failed command stdout.
+
+## Auto Research broker call
+
+After `research setup` has selected and configured this Skill, discovery uses:
+
+```json
+{
+  "capability_id": "database.tiangong.sci-search",
+  "url": "<the exact manifest endpoint>",
+  "request_body": {
+    "query": "research claim",
+    "topK": 5,
+    "getMeta": true
+  }
+}
+```
+
+Use only documented non-secret request fields. Never add the API key, headers,
+cookies, endpoint override, or token to `request_body`. The broker injects the
+logical `tiangong.sci.api-key` as `x-api-key`, sends the locked `x-region`,
+refuses POST redirects, and records only the request-body SHA-256 outside the
+permanent raw response object. This database supplements but does not replace
+Auto Research's independent public-internet evidence requirement.

--- a/tiangong-kb-sci-search/agents/openai.yaml
+++ b/tiangong-kb-sci-search/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong KB SCI Search"
-  short_description: "Search only Tiangong KB SCI sources via CLI"
-  default_prompt: "Use $tiangong-kb-sci-search to search Tiangong KB SCI sources only."
+  short_description: "Search an authorized Tiangong SCI database"
+  default_prompt: "Use $tiangong-kb-sci-search to search only the owner-authorized Tiangong SCI source without exposing credentials."

--- a/tiangong-kb-sci-search/scripts/sci_search.sh
+++ b/tiangong-kb-sci-search/scripts/sci_search.sh
@@ -3,6 +3,7 @@
 # Usage: ./sci_search.sh '{"query": "claim or topic", ...}' [output_file]
 
 set -euo pipefail
+umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
@@ -12,7 +13,7 @@ if [ -n "${TIANGONG_AI_CLI:-}" ]; then
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
+    CLI_COMMAND=(npx --yes @tiangong-ai/cli@0.0.24)
 fi
 
 if [ -z "$JSON_INPUT" ]; then
@@ -30,6 +31,15 @@ if ! echo "$JSON_INPUT" | jq empty 2>/dev/null; then
     exit 1
 fi
 
+contains_sensitive_json() {
+    jq -e '[.. | objects | keys[]] | any(.[]; test("(^|[_-])(access[_-]?token|api[_-]?key|apikey|auth|authorization|cookie|credential|password|secret|session|token)([_-]|$)"; "i"))' >/dev/null
+}
+
+if echo "$JSON_INPUT" | contains_sensitive_json; then
+    echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
+    exit 2
+fi
+
 jq_value() {
     local key="$1"
     echo "$JSON_INPUT" | jq -r ".${key} // empty"
@@ -42,7 +52,28 @@ jq_bool() {
 
 load_env_file() {
     local env_file="$1"
-    [ -f "$env_file" ] || return 0
+    local required="${2:-false}"
+    if [ ! -e "$env_file" ]; then
+        if [ "$required" = "true" ]; then
+            echo "Error: explicit env_file does not exist" >&2
+            exit 2
+        fi
+        return 0
+    fi
+    if [ -L "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo "Error: env_file must be a regular non-symlink file" >&2
+        exit 2
+    fi
+    local mode=""
+    if stat -f '%Lp' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -f '%Lp' "$env_file")"
+    elif stat -c '%a' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -c '%a' "$env_file")"
+    fi
+    if [ -n "$mode" ] && [ $((10#$mode % 100)) -ne 0 ]; then
+        echo "Error: env_file must be owner-only (chmod 600)" >&2
+        exit 2
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
@@ -60,6 +91,13 @@ load_env_file() {
         value="${value#\"}"
         value="${value%\'}"
         value="${value#\'}"
+        case "$key" in
+            TIANGONG_AI_APIKEY|TIANGONG_SCI_APIKEY|TIANGONG_RESEARCH_API_BASE_URL|TIANGONG_AI_SEARCH_API_BASE_URL|TIANGONG_AI_API_BASE_URL|TIANGONG_SCI_SEARCH_URL|TIANGONG_REGION|TIANGONG_RESEARCH_TIMEOUT)
+                ;;
+            *)
+                continue
+                ;;
+        esac
         export "$key=$value"
     done < "$env_file"
 }
@@ -91,10 +129,26 @@ esac
 REQUEST_FILE=$(echo "$JSON_INPUT" | jq -r '.request_file // .input_file // empty')
 QUERY=$(echo "$JSON_INPUT" | jq -r '.query // .input // .claim // empty')
 TMP_REQUEST_FILE=""
+TMP_OUTPUT=""
 ENV_FILE=$(echo "$JSON_INPUT" | jq -r '.env_file // empty')
 
+if [ -n "$REQUEST_FILE" ]; then
+    if [ -L "$REQUEST_FILE" ] || [ ! -f "$REQUEST_FILE" ]; then
+        echo "Error: request_file must be a regular non-symlink JSON file" >&2
+        exit 2
+    fi
+    if ! jq empty "$REQUEST_FILE" 2>/dev/null; then
+        echo "Error: request_file is not valid JSON" >&2
+        exit 2
+    fi
+    if contains_sensitive_json < "$REQUEST_FILE"; then
+        echo "Error: request_file contains credential-like fields; use owner environment variables" >&2
+        exit 2
+    fi
+fi
+
 if [ -n "$ENV_FILE" ]; then
-    load_env_file "$ENV_FILE"
+    load_env_file "$ENV_FILE" true
 elif [ -n "$REQUEST_FILE" ]; then
     load_env_near_file "$REQUEST_FILE"
 fi
@@ -102,6 +156,9 @@ fi
 cleanup() {
     if [ -n "$TMP_REQUEST_FILE" ]; then
         rm -f "$TMP_REQUEST_FILE"
+    fi
+    if [ -n "$TMP_OUTPUT" ]; then
+        rm -f "$TMP_OUTPUT"
     fi
 }
 trap cleanup EXIT
@@ -147,10 +204,33 @@ value_arg() {
     fi
 }
 
-value_arg "api_base_url" "--api-base-url"
-value_arg "api_key" "--api-key"
-value_arg "sci_api_key" "--sci-api-key"
-value_arg "sci_url" "--sci-url"
+safe_url_arg() {
+    local json_key="$1"
+    local cli_flag="$2"
+    local value
+    value=$(jq_value "$json_key")
+    if [ -z "$value" ]; then
+        return 0
+    fi
+    case "$value" in
+        https://*)
+            ;;
+        *)
+            echo "Error: $json_key must be an HTTPS URL" >&2
+            exit 2
+            ;;
+    esac
+    case "$value" in
+        *\?*|*\#*|*@*)
+            echo "Error: $json_key must not contain userinfo, query parameters, or fragments" >&2
+            exit 2
+            ;;
+    esac
+    ARGS+=("$cli_flag" "$value")
+}
+
+safe_url_arg "api_base_url" "--api-base-url"
+safe_url_arg "sci_url" "--sci-url"
 value_arg "region" "--region"
 value_arg "timeout" "--timeout"
 
@@ -168,21 +248,25 @@ fi
 
 run_cli() {
     if [[ "${CLI_COMMAND[0]}" == *.js ]]; then
-        node "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 node "${CLI_COMMAND[@]}" "${ARGS[@]}"
     else
-        "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 "${CLI_COMMAND[@]}" "${ARGS[@]}"
     fi
 }
 
 if [ -n "$OUTPUT_FILE" ]; then
-    TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
+    if [ -L "$OUTPUT_FILE" ]; then
+        echo "Error: output_file must not be a symbolic link" >&2
+        exit 2
+    fi
+    TMP_OUTPUT=$(mktemp "${OUTPUT_FILE}.tmp.XXXXXX")
     if run_cli > "$TMP_OUTPUT"; then
         mv "$TMP_OUTPUT" "$OUTPUT_FILE"
+        TMP_OUTPUT=""
         echo "Results saved to: $OUTPUT_FILE"
     else
         STATUS=$?
-        cat "$TMP_OUTPUT" >&2 || true
-        rm -f "$TMP_OUTPUT"
+        echo "Error: Tiangong CLI search failed; see its sanitized stderr diagnostic" >&2
         exit "$STATUS"
     fi
 else

--- a/tiangong-kb-sci-search/scripts/test-sci-search.sh
+++ b/tiangong-kb-sci-search/scripts/test-sci-search.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/sci_search.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tiangong-kb-sci-test.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+FAKE_CLI="$TEST_ROOT/fake-cli"
+AUDIT_ARGS="$TEST_ROOT/args.txt"
+AUDIT_ENV="$TEST_ROOT/env.txt"
+MARKER="$TEST_ROOT/invoked"
+
+printf '%s\n' \
+    '#!/bin/bash' \
+    'set -euo pipefail' \
+    ': > "$FAKE_MARKER"' \
+    'printf "%s\n" "$@" > "$FAKE_ARGS"' \
+    'printf "SCI=%s\nAI=%s\nTRACK=%s\nEVIL=%s\n" "${TIANGONG_SCI_APIKEY:-}" "${TIANGONG_AI_APIKEY:-}" "${DO_NOT_TRACK:-}" "${EVIL_SETTING:-}" > "$FAKE_ENV"' \
+    'printf "{\"ok\":true,\"data\":{\"source\":\"sci\"}}\n"' \
+    > "$FAKE_CLI"
+chmod 700 "$FAKE_CLI"
+
+run_wrapper() {
+    FAKE_ARGS="$AUDIT_ARGS" \
+    FAKE_ENV="$AUDIT_ENV" \
+    FAKE_MARKER="$MARKER" \
+    TIANGONG_AI_CLI_BIN="$FAKE_CLI" \
+    "$WRAPPER" "$@"
+}
+
+SECRET='owner-only-sci-key-value'
+STDOUT="$TEST_ROOT/stdout.txt"
+STDERR="$TEST_ROOT/stderr.txt"
+TIANGONG_SCI_APIKEY="$SECRET" run_wrapper '{"query":"deterministic query","dry_run":true}' \
+    > "$STDOUT" 2> "$STDERR"
+
+grep -Fx 'research' "$AUDIT_ARGS" >/dev/null
+grep -Fx 'search' "$AUDIT_ARGS" >/dev/null
+grep -Fx -- '--sources' "$AUDIT_ARGS" >/dev/null
+grep -Fx 'sci' "$AUDIT_ARGS" >/dev/null
+grep -F "SCI=$SECRET" "$AUDIT_ENV" >/dev/null
+grep -Fx 'TRACK=1' "$AUDIT_ENV" >/dev/null
+if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'secret leaked into argv or command output' >&2
+    exit 1
+fi
+
+rm -f "$MARKER"
+if run_wrapper "{\"query\":\"blocked\",\"sci_api_key\":\"$SECRET\"}" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'credential-like inline JSON was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+if grep -F "$SECRET" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'rejected inline secret was echoed' >&2
+    exit 1
+fi
+
+rm -f "$MARKER"
+if run_wrapper "{\"query\":\"blocked\",\"sci_url\":\"https://sci.example.test/search?api_key=$SECRET\"}" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'credential-bearing endpoint URL was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+if grep -F "$SECRET" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'rejected endpoint secret was echoed' >&2
+    exit 1
+fi
+
+REQUEST_FILE="$TEST_ROOT/request.json"
+printf '%s\n' "{\"query\":\"blocked\",\"nested\":{\"access_token\":\"$SECRET\"}}" \
+    > "$REQUEST_FILE"
+rm -f "$MARKER"
+if run_wrapper "$(printf '{\"request_file\":\"%s\"}' "$REQUEST_FILE")" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'credential-like request file was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+if grep -F "$SECRET" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'rejected request-file secret was echoed' >&2
+    exit 1
+fi
+
+MISSING_ENV="$TEST_ROOT/missing.env"
+rm -f "$MARKER"
+if run_wrapper "$(printf '{\"query\":\"q\",\"env_file\":\"%s\"}' "$MISSING_ENV")" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'missing explicit env file was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+
+ENV_FILE="$TEST_ROOT/owner.env"
+printf '%s\n' "TIANGONG_SCI_APIKEY=$SECRET" 'EVIL_SETTING=must-not-load' > "$ENV_FILE"
+chmod 644 "$ENV_FILE"
+rm -f "$MARKER"
+if run_wrapper "$(printf '{\"query\":\"q\",\"env_file\":\"%s\"}' "$ENV_FILE")" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'non-owner-only env file was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+
+chmod 600 "$ENV_FILE"
+unset TIANGONG_SCI_APIKEY TIANGONG_AI_APIKEY EVIL_SETTING || true
+run_wrapper "$(printf '{\"query\":\"q\",\"env_file\":\"%s\"}' "$ENV_FILE")" \
+    > "$STDOUT" 2> "$STDERR"
+grep -F "SCI=$SECRET" "$AUDIT_ENV" >/dev/null
+grep -Fx 'EVIL=' "$AUDIT_ENV" >/dev/null
+if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'env-file secret leaked into argv or command output' >&2
+    exit 1
+fi
+
+SAFE_REQUEST="$TEST_ROOT/safe-request.json"
+REQUEST_LINK="$TEST_ROOT/request-link.json"
+printf '%s\n' '{"query":"safe"}' > "$SAFE_REQUEST"
+ln -s "$SAFE_REQUEST" "$REQUEST_LINK"
+rm -f "$MARKER"
+if run_wrapper "$(printf '{\"request_file\":\"%s\"}' "$REQUEST_LINK")" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'symlinked request file was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+
+echo 'tiangong-kb-sci-search wrapper tests passed'


### PR DESCRIPTION
Closes #45

## Summary
- documents the user-selected, immutable external Skill setup Wizard and automation flow
- defines evidence, preprocessing, acquisition, and post-closure execution boundaries
- hardens direct Tiangong SCI credentials and adds deterministic wrapper tests
- regenerates OpenAI Skill metadata and records docpact review evidence

## Validation
- skill-creator quick_validate: tiangong-auto-research, tiangong-kb-sci-search
- tiangong-kb-sci-search/scripts/test-sci-search.sh
- tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
- academic-paper-download: 71 unittest tests with pypdf==6.14.2 in isolated env
- docpact 0.1.4 validate-config --strict
- docpact 0.1.4 lint --staged --mode enforce
- git diff --check