### PR TITLE
docs: clarify skills installer destinations

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b"
+lastReviewedCommit: "1fa6b9101c6421de2c0f157217988f31d1352da5"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # Tiangong AI Skills
@@ -52,8 +52,13 @@ npm i skills -g
   npx skills add https://github.com/tiangong-ai/skills -g
   ```
 - Scope notes:
-  - Project scope installs into `./<agent>/skills/`.
-  - Global scope installs into `~/<agent>/skills/`.
+  - Codex is a universal agent: project scope uses `./.agents/skills`, and
+    global scope uses `$HOME/.agents/skills`. `CODEX_HOME` does not change the
+    `skills@1.5.22` global destination.
+  - Claude Code project scope uses `./.claude/skills`; global scope uses
+    `$CLAUDE_CONFIG_DIR/skills` when set, otherwise `$HOME/.claude/skills`.
+  - Other agents have their own directories; inspect the exact path reported by
+    the pinned `skills` CLI rather than deriving `~/<agent>/skills` by analogy.
 
 ## Install method
 - Interactive installs let you choose:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # 天工 AI Skills
@@ -52,8 +52,12 @@ npm i skills -g
   npx skills add https://github.com/tiangong-ai/skills -g
   ```
 - 作用域说明:
-  - 项目级安装到 `./<agent>/skills/`.
-  - 全局安装到 `~/<agent>/skills/`.
+  - Codex 是 universal agent：项目级使用 `./.agents/skills`，全局使用
+    `$HOME/.agents/skills`；`CODEX_HOME` 不会改变 `skills@1.5.22` 的全局目标。
+  - Claude Code 项目级使用 `./.claude/skills`；全局优先使用
+    `$CLAUDE_CONFIG_DIR/skills`，否则使用 `$HOME/.claude/skills`。
+  - 其他 agent 有各自目录；应查看精确锁定的 `skills` CLI 返回路径，不要按
+    `~/<agent>/skills` 类推。
 
 ## 安装方式
 - 交互式安装可选:

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0eaad7bb9de299eb74b28cd667ded7bd17f6ba6b
+lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
 ---
 
 # Skills Documentation Standards


### PR DESCRIPTION
Follow-up to #46 and refs #45.

Documents the exact project/global destinations used by the pinned skills@1.5.22 installer for Codex and Claude Code, including that CODEX_HOME does not alter the Codex global destination.

Validation:
- docpact 0.1.4 staged lint (enforce)
- git diff --check