### PR TITLE
docs(auto-research): require CLI 0.0.26 setup fix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "c371dbc464dc51ac1d8b0d0d59b318942418cc7b"
+lastReviewedCommit: "d4a1ddfae7f956468c678a09e5a83ef5c9428650"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
+lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ destinations, license choices, credential names, and audit state. Start with the
 read-only catalog or the guided Wizard:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.25 research setup \
-  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.26 research setup \
+  --workspace /absolute/path/to/workspace
 ```
 
 The catalog includes Brave internet evidence, optional Tiangong SCI/document/

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,10 +91,10 @@ commit、Skill tree hash、目标目录、许可证选择、凭据名称和审�
 目录，或启动交互式 Wizard：
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.25 research setup \
-  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.26 research setup \
+  --workspace /absolute/path/to/workspace
 ```
 
 目录包含 Brave 互联网证据能力、可选的 Tiangong SCI/文档解析/论文获取 companion，

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
+lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
+lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
+lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
+lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: c371dbc464dc51ac1d8b0d0d59b318942418cc7b
+lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -8,7 +8,7 @@ description: Run or set up smoke-test and production Tiangong research workspace
 Use the exact CLI release for all workspace operations:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research --help
+npx --yes @tiangong-ai/cli@0.0.26 research --help
 ```
 
 The CLI owns the setup catalog, immutable setup plan, capability policy, output
@@ -40,7 +40,7 @@ files by hand.
 Resolve paths to absolute paths, then inspect the directory:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research context inspect \
+npx --yes @tiangong-ai/cli@0.0.26 research context inspect \
   --path /absolute/path/to/workspace --json
 ```
 
@@ -51,9 +51,9 @@ For a clean directory, show the read-only ecosystem catalog and run the guided
 setup only after the user asks to configure it:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.25 research setup \
+npx --yes @tiangong-ai/cli@0.0.26 research setup \
   --workspace /absolute/path/to/workspace --json
 ```
 
@@ -89,13 +89,13 @@ local sources, create an immutable input plan with bounded context files or
 ranges.
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research project preflight \
+npx --yes @tiangong-ai/cli@0.0.26 research project preflight \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json --json
 
-npx --yes @tiangong-ai/cli@0.0.25 research project init PROJECT \
+npx --yes @tiangong-ai/cli@0.0.26 research project init PROJECT \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
@@ -114,14 +114,14 @@ agent families, a current setup doctor report, and real capsule/provider smoke
 attestations:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup doctor \
+npx --yes @tiangong-ai/cli@0.0.26 research setup doctor \
   --workspace /absolute/path/to/workspace --live --json
-npx --yes @tiangong-ai/cli@0.0.25 research workspace doctor \
+npx --yes @tiangong-ai/cli@0.0.26 research workspace doctor \
   --workspace /absolute/path/to/workspace \
   --agent-smoke --capability-smoke --json
-npx --yes @tiangong-ai/cli@0.0.25 research run \
+npx --yes @tiangong-ai/cli@0.0.26 research run \
   --workspace /absolute/path/to/workspace --project PROJECT --dry-run --json
-npx --yes @tiangong-ai/cli@0.0.25 research run \
+npx --yes @tiangong-ai/cli@0.0.26 research run \
   --workspace /absolute/path/to/workspace --project PROJECT \
   --max-cycles 20 --progress-jsonl --json
 ```

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -3,7 +3,7 @@
 ## Base prerequisites
 
 - Node.js 24, `git`, and `npx` access to
-  `@tiangong-ai/cli@0.0.25` and the exact setup-pinned `skills@1.5.22` package.
+  `@tiangong-ai/cli@0.0.26` and the exact setup-pinned `skills@1.5.22` package.
 - Authenticated `codex` and `claude` executables for the configured producer and
   reviewer routes.
 - macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`).
@@ -47,7 +47,7 @@ Use the supported command to rotate one selected credential:
 
 ```bash
 export OWNER_NEW_BRAVE_KEY='new owner value'
-npx --yes @tiangong-ai/cli@0.0.25 research setup credential set \
+npx --yes @tiangong-ai/cli@0.0.26 research setup credential set \
   --id brave.search.api-key --from-env OWNER_NEW_BRAVE_KEY \
   --workspace /absolute/path/to/workspace --json
 ```

--- a/tiangong-auto-research/references/external-skills.md
+++ b/tiangong-auto-research/references/external-skills.md
@@ -5,7 +5,7 @@ allowed to do, which credentials it needs, and how installation is governed.
 The live machine-readable source of truth is:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
   --workspace /absolute/path/to/workspace --json
 ```
 

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -116,9 +116,9 @@ registered for review; it does not expose that entire file to discovery.
 Inspect, but never copy or fork, a current contract with:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research schema show discover --json
-npx --yes @tiangong-ai/cli@0.0.25 research schema show analyze --json
-npx --yes @tiangong-ai/cli@0.0.25 research schema show review --json
+npx --yes @tiangong-ai/cli@0.0.26 research schema show discover --json
+npx --yes @tiangong-ai/cli@0.0.26 research schema show analyze --json
+npx --yes @tiangong-ai/cli@0.0.26 research schema show review --json
 ```
 
 Evidence sources include stable ID/title/locator/provenance, URL or DOI when
@@ -236,9 +236,9 @@ Failures are classified:
 Use an explicit management command instead of editing state:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research project retry PROJECT \
+npx --yes @tiangong-ai/cli@0.0.26 research project retry PROJECT \
   --package PACKAGE --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.25 research project fork SOURCE \
+npx --yes @tiangong-ai/cli@0.0.26 research project fork SOURCE \
   --to TARGET --resume-through analyze \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -251,7 +251,7 @@ and closure always run again.
 Run one recovered or canary project with an explicit scope:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research run \
+npx --yes @tiangong-ai/cli@0.0.26 research run \
   --project PROJECT --workspace /absolute/path/to/workspace \
   --progress-jsonl --json
 ```

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -44,9 +44,9 @@ export UNSTRUCTURED_AUTH_TOKEN='owner Unstructure bearer token'
 # Optional; academic-paper-download can use Semantic Scholar anonymously.
 export SEMANTIC_SCHOLAR_API_KEY='optional Semantic Scholar key'
 
