### PR TITLE
docs(auto-research): align presentation Skill preference

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "1fa6b9101c6421de2c0f157217988f31d1352da5"
+lastReviewedCommit: "c371dbc464dc51ac1d8b0d0d59b318942418cc7b"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ destinations, license choices, credential names, and audit state. Start with the
 read-only catalog or the guided Wizard:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.24 research setup \
+npx --yes @tiangong-ai/cli@0.0.25 research setup \
   --workspace /absolute/path/to/workspace --json
 ```
 
@@ -104,3 +104,5 @@ paper companions, and optional Anthropic or PPT Master post-closure authoring
 Skills. Every entry is external, separately licensed, pinned, and user-selected;
 nothing is bundled or installed by a research package. See
 `tiangong-auto-research/references/setup.md` and `external-skills.md`.
+For PPT creation, prefer PPT Master; Anthropic PPTX remains compatible and may
+be selected alongside it when its workflow fits the task.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,9 +91,9 @@ commit、Skill tree hash、目标目录、许可证选择、凭据名称和审�
 目录，或启动交互式 Wizard：
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.24 research setup \
+npx --yes @tiangong-ai/cli@0.0.25 research setup \
   --workspace /absolute/path/to/workspace --json
 ```
 
@@ -101,3 +101,5 @@ npx --yes @tiangong-ai/cli@0.0.24 research setup \
 以及可选的 Anthropic 或 PPT Master 闭环后创作 Skills。所有条目都是外生、独立
 授权、精确锁定且由用户选择；研究 package 不会捆绑或安装它们。完整流程见
 `tiangong-auto-research/references/setup.md` 和 `external-skills.md`。
+创建 PPT 时首选 PPT Master；Anthropic PPTX 仍是兼容的按场景选项，需要时可在
+同一显式计划中一起选择。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -8,7 +8,7 @@ description: Run or set up smoke-test and production Tiangong research workspace
 Use the exact CLI release for all workspace operations:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research --help
+npx --yes @tiangong-ai/cli@0.0.25 research --help
 ```
 
 The CLI owns the setup catalog, immutable setup plan, capability policy, output
@@ -40,7 +40,7 @@ files by hand.
 Resolve paths to absolute paths, then inspect the directory:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research context inspect \
+npx --yes @tiangong-ai/cli@0.0.25 research context inspect \
   --path /absolute/path/to/workspace --json
 ```
 
@@ -51,9 +51,9 @@ For a clean directory, show the read-only ecosystem catalog and run the guided
 setup only after the user asks to configure it:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.24 research setup \
+npx --yes @tiangong-ai/cli@0.0.25 research setup \
   --workspace /absolute/path/to/workspace --json
 ```
 
@@ -78,6 +78,8 @@ license. Missing required credentials must block before any source download.
 - Document/PDF/spreadsheet/presentation Skills are `post-closure-authoring`.
   They may format a closed report but cannot produce or alter admitted evidence,
   analysis, review, or closure.
+- For PPT creation, prefer `hugohe3.ppt-master`. Keep `anthropic.pptx` as a
+  compatible situational option; both may be selected explicitly in one plan.
 
 ## Preflight and initialize a project
 
@@ -87,13 +89,13 @@ local sources, create an immutable input plan with bounded context files or
 ranges.
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research project preflight \
+npx --yes @tiangong-ai/cli@0.0.25 research project preflight \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json --json
 
-npx --yes @tiangong-ai/cli@0.0.24 research project init PROJECT \
+npx --yes @tiangong-ai/cli@0.0.25 research project init PROJECT \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
@@ -112,14 +114,14 @@ agent families, a current setup doctor report, and real capsule/provider smoke
 attestations:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup doctor \
+npx --yes @tiangong-ai/cli@0.0.25 research setup doctor \
   --workspace /absolute/path/to/workspace --live --json
-npx --yes @tiangong-ai/cli@0.0.24 research workspace doctor \
+npx --yes @tiangong-ai/cli@0.0.25 research workspace doctor \
   --workspace /absolute/path/to/workspace \
   --agent-smoke --capability-smoke --json
-npx --yes @tiangong-ai/cli@0.0.24 research run \
+npx --yes @tiangong-ai/cli@0.0.25 research run \
   --workspace /absolute/path/to/workspace --project PROJECT --dry-run --json
-npx --yes @tiangong-ai/cli@0.0.24 research run \
+npx --yes @tiangong-ai/cli@0.0.25 research run \
   --workspace /absolute/path/to/workspace --project PROJECT \
   --max-cycles 20 --progress-jsonl --json
 ```

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -3,7 +3,7 @@
 ## Base prerequisites
 
 - Node.js 24, `git`, and `npx` access to
