### PR TITLE
docs(auto-research): define production setup and evidence workflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "3dbc264d97573060b5c2e5fa08a4ab8242db87dc"
+lastReviewedCommit: "a300a49803c193b686e7cde55b5f2d170f993af5"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -93,16 +93,18 @@ destinations, license choices, credential names, and audit state. Start with the
 read-only catalog or the guided Wizard:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.26 research setup \
+npx --yes @tiangong-ai/cli@0.0.28 research setup \
   --workspace /absolute/path/to/workspace
 ```
 
-The catalog includes Brave internet evidence, optional Tiangong SCI/document/
-paper companions, and optional Anthropic or PPT Master post-closure authoring
-Skills. Every entry is external, separately licensed, pinned, and user-selected;
-nothing is bundled or installed by a research package. See
+The catalog also offers the `tiangong-auto-research` workflow orchestrator,
+default-baseline Brave internet evidence, optional Tiangong SCI/document/paper
+companions, and optional Anthropic or PPT Master post-closure authoring Skills.
+The workspace can be any user-selected directory. Every entry is external,
+separately licensed, pinned, and explicitly confirmed/selected; nothing is
+bundled or installed by a research package. See
 `tiangong-auto-research/references/setup.md` and `external-skills.md`.
 For PPT creation, prefer PPT Master; Anthropic PPTX remains compatible and may
 be selected alongside it when its workflow fits the task.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,15 +91,17 @@ commit、Skill tree hash、目标目录、许可证选择、凭据名称和审�
 目录，或启动交互式 Wizard：
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.26 research setup \
+npx --yes @tiangong-ai/cli@0.0.28 research setup \
   --workspace /absolute/path/to/workspace
 ```
 
-目录包含 Brave 互联网证据能力、可选的 Tiangong SCI/文档解析/论文获取 companion，
-以及可选的 Anthropic 或 PPT Master 闭环后创作 Skills。所有条目都是外生、独立
-授权、精确锁定且由用户选择；研究 package 不会捆绑或安装它们。完整流程见
+目录还提供 `tiangong-auto-research` 工作流 orchestrator、默认基线 Brave
+互联网证据能力、可选的 Tiangong SCI/文档解析/论文获取 companion，以及可选的
+Anthropic 或 PPT Master 闭环后创作 Skills。workspace 可以是用户指定的任意目录。
+所有条目都是外生、独立授权、精确锁定且经用户明确确认或选择；研究 package
+不会捆绑或安装它们。完整流程见
 `tiangong-auto-research/references/setup.md` 和 `external-skills.md`。
 创建 PPT 时首选 PPT Master；Anthropic PPTX 仍是兼容的按场景选项，需要时可在
 同一显式计划中一起选择。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-auto-research
-description: Run or set up smoke-test and production Tiangong research workspaces with an explicit, user-selected external Skill ecosystem; public-internet and owner-whitelisted broker evidence; immutable inputs and evidence; pre-call budgets; isolated producers; independent review; and mechanical closure. Use when a user asks to configure, plan, initialize, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
+description: Set up or run smoke-test and production Tiangong research workspaces in any user-selected directory with an explicitly installed orchestrator and external Skill ecosystem; public-internet and owner-whitelisted broker evidence; immutable inputs and evidence; pre-call budgets; isolated producers; independent review; and mechanical closure. Use when a user asks to configure, plan, initialize, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
 ---
 
 # Tiangong Auto Research
@@ -8,7 +8,7 @@ description: Run or set up smoke-test and production Tiangong research workspace
 Use the exact CLI release for all workspace operations:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research --help
+npx --yes @tiangong-ai/cli@0.0.28 research --help
 ```
 
 The CLI owns the setup catalog, immutable setup plan, capability policy, output
@@ -37,10 +37,12 @@ files by hand.
 
 ## Inspect before mutation
 
-Resolve paths to absolute paths, then inspect the directory:
+The workspace may be any user-selected directory; example paths are
+placeholders, never defaults. Resolve paths to absolute paths, then inspect the
+directory:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research context inspect \
+npx --yes @tiangong-ai/cli@0.0.28 research context inspect \
   --path /absolute/path/to/workspace --json
 ```
 
@@ -51,16 +53,19 @@ For a clean directory, show the read-only ecosystem catalog and run the guided
 setup only after the user asks to configure it:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.26 research setup \