-npx --yes @tiangong-ai/cli@0.0.25 --version
-npx --yes @tiangong-ai/cli@0.0.25 research setup \
-  --workspace /absolute/path/to/research-workspace --json
+npx --yes @tiangong-ai/cli@0.0.26 --version
+npx --yes @tiangong-ai/cli@0.0.26 research setup \
+  --workspace /absolute/path/to/research-workspace
 ```
 
 Do not paste a secret when the Wizard asks for an environment variable name.
@@ -77,7 +77,7 @@ recreate the plan merely to bypass preflight.
 The catalog command never creates workspace files:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
   --workspace /absolute/path/to/research-workspace \
   --scope project --agents codex --json
 ```
@@ -95,7 +95,7 @@ environment variable names, not values:
 Create and review a minimal production plan, then apply its exact path:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup plan \
+npx --yes @tiangong-ai/cli@0.0.26 research setup plan \
   --workspace /absolute/path/to/research-workspace \
   --mode production-research \
   --evidence-profile brave-context \
@@ -104,7 +104,7 @@ npx --yes @tiangong-ai/cli@0.0.25 research setup plan \
   --accept-license brave-search-skills:MIT \
   --confirm-network-downloads --json
 
-npx --yes @tiangong-ai/cli@0.0.25 research setup apply \
+npx --yes @tiangong-ai/cli@0.0.26 research setup apply \
   --plan /absolute/path/to/research-workspace/.tiangong-research/setup-plan.json \
   --json
 ```
@@ -116,9 +116,9 @@ document; the CLI catalog is authoritative.
 ## Status, doctor, and recovery
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup status \
+npx --yes @tiangong-ai/cli@0.0.26 research setup status \
   --workspace /absolute/path/to/research-workspace --json
-npx --yes @tiangong-ai/cli@0.0.25 research setup doctor \
+npx --yes @tiangong-ai/cli@0.0.26 research setup doctor \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -132,12 +132,29 @@ On a blocked apply, use the exact `retryCommand` in setup state. Clear a stale
 lock only with both stale-lock flags after confirming no setup process owns it.
 Do not delete plan/state/source-cache directories or overwrite installed trees.
 
+### Replace an affected CLI 0.0.25 plan
+
+CLI `0.0.25` recorded Brave Skill paths without the upstream `skills/`
+directory, so a plan created by that release can report every selected Brave
+Skill as `missing`. Do not edit the hash-bound plan or keep retrying it. Upgrade
+to `0.0.26`, run the Wizard again, and choose its explicit replacement action:
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.26 research setup \
+  --workspace /absolute/path/to/research-workspace
+```
+
+For automation, rerun the same reviewed `research setup plan` inputs with
+`--replace-plan`. The CLI archives the previous generation and creates a new
+plan whose pinned Brave paths are `skills/web-search`, `skills/news-search`,
+`skills/llm-context`, `skills/images-search`, and `skills/videos-search`.
+
 ## Update without version drift
 
 `update --check` is read-only. The currently installed generation stays pinned:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup update --check \
+npx --yes @tiangong-ai/cli@0.0.26 research setup update --check \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -145,7 +162,7 @@ An upgrade is a new immutable plan, never an in-place floating update. Review
 new licenses and pins, then apply the newly generated plan:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup upgrade \
+npx --yes @tiangong-ai/cli@0.0.26 research setup upgrade \
   --plan --confirm-upgrade \
   --accept-license <every-selected-current-license-id> \
   --workspace /absolute/path/to/research-workspace --json
@@ -161,7 +178,7 @@ environment and verified Skill tree. Document output uses a unique temporary
 file and a no-overwrite atomic commit:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.25 research setup companion run \
+npx --yes @tiangong-ai/cli@0.0.26 research setup companion run \
   --id tiangong.document-granular-decompose \
   --input /absolute/path/to/source.pdf \
   --output /absolute/path/to/source.fulltext.md \
@@ -173,7 +190,7 @@ chooses the newest PDF in a directory:
 
 ```bash
 mkdir -p /absolute/path/to/papers
-npx --yes @tiangong-ai/cli@0.0.25 research setup companion run \
+npx --yes @tiangong-ai/cli@0.0.26 research setup companion run \
   --id tiangong.academic-paper-download \
   --doi 10.1234/example --out /absolute/path/to/papers \
   --workspace /absolute/path/to/research-workspace --json


### PR DESCRIPTION
Closes #50.

Parent delivery: tiangong-ai/workspace#100
Depends on tiangong-ai/cli#27 and the verified @tiangong-ai/cli@0.0.26 publication.

## What changed

- Pin every Auto Research command example to CLI 0.0.26.
- Document recovery for immutable setup plans created by CLI 0.0.25 with incorrect Brave paths.
- Direct operators to use the Wizard replacement action or an explicitly reviewed --replace-plan invocation; never edit or repeatedly retry the old plan.
- Keep human Wizard examples in normal TTY mode so the new semantic styling is visible.

## Validation

- skill-creator quick_validate.py in an isolated PyYAML 6.0.2 environment
- docpact validate-config --root . --strict
- docpact lint --root . --worktree --mode enforce --format json --output .docpact/runs/latest.json
- git diff --check

The Skill trigger description and agents/openai.yaml UI contract are unchanged.