-  `@tiangong-ai/cli@0.0.24` and the exact setup-pinned `skills@1.5.22` package.
+  `@tiangong-ai/cli@0.0.25` and the exact setup-pinned `skills@1.5.22` package.
 - Authenticated `codex` and `claude` executables for the configured producer and
   reviewer routes.
 - macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`).
@@ -47,7 +47,7 @@ Use the supported command to rotate one selected credential:
 
 ```bash
 export OWNER_NEW_BRAVE_KEY='new owner value'
-npx --yes @tiangong-ai/cli@0.0.24 research setup credential set \
+npx --yes @tiangong-ai/cli@0.0.25 research setup credential set \
   --id brave.search.api-key --from-env OWNER_NEW_BRAVE_KEY \
   --workspace /absolute/path/to/workspace --json
 ```

--- a/tiangong-auto-research/references/external-skills.md
+++ b/tiangong-auto-research/references/external-skills.md
@@ -5,7 +5,7 @@ allowed to do, which credentials it needs, and how installation is governed.
 The live machine-readable source of truth is:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
   --workspace /absolute/path/to/workspace --json
 ```
 
@@ -83,11 +83,14 @@ research artifacts:
 | Catalog IDs | Source | License/configuration note |
 | --- | --- | --- |
 | `anthropic.doc-coauthoring` | `anthropics/skills` | No API key. The pinned Skill tree has no per-Skill license file; catalog reports `NOASSERTION`, so the user must review and explicitly accept the notice. |
-| `anthropic.docx`, `anthropic.pdf`, `anthropic.pptx`, `anthropic.xlsx` | `anthropics/skills` | No API key. Source-available Anthropic document terms are not open source; nothing is bundled and installation is opt-in. |
-| `hugohe3.ppt-master` | `hugohe3/ppt-master` | MIT, no API key. Upstream Python requirements contain ranges; setup refuses to resolve/install them until the user creates and reviews an exact isolated lock. |
+| `anthropic.docx`, `anthropic.pdf`, `anthropic.pptx`, `anthropic.xlsx` | `anthropics/skills` | No API key. Source-available Anthropic document terms are not open source; nothing is bundled and installation is opt-in. Use `anthropic.pptx` when its reading, editing, or alternative authoring workflow better fits the task. |
+| `hugohe3.ppt-master` | `hugohe3/ppt-master` | Preferred for creating PPT presentations. MIT, no API key. Upstream Python requirements contain ranges; setup refuses to resolve/install them until the user creates and reviews an exact isolated lock. |
 
-`anthropic.pptx` and `hugohe3.ppt-master` are mutually exclusive in one setup
-plan to avoid ambiguous presentation routing. Choose one or use separate plans.
+`anthropic.pptx` and `hugohe3.ppt-master` are compatible selections and may be
+installed by the same explicit setup plan. This is a task preference, not an
+installation conflict: default to PPT Master when creating a PPT, then use
+Anthropic PPTX or another selected authoring Skill when the concrete task makes
+that workflow a better fit. Setup does not auto-select either Skill.
 
 ## Credential and setting matrix
 

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -116,9 +116,9 @@ registered for review; it does not expose that entire file to discovery.
 Inspect, but never copy or fork, a current contract with:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research schema show discover --json
-npx --yes @tiangong-ai/cli@0.0.24 research schema show analyze --json
-npx --yes @tiangong-ai/cli@0.0.24 research schema show review --json
+npx --yes @tiangong-ai/cli@0.0.25 research schema show discover --json
+npx --yes @tiangong-ai/cli@0.0.25 research schema show analyze --json
+npx --yes @tiangong-ai/cli@0.0.25 research schema show review --json
 ```
 
 Evidence sources include stable ID/title/locator/provenance, URL or DOI when
@@ -236,9 +236,9 @@ Failures are classified:
 Use an explicit management command instead of editing state:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research project retry PROJECT \
+npx --yes @tiangong-ai/cli@0.0.25 research project retry PROJECT \
   --package PACKAGE --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.24 research project fork SOURCE \
+npx --yes @tiangong-ai/cli@0.0.25 research project fork SOURCE \
   --to TARGET --resume-through analyze \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -251,7 +251,7 @@ and closure always run again.
 Run one recovered or canary project with an explicit scope:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research run \
+npx --yes @tiangong-ai/cli@0.0.25 research run \
   --project PROJECT --workspace /absolute/path/to/workspace \
   --progress-jsonl --json
 ```

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -44,8 +44,8 @@ export UNSTRUCTURED_AUTH_TOKEN='owner Unstructure bearer token'
 # Optional; academic-paper-download can use Semantic Scholar anonymously.
 export SEMANTIC_SCHOLAR_API_KEY='optional Semantic Scholar key'
 
-npx --yes @tiangong-ai/cli@0.0.24 --version
-npx --yes @tiangong-ai/cli@0.0.24 research setup \
+npx --yes @tiangong-ai/cli@0.0.25 --version
+npx --yes @tiangong-ai/cli@0.0.25 research setup \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -55,7 +55,9 @@ user through:
 
 - smoke-test versus production mode;
 - public-internet profile;