+npx --yes @tiangong-ai/cli@0.0.28 research setup \
   --workspace /absolute/path/to/workspace --json
 ```
 
-The user must choose every external source and accept its pinned license. The
-Wizard may create a plan without applying it. Never silently install a Skill,
-write globally, substitute a provider, downgrade a profile, or accept a
-license. Missing required credentials must block before any source download.
+The user must explicitly confirm the recommended project-local
+`tiangong-auto-research` orchestrator and every external source, then accept its
+pinned license. The Wizard defaults evidence to Brave web/news; context and
+media remain visibly subscription-dependent choices. It may create a plan
+without applying it. Never silently install a Skill, write globally, substitute
+a provider, downgrade a profile, or accept a license. Missing required
+credentials must block before any source download.
 
 ## Preserve execution boundaries
 
@@ -88,14 +93,29 @@ Prepare evidence requirements with `dimensions`, `sourceTypes`, `minSources`,
 local sources, create an immutable input plan with bounded context files or
 ranges.
 
+First require the current setup generation and its real production checks to
+pass. One setup doctor invocation performs the nested workspace/capability and
+agent capsule smokes, so do not repeat paid smokes unnecessarily:
+
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research project preflight \
+npx --yes @tiangong-ai/cli@0.0.28 research setup status \
+  --workspace /absolute/path/to/workspace --json
+npx --yes @tiangong-ai/cli@0.0.28 research setup doctor \
+  --workspace /absolute/path/to/workspace --live \
+  --agent-smoke --confirm-agent-smoke-cost --json
+```
+
+Stop unless readiness is `READY`. An explicitly requested smoke failure is
+`BLOCKED`, not advisory.
+
+```bash
+npx --yes @tiangong-ai/cli@0.0.28 research project preflight \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json --json
 
-npx --yes @tiangong-ai/cli@0.0.26 research project init PROJECT \
+npx --yes @tiangong-ai/cli@0.0.28 research project init PROJECT \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
@@ -111,17 +131,13 @@ initialization.
 
 Production requires explicit models/prices, different producer and reviewer
 agent families, a current setup doctor report, and real capsule/provider smoke
-attestations:
+attestations. After successful preflight and initialization, use dry-run before
+the paid run:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup doctor \
-  --workspace /absolute/path/to/workspace --live --json
-npx --yes @tiangong-ai/cli@0.0.26 research workspace doctor \
-  --workspace /absolute/path/to/workspace \
-  --agent-smoke --capability-smoke --json
-npx --yes @tiangong-ai/cli@0.0.26 research run \
+npx --yes @tiangong-ai/cli@0.0.28 research run \
   --workspace /absolute/path/to/workspace --project PROJECT --dry-run --json
-npx --yes @tiangong-ai/cli@0.0.26 research run \
+npx --yes @tiangong-ai/cli@0.0.28 research run \
   --workspace /absolute/path/to/workspace --project PROJECT \
   --max-cycles 20 --progress-jsonl --json
 ```

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
   short_description: "Set up and run auditable internet research"
-  default_prompt: "Use $tiangong-auto-research to guide me through external Skill setup, verify evidence coverage and budget, and run a traceable production research workspace."
+  default_prompt: "Use $tiangong-auto-research to set up or run a traceable research workspace in my selected directory, verify external evidence coverage and budget, and stop on any unmet production gate."

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -3,7 +3,7 @@
 ## Base prerequisites
 
 - Node.js 24, `git`, and `npx` access to
-  `@tiangong-ai/cli@0.0.26` and the exact setup-pinned `skills@1.5.22` package.
+  `@tiangong-ai/cli@0.0.28` and the exact setup-pinned `skills@1.5.22` package.
 - Authenticated `codex` and `claude` executables for the configured producer and
   reviewer routes.
 - macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`).
@@ -34,20 +34,26 @@ recommended defaults are:
 
 The variable name can differ, but it must be explicitly bound in the immutable
 plan. Values must be non-trivial and remain in the owner process environment
-only until setup stores them. Do not put values in setup JSON files, CLI
-arguments, shell history, Skill files, capability declarations, or chat.
+only until setup stores them. After a successful apply, later
+status/doctor/run commands use the owner-only logical stores and do not require
+those source shell variables to remain exported. Do not put values in setup
+JSON files, CLI arguments, shell history, Skill files, capability declarations,
+or chat.
 
 Broker credentials are written to the owner-only
 `.tiangong-research/.env` logical credential store. Adapter credentials are
 written separately to owner-only `.tiangong-research/setup-adapters.env`.
 Neither file supports arbitrary dotenv keys or shell interpolation. Both reject
 symlinks, duplicate/undeclared entries, malformed JSON, and group/other access.
+An explicitly reviewed replacement reconciles both stores to the new selection,
+so deselected logical entries do not invalidate the new configuration; values
+are never printed during reconciliation.
 
 Use the supported command to rotate one selected credential:
 
 ```bash
 export OWNER_NEW_BRAVE_KEY='new owner value'
