### PR TITLE
ci: upgrade checkout action to v7

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "d4a1ddfae7f956468c678a09e5a83ef5c9428650"
+lastReviewedAt: "2026-08-09"
+lastReviewedCommit: "3dbc264d97573060b5c2e5fa08a4ab8242db87dc"
 
 repo:
   id: skills

--- a/.github/workflows/docpact.yml
+++ b/.github/workflows/docpact.yml
@@ -11,7 +11,7 @@ jobs:
   validate-config:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: Biaoo/docpact@v0.1.4
@@ -26,7 +26,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: Biaoo/docpact@v0.1.4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1fa6b9101c6421de2c0f157217988f31d1352da5
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: d4a1ddfae7f956468c678a09e5a83ef5c9428650
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
 ---
 
 # Skills Documentation Standards


### PR DESCRIPTION
Refs tiangong-ai/workspace#106

## Summary

- Upgrade this repository's first-party checkout steps to `actions/checkout@v7`.
- Preserve existing workflow inputs and behavior.
- Record required docpact review evidence where this repository is governed.

## Key Decisions

- Keep the requested major tag rather than pinning a patch SHA.
- Do not change unrelated Actions or product code.

## Validation

- Workflow YAML parsed successfully.\n- docpact 0.1.9 strict config validation and enforce lint passed.\n- docpact-governance skill quick validation passed.\n- git diff --check passed.

## Risks / Rollback

- checkout v7 runs on Node 24 and requires runner v2.327.1 or newer; this repository uses GitHub-hosted runners.
- Rollback is limited to reverting the checkout major and review metadata commit.

## Follow-ups

- Complete the multi-repository pin update tracked by tiangong-ai/workspace#106.

## Workspace Integration

- Required: the root workspace must pin the merged commit.