-- optional Tiangong companions and post-closure authoring Skills;
+- optional Tiangong companions and post-closure authoring Skills; for PPT
+  creation it presents PPT Master as preferred while keeping Anthropic PPTX as
+  a compatible situational choice;
 - Codex/Claude install targets and project/global scope;
 - non-secret endpoints/settings;
 - credential environment names;
@@ -75,7 +77,7 @@ recreate the plan merely to bypass preflight.
 The catalog command never creates workspace files:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
   --workspace /absolute/path/to/research-workspace \
   --scope project --agents codex --json
 ```
@@ -93,7 +95,7 @@ environment variable names, not values:
 Create and review a minimal production plan, then apply its exact path:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup plan \
+npx --yes @tiangong-ai/cli@0.0.25 research setup plan \
   --workspace /absolute/path/to/research-workspace \
   --mode production-research \
   --evidence-profile brave-context \
@@ -102,7 +104,7 @@ npx --yes @tiangong-ai/cli@0.0.24 research setup plan \
   --accept-license brave-search-skills:MIT \
   --confirm-network-downloads --json
 
-npx --yes @tiangong-ai/cli@0.0.24 research setup apply \
+npx --yes @tiangong-ai/cli@0.0.25 research setup apply \
   --plan /absolute/path/to/research-workspace/.tiangong-research/setup-plan.json \
   --json
 ```
@@ -114,9 +116,9 @@ document; the CLI catalog is authoritative.
 ## Status, doctor, and recovery
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup status \
+npx --yes @tiangong-ai/cli@0.0.25 research setup status \
   --workspace /absolute/path/to/research-workspace --json
-npx --yes @tiangong-ai/cli@0.0.24 research setup doctor \
+npx --yes @tiangong-ai/cli@0.0.25 research setup doctor \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -135,7 +137,7 @@ Do not delete plan/state/source-cache directories or overwrite installed trees.
 `update --check` is read-only. The currently installed generation stays pinned:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup update --check \
+npx --yes @tiangong-ai/cli@0.0.25 research setup update --check \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -143,7 +145,7 @@ An upgrade is a new immutable plan, never an in-place floating update. Review
 new licenses and pins, then apply the newly generated plan:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup upgrade \
+npx --yes @tiangong-ai/cli@0.0.25 research setup upgrade \
   --plan --confirm-upgrade \
   --accept-license <every-selected-current-license-id> \
   --workspace /absolute/path/to/research-workspace --json
@@ -159,7 +161,7 @@ environment and verified Skill tree. Document output uses a unique temporary
 file and a no-overwrite atomic commit:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research setup companion run \
+npx --yes @tiangong-ai/cli@0.0.25 research setup companion run \
   --id tiangong.document-granular-decompose \
   --input /absolute/path/to/source.pdf \
   --output /absolute/path/to/source.fulltext.md \
@@ -171,7 +173,7 @@ chooses the newest PDF in a directory:
 
 ```bash
 mkdir -p /absolute/path/to/papers
-npx --yes @tiangong-ai/cli@0.0.24 research setup companion run \
+npx --yes @tiangong-ai/cli@0.0.25 research setup companion run \
   --id tiangong.academic-paper-download \
   --doi 10.1234/example --out /absolute/path/to/papers \
   --workspace /absolute/path/to/research-workspace --json


### PR DESCRIPTION
Closes #48. Parent tracking: tiangong-ai/workspace#97.

## Summary

- removes the separate-plan/mutual-exclusion guidance for `anthropic.pptx` and `hugohe3.ppt-master`
- states that PPT Master is preferred for PPT creation
- keeps Anthropic PPTX as a compatible situational reading/editing/alternative-authoring option
- preserves explicit selection, separate license acceptance, dependency review, and post-closure-only boundaries
- updates exact CLI examples to the pending `0.0.25` patch release

## Key decisions

The concise core rule lives in `SKILL.md`; detailed task fit and compatibility remain in the first-level external Skills reference. The trigger description did not change, so generated `agents/openai.yaml` metadata remains valid and was not rewritten.

## Validation

- skill-creator `quick_validate.py tiangong-auto-research` in an isolated environment with `PyYAML==6.0.3`
- `docpact 0.1.9 validate-config --strict`
- `docpact 0.1.9 lint --worktree --mode enforce`
- `git diff --check`

## Risks / rollback

Documentation-only behavior guidance. Roll back this commit if CLI `0.0.25` is not released; otherwise the referenced command version and catalog contract remain aligned.

## Follow-ups

Merge after the CLI patch is available, then integrate the exact Skills commit in the root workspace.

## Workspace integration

Required through tiangong-ai/workspace#97.