-npx --yes @tiangong-ai/cli@0.0.26 research setup credential set \
+npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
   --id brave.search.api-key --from-env OWNER_NEW_BRAVE_KEY \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -126,3 +132,7 @@ in the keychain.
 The outer sandbox is the execution boundary. Discovery has no shell or ambient
 filesystem/network access and can call only the scoped broker. Analyze,
 synthesize, and review are tool-free.
+
+Codex also receives a capsule-local project-root marker override. Its project
+configuration walk stops inside the capsule and never requires read access to a
+parent workspace `.codex/config.toml`.

--- a/tiangong-auto-research/references/external-skills.md
+++ b/tiangong-auto-research/references/external-skills.md
@@ -5,7 +5,7 @@ allowed to do, which credentials it needs, and how installation is governed.
 The live machine-readable source of truth is:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
   --workspace /absolute/path/to/workspace --json
 ```
 
@@ -32,6 +32,16 @@ adopts or overwrites a drifted copy. Project-local `.agents/skills` or
 `.claude/skills` copy mode is the reproducible default. Global scope is an
 explicit operator choice.
 
+## Workflow orchestrator
+
+`tiangong.auto-research` installs the separately sourced
+`tiangong-auto-research` Skill. Its role is `orchestrator`: it routes ordinary
+research requests through context resolution, setup/status/doctor, preflight,
+initialization, dry-run, execution, review, and closure. It is not an evidence
+source and receives no provider credential. The Wizard recommends a
+project-local copy but asks for explicit confirmation; automation selects it
+with `--skills tiangong.auto-research`.
+
 ## Evidence capabilities
 
 These Skills can contribute candidate evidence only through the locked HTTP
@@ -44,12 +54,23 @@ broker during discovery:
 | `brave.images-search`, `brave.videos-search` | same | Conditional visual/audiovisual discovery only when material to the question. | same Brave key |
 | `tiangong.kb-sci-search` | `tiangong-ai/skills` | Optional owner-whitelisted academic database. It supplements, but never satisfies, the production public-internet gate. | `tiangong.sci.api-key` from `TIANGONG_SCI_APIKEY` or another explicitly named owner variable |
 
-Brave capabilities use their manifest-declared GET endpoints. Tiangong SCI uses
-the exact declared JSON POST endpoint, `x-region`, and `x-api-key` credential
-injection. The discovery agent supplies only non-secret `request_body` fields;
-the broker rejects credential-like fields, persists only the request-body hash,
-refuses POST redirects, bounds the response, and promotes the exact response to
-the permanent evidence store.
+The staged manifest exposes each locked, non-secret, exact endpoint so the
+discovery agent never has to guess a path. Brave capabilities use their declared
+GET endpoints. Tiangong SCI uses the exact declared JSON POST endpoint,
+`x-region`, and `x-api-key` credential injection. The discovery agent supplies
+only non-secret `request_body` fields; the broker rejects credential-like fields,
+persists only the request-body hash, refuses POST redirects, enforces the endpoint
+scope for the initial request and every redirect, bounds both response size and
+the package's broker-call count, and promotes the exact response to the permanent
+evidence store. A brokered declaration without an explicit endpoint is invalid;
+setup does not migrate an older declaration implicitly.
+
+For a short `429`, the broker performs at most one inline retry. It uses
+`Retry-After` when present, defaults to one second when absent, and retries
+inline only when that delay is at most five seconds. Longer throttles are
+returned as actionable failures rather than holding the agent call open. The
+journal records only sanitized response metadata and a safe request ID; it
+never records the raw target or credentials.
 
 Do not run a staged Skill's shell/curl examples inside a research capsule. Agent
 processes never receive provider credentials. Authentication, authorization,
@@ -127,6 +148,14 @@ Brave endpoint does not prove that LLM Context, image, or video access is
 included in the provider plan. The Unstructure live check uploads a generated
 one-page PDF only with its separate confirmation. Agent smoke is separately
 cost-confirmed.
+
+Capability doctor retains only a bounded sanitized provider code/detail and a
+safe request ID. `OPTION_NOT_IN_PLAN` is an operator decision: either create a
+reviewed replacement using the Brave web/news baseline or enable the provider
+subscription. It never triggers an automatic profile switch. Replacement
+removes deselected setup-managed declarations and stale logical credential
+entries, preserves custom capabilities, and leaves all installed Skill
+directories untouched.
 
 ## Custom owner-whitelisted databases
 

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -6,6 +6,13 @@ reference and runtime output differ.
 
 ## Production admission checklist
 
+Start from the user-selected workspace's current immutable setup generation.
+Run `research setup status`, then one explicitly cost-confirmed
+`research setup doctor --live --agent-smoke --confirm-agent-smoke-cost` before
+project preflight. That command performs the nested capability and agent capsule
+smokes; do not repeat paid smokes without a reason. Any requested smoke failure
+must leave setup `BLOCKED`.
+
 Before `project init`, record and show the user:
 
 1. The research question and evidence dimensions.
@@ -35,7 +42,16 @@ reported version, actual/configured model, OS, and architecture.
 `workspace doctor --agent-smoke` executes both routes in real capsules and
 writes a 24-hour attestation bound to those runtime fingerprints, workspace
 config, capability lock, and doctor schema. Expiry or drift blocks execution
-before the next agent invocation.
+before the next agent invocation. During that validity window, plain
+`workspace doctor` rechecks all bound hashes and fingerprints the currently
+resolved producer/reviewer runtimes before reusing the attested agent and
+capability smoke results. Use explicit smoke flags to refresh the checks;
+missing, expired, or drifted attestations never receive an implicit pass.
+
+Within one package, a formatting repair may reuse the capsule-local agent auth
+copy only when it remains a regular owner-only file whose SHA-256 matches the
+owner source. Authentication drift stops the package; setup/runtime never
+overwrite the capsule copy or silently choose another credential.
 
 The budget includes:
 
@@ -43,13 +59,14 @@ The budget includes:
 - a token reservation for every agent stage;
 - maximum structured-output and repair tokens;
 - output file count/bytes and attempts;
-- broker response bytes, context items, and estimated context tokens;
+- broker calls, response bytes, context items, and estimated context tokens;
 - the cost-confirmation threshold.
 
-New workspaces default to 500,000 total tokens, with 200,000 reserved as the
-discovery package ceiling; analyze, synthesize, and review default to 55,000,
-60,000, and 120,000. These values are admission ceilings, not a target spend.
-Lower them only when preflight proves every complete reservation still fits.
+New workspaces default to 550,000 total tokens, with 230,000 reserved as the
+discovery package ceiling; analyze, synthesize, and review default to 60,000,
+70,000, and 175,000. Primary output is bounded at 6,000 tokens and repair at
+4,000. These values are admission ceilings, not a target spend. Lower them only
+when preflight proves every complete reservation still fits.
 
 The CLI will not start a package unless its full token and conservative price
 reservation fits. Immediately before each call it accounts for prompt and
@@ -57,9 +74,10 @@ schema bytes at three bytes per token, agent-specific protocol overhead,
 input repeated for every permitted API turn, the maximum bounded broker context
 for every permitted discovery turn, primary output, and a possible isolated
 repair's input and output. The provider cost cap is derived from that package
-reservation, not the project's remaining global allowance. Tool-free
-primary stages allow two protocol turns because Claude's schema output uses
-`StructuredOutput` followed by its result; external tools remain disabled. The
+reservation, not the project's remaining global allowance. Tool-free Codex
+primary stages reserve two protocol turns. Claude JSON Schema primary stages
+reserve and receive a three-turn provider cap, matching the current Claude Code
+structured-output exchange; external tools remain disabled. The
 repair path omits the provider schema tool, requests plain JSON in one turn,
 and still passes through the same CLI validators.
 Current Codex and Claude CLI adapters expose final output usage only after the
@@ -67,7 +85,10 @@ call. Preflight therefore reports `outputTokenLimitEnforcement` as
 `post-execution`: captured bytes bound the process, and an over-limit result is
 rejected without promotion, but the limit is not a provider-side hard stop.
 Discovery capture allowance includes bounded broker tool-result events as well
-as the requested final output.
+as the requested final output. Preflight and runtime share the reservation
+calculator, including the complete bounded capability-documentation allowance.
+The broker separately enforces at most six provider fetch calls per discovery
+run and returns the remaining call budget after each success.
 Reserve enough output for the discover schema and enough input context for the
 embedded prior-stage artifacts; preflight reports both gaps mechanically.
 It also reports per-stage `maxTurns` and route-specific
@@ -116,9 +137,9 @@ registered for review; it does not expose that entire file to discovery.
 Inspect, but never copy or fork, a current contract with:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research schema show discover --json
-npx --yes @tiangong-ai/cli@0.0.26 research schema show analyze --json
-npx --yes @tiangong-ai/cli@0.0.26 research schema show review --json
+npx --yes @tiangong-ai/cli@0.0.28 research schema show discover --json
+npx --yes @tiangong-ai/cli@0.0.28 research schema show analyze --json
+npx --yes @tiangong-ai/cli@0.0.28 research schema show review --json
 ```
 
 Evidence sources include stable ID/title/locator/provenance, URL or DOI when
@@ -145,6 +166,7 @@ A `brokered-network` capability has exact hosts plus an HTTP policy:
   "permissions": ["project-read", "candidate-write", "brokered-network"],
   "allowedHosts": ["api.example.org"],
   "http": {
+    "endpoint": "https://api.example.org/v1/search",
     "method": "GET",
     "accept": "application/json",
     "allowedContentTypes": ["application/json"],
@@ -169,14 +191,16 @@ content type, hashed final URL, raw locator, bounded context locator, retrieval
 time, and cache status. Review packets enumerate and hash these permanent
 objects.
 
-The review capsule merges the registered local bounded contexts and every
-cited broker receipt's exact bounded view. That merged context and the complete
-review packet are themselves stored by content hash under the project's
-`review/contexts/` and `review/packets/` directories. The packet enumerates raw
-broker objects and full local-file hashes; the model reads only the merged
-bounded views. Mechanical closure checks that the packet, merged context,
-broker objects, and local input/context hashes still exist and match before it
-records their safe locators.
+The review capsule deterministically distributes one global context budget
+across registered local bounded contexts and every broker receipt. The
+resulting excerpt bundle and the complete review packet are themselves stored
+by content hash under the project's `review/contexts/` and `review/packets/`
+directories. The packet enumerates raw broker objects, original per-receipt
+bounded contexts, and full local-file hashes; its hash is schema-bound without
+duplicating packet metadata in the model prompt. The model reads only the
+global excerpt bundle and generated artifacts. Mechanical closure checks that
+the packet, bundle, broker objects, and local input/context hashes still exist
+and match before it records their safe locators.
 
 Use `json_pointer` and `max_items` for a bounded JSON view. The workspace's
 `maxBrokerContextTokens` limit additionally caps the staged view using a
@@ -190,17 +214,28 @@ to the persistent cache; pass `cache_mode=bypass` for a fresh request.
 Credentialed requests always require bypass to avoid replaying scoped content
 under changed authorization.
 
-The broker sends the capability's exact `Accept`, checks every redirect host,
+Capability health checks separately retain only a bounded sanitized provider
+code/detail and safe request ID. In particular, `OPTION_NOT_IN_PLAN` requires an
+explicit baseline replacement or provider subscription change; it is never an
+automatic retry or fallback signal.
+
+The locked manifest exposes the exact non-secret endpoint so discovery never
+guesses a path. The broker sends the capability's exact `Accept`, checks the
+initial target and every GET redirect against both the host and endpoint scope,
 screens credential-like response material, and rejects undeclared content
-types or oversized bodies. Non-2xx results include only status, a sanitized
-short response, safe request ID, and parsed `Retry-After`.
+types or oversized bodies. A `/` endpoint explicitly grants origin-wide paths;
+other endpoint paths are exact. Non-2xx results include only status, a
+sanitized short response, safe request ID, and parsed `Retry-After`.
+The broker performs at most one inline retry for a `429` whose declared or
+default delay is at most five seconds. A longer throttle remains a classified
+failure and does not hold the discovery call open.
 
 Capabilities may instead declare bounded JSON `POST`, an exact safe static
 header map, and a positive `maxRequestBytes`. Discovery then supplies only the
 documented non-secret `request_body`; credential-like keys are rejected, the
 credential is injected by the broker, POST redirects are refused, and the
 journal/cache metadata records only the canonical body SHA-256 rather than the
-body. GET remains the default for existing imported definitions.
+body. GET remains the default method inside an explicit HTTP endpoint policy.
 
 ## Coverage, retry, and recovery
 
@@ -212,33 +247,46 @@ admitted sources and declared minimums. `partial` is usable but incomplete;
 packages. Model-provided qualitative gaps remain visible but cannot override
 those derived fields.
 
+Every manifest capability marked `requiredForDiscovery=true` must produce a
+verified broker receipt. The gate distinguishes a capability that was never
+called from one that was called but yielded no admissible receipt; the latter
+reports only sanitized failure kinds such as `rate-limit`, never request URLs or
+credentials.
+
 Discovery receives no shell or filesystem tools. The CLI embeds the locked
 capability manifest and each staged external Skill's top-level `SKILL.md`, and
 the scoped broker is its only execution tool. Broker results include the exact
 bounded view inline with the receipt. Analyze embeds the admitted evidence
 object; synthesize embeds admitted evidence and analysis. Both stages run with
-tools disabled. Review is also tool-free and embeds the immutable packet,
-generated artifacts, and exact bounded local/broker evidence views within two
-structured-output protocol turns. Full files and raw
-objects remain hash-bound for later human/mechanical audit; never report that
-the model read beyond the embedded views. Run records, journal usage, and JSONL
-progress include sanitized event/item counts, provider turns, tool calls,
-reasoning-token counts, and bounded provider errors.
+tools disabled. Review is also tool-free and embeds generated artifacts plus
+deterministic excerpts from bounded local/broker evidence views within the
+reviewer's route-specific structured-output turn cap. Preflight and runtime reserve the same
+stage-specific ceiling: three maximum-size generated artifacts plus one
+`maxInputContextTokens` excerpt bundle. The complete packet, full files,
+original bounded contexts, and raw objects remain hash-bound for later
+human/mechanical audit; never report that the model read beyond the embedded
+excerpts. Run records, journal usage, and JSONL progress include sanitized
+event/item counts, provider turns, tool calls, reasoning-token counts, and
+bounded provider errors.
 
 Failures are classified:
 
 - configuration/authentication/deterministic 4xx, coverage, and review failures
   stop immediately;
-- structured-output failures use only the repair path;
-- 429 may retry after its recorded delay;
+- structured-output failures use only the repair path; synthesis mechanically
+  converts literal `/n` or double-escaped `\\n` immediately before Markdown
+  block structures into line feeds, records a content-free normalization event,
+  and leaves URLs or unmatched text unchanged before independent review;
+- a short 429 receives at most one broker-level bounded-delay retry; a remaining
+  429 may schedule package recovery after its recorded delay;
 - bounded transient/5xx failures may retry while attempts and budget remain.
 
 Use an explicit management command instead of editing state:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research project retry PROJECT \
+npx --yes @tiangong-ai/cli@0.0.28 research project retry PROJECT \
   --package PACKAGE --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.26 research project fork SOURCE \
+npx --yes @tiangong-ai/cli@0.0.28 research project fork SOURCE \
   --to TARGET --resume-through analyze \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -251,7 +299,7 @@ and closure always run again.
 Run one recovered or canary project with an explicit scope:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research run \
+npx --yes @tiangong-ai/cli@0.0.28 research run \
   --project PROJECT --workspace /absolute/path/to/workspace \
   --progress-jsonl --json
 ```

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -6,7 +6,8 @@ to inspect, resume, update, or replace an existing setup generation.
 ## Safety model
 
 Setup is a separate owner operation, not part of a research package. No
-recommended Skill is bundled with the CLI or installed implicitly. The CLI:
+recommended Skill is bundled with the CLI or installed without an explicit
+Wizard confirmation or plan selection. The CLI:
 
 1. shows the complete recommendation catalog without writing files;
 2. records exact source commits, Skill tree hashes, installer version and npm
@@ -26,6 +27,9 @@ Skill destination symlink, and never performs a floating update.
 
 ## Clean-directory Wizard
 
+The workspace may be any ordinary user-selected directory. Example paths below
+are placeholders, not defaults or repository requirements.
+
 Prerequisites are Node.js 24, `git`, `npx`, an agent-compatible sandbox
 (`/usr/bin/sandbox-exec` on macOS or `bwrap` on Linux), and normal Codex/Claude
 CLI authentication for the routes you intend to use. Create or choose the
@@ -44,8 +48,8 @@ export UNSTRUCTURED_AUTH_TOKEN='owner Unstructure bearer token'
 # Optional; academic-paper-download can use Semantic Scholar anonymously.
 export SEMANTIC_SCHOLAR_API_KEY='optional Semantic Scholar key'
 
-npx --yes @tiangong-ai/cli@0.0.26 --version
-npx --yes @tiangong-ai/cli@0.0.26 research setup \
+npx --yes @tiangong-ai/cli@0.0.28 --version
+npx --yes @tiangong-ai/cli@0.0.28 research setup \
   --workspace /absolute/path/to/research-workspace
 ```
 
@@ -54,7 +58,10 @@ It displays only whether the named variable is present. It then guides the
 user through:
 
 - smoke-test versus production mode;
-- public-internet profile;
+- a Brave web/news public-internet baseline by default; bounded context and
+  media profiles are visibly marked subscription-dependent;
+- explicit project-local installation of the `tiangong-auto-research`
+  orchestrator (recommended) so normal research requests enter this workflow;
 - optional Tiangong companions and post-closure authoring Skills; for PPT
   creation it presents PPT Master as preferred while keeping Anthropic PPTX as
   a compatible situational choice;
@@ -77,7 +84,7 @@ recreate the plan merely to bypass preflight.
 The catalog command never creates workspace files:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup catalog \
+npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
   --workspace /absolute/path/to/research-workspace \
   --scope project --agents codex --json
 ```
@@ -95,16 +102,17 @@ environment variable names, not values:
 Create and review a minimal production plan, then apply its exact path:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup plan \
+npx --yes @tiangong-ai/cli@0.0.28 research setup plan \
   --workspace /absolute/path/to/research-workspace \
   --mode production-research \
-  --evidence-profile brave-context \
+  --evidence-profile brave-baseline \
+  --skills tiangong.auto-research \
   --agents codex --scope project \
   --credential-env /absolute/path/to/credential-env.json \
-  --accept-license brave-search-skills:MIT \
+  --accept-license brave-search-skills:MIT,tiangong-ai-skills:MIT \
   --confirm-network-downloads --json
 
-npx --yes @tiangong-ai/cli@0.0.26 research setup apply \
+npx --yes @tiangong-ai/cli@0.0.28 research setup apply \
   --plan /absolute/path/to/research-workspace/.tiangong-research/setup-plan.json \
   --json
 ```
@@ -116,9 +124,9 @@ document; the CLI catalog is authoritative.
 ## Status, doctor, and recovery
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup status \
+npx --yes @tiangong-ai/cli@0.0.28 research setup status \
   --workspace /absolute/path/to/research-workspace --json
-npx --yes @tiangong-ai/cli@0.0.26 research setup doctor \
+npx --yes @tiangong-ai/cli@0.0.28 research setup doctor \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -126,35 +134,42 @@ Static doctor checks installed tree hashes, required settings, owner-only
 credential stores, Node/git/npx, sandbox, agent CLIs, Python, and pinned Python
 requirements. `--live` uses provider network/quota. A synthetic document upload
 also requires `--allow-synthetic-unstructure-upload`; model-agent smoke requires
-`--agent-smoke --confirm-agent-smoke-cost`.
+`--agent-smoke --confirm-agent-smoke-cost`. When one of those explicitly
+requested smoke checks fails, readiness is `BLOCKED`; it is never downgraded to
+an advisory warning. After both production smokes succeed, ordinary workspace
+doctor calls may reuse the unexpired hash-bound attestation only after checking
+the current agent runtime fingerprints. Explicit smoke flags refresh the
+attestation; expiry or drift remains blocking.
 
 On a blocked apply, use the exact `retryCommand` in setup state. Clear a stale
 lock only with both stale-lock flags after confirming no setup process owns it.
 Do not delete plan/state/source-cache directories or overwrite installed trees.
 
-### Replace an affected CLI 0.0.25 plan
+### Replace the current immutable selection
 
-CLI `0.0.25` recorded Brave Skill paths without the upstream `skills/`
-directory, so a plan created by that release can report every selected Brave
-Skill as `missing`. Do not edit the hash-bound plan or keep retrying it. Upgrade
-to `0.0.26`, run the Wizard again, and choose its explicit replacement action:
+Do not edit a hash-bound plan. To change an evidence profile, companion, or
+orchestrator selection, run the exact CLI again and choose its explicit
+replacement action:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup \
+npx --yes @tiangong-ai/cli@0.0.28 research setup \
   --workspace /absolute/path/to/research-workspace
 ```
 
-For automation, rerun the same reviewed `research setup plan` inputs with
-`--replace-plan`. The CLI archives the previous generation and creates a new
-plan whose pinned Brave paths are `skills/web-search`, `skills/news-search`,
-`skills/llm-context`, `skills/images-search`, and `skills/videos-search`.
+For automation, rerun the reviewed `research setup plan` inputs with
+`--replace-plan`. Replacement reconciles the complete setup-managed capability
+set and both credential stores: deselected Brave/Sci declarations and lock
+records are removed, custom capability declarations are preserved, and no
+installed Skill directory is deleted. A provider `OPTION_NOT_IN_PLAN` result
+must lead to an explicit operator choice between a baseline replacement and a
+subscription change; setup never switches profiles silently.
 
 ## Update without version drift
 
 `update --check` is read-only. The currently installed generation stays pinned:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup update --check \
+npx --yes @tiangong-ai/cli@0.0.28 research setup update --check \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -162,7 +177,7 @@ An upgrade is a new immutable plan, never an in-place floating update. Review
 new licenses and pins, then apply the newly generated plan:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup upgrade \
+npx --yes @tiangong-ai/cli@0.0.28 research setup upgrade \
   --plan --confirm-upgrade \
   --accept-license <every-selected-current-license-id> \
   --workspace /absolute/path/to/research-workspace --json
@@ -178,7 +193,7 @@ environment and verified Skill tree. Document output uses a unique temporary
 file and a no-overwrite atomic commit:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.26 research setup companion run \
+npx --yes @tiangong-ai/cli@0.0.28 research setup companion run \
   --id tiangong.document-granular-decompose \
   --input /absolute/path/to/source.pdf \
   --output /absolute/path/to/source.fulltext.md \
@@ -190,7 +205,7 @@ chooses the newest PDF in a directory:
 
 ```bash
 mkdir -p /absolute/path/to/papers
-npx --yes @tiangong-ai/cli@0.0.26 research setup companion run \
+npx --yes @tiangong-ai/cli@0.0.28 research setup companion run \
   --id tiangong.academic-paper-download \
   --doi 10.1234/example --out /absolute/path/to/papers \
   --workspace /absolute/path/to/research-workspace --json


### PR DESCRIPTION
Closes tiangong-ai/skills#53

## Summary
- document clean-directory setup for the external Auto Research orchestrator and recommended internet, database, document, and presentation Skills
- align production admission, evidence coverage, budget, retry, review, recovery, and doctor behavior with CLI 0.0.28
- clarify explicit credential and Skill selection without making optional third-party Skills part of this repository

## Key Decisions
- workspaces are user-selected paths; the repository sandbox is only a test fixture and never a default
- all recommended capability Skills remain external and explicitly installed
- hugohe3/ppt-master is preferred for presentation work without making Anthropic pptx mutually exclusive
- no compatibility path is documented for a missing current setup plan

## Validation
- skill-creator quick_validate.py tiangong-auto-research: passed
- docpact 0.1.9 strict validation and worktree lint: passed
- git diff --check: passed
- CLI production canary and provider smoke results recorded in the matching CLI PR

## Risks / Rollback
- documentation requires CLI 0.0.28 behavior; revert this PR together with the root pin if the CLI release is rolled back

## Follow-ups
- none required for this scope

## Workspace Integration
- required: pin this merged commit alongside the CLI 0.0.28 commit in tiangong-ai/workspace