### PR TITLE
docs(research): document guided credential setup

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "a300a49803c193b686e7cde55b5f2d170f993af5"
+lastReviewedCommit: "cb50e5c352fee5349e29a9d08b81a7bc05644452"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # Tiangong AI Skills
@@ -89,8 +89,10 @@ an external service, read that skill's `references/env.md` when present.
 Use `npx skills` directly for ordinary Skill management. For an Auto Research
 workspace, prefer the CLI's guarded setup layer: it still uses the exact pinned
 `skills` CLI underneath, while also binding source commits, tree hashes,
-destinations, license choices, credential names, and audit state. Start with the
-read-only catalog or the guided Wizard:
+destinations, license choices, safe credential bindings, and audit state. The
+Wizard lets ordinary users enter each selected key with hidden TTY input; named
+environment variables and bounded stdin/password-manager input remain explicit
+alternatives. Start with the read-only catalog or the guided Wizard:
 
 ```bash
 npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: 3dbc264d97573060b5c2e5fa08a4ab8242db87dc
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # 天工 AI Skills
@@ -87,8 +87,9 @@ skill 的 `references/env.md`（如存在）。
 
 普通 Skill 管理可以直接使用 `npx skills`。Auto Research workspace 应优先使用
 CLI 的防呆 setup 层：底层仍调用精确锁定的 `skills` CLI，同时额外绑定来源
-commit、Skill tree hash、目标目录、许可证选择、凭据名称和审计状态。先查看只读
-目录，或启动交互式 Wizard：
+commit、Skill tree hash、目标目录、许可证选择、安全凭据绑定和审计状态。普通用户
+可在 Wizard 中隐藏输入每个已选 Key；命名环境变量和有界 stdin/密码管理器输入仍是
+显式可选方式。先查看只读目录，或启动交互式 Wizard：
 
 ```bash
 npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: a300a49803c193b686e7cde55b5f2d170f993af5
+lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -62,10 +62,13 @@ npx --yes @tiangong-ai/cli@0.0.28 research setup \
 The user must explicitly confirm the recommended project-local
 `tiangong-auto-research` orchestrator and every external source, then accept its
 pinned license. The Wizard defaults evidence to Brave web/news; context and
-media remain visibly subscription-dependent choices. It may create a plan
-without applying it. Never silently install a Skill, write globally, substitute
-a provider, downgrade a profile, or accept a license. Missing required
-credentials must block before any source download.
+media remain visibly subscription-dependent choices. For each selected
+credential it offers hidden input, an owner environment variable, preloaded
+stdin/password-manager input, or an explicit skip; read
+[references/env.md](references/env.md) for the exact safe paths. It may create a
+plan without applying it. Never silently install a Skill, write globally,
+substitute a provider, downgrade a profile, or accept a license. Missing
+required credentials must block before any source download.
 
 ## Preserve execution boundaries
 

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -20,10 +20,17 @@ Production doctor must run real agent and capability smokes before a costly
 package. These checks may use quota and therefore require explicit flags and
 cost confirmation.
 
-## Setup credential variables
+## Setup credential input
 
-The Wizard asks for an environment variable *name*, never a secret value. The
-recommended defaults are:
+For every selected logical credential, the Wizard offers hidden TTY input
+(recommended), a named environment variable, preloaded stdin/password-manager
+input, or an explicit skip. Hidden input is not echoed. Stdin is bounded and
+must contain exactly one line per logical ID listed with
+`--credential-stdin <id[,id...]>`. Neither path writes a value to the command
+line, setup plan, stdout, stderr, journal, report, or shell history.
+
+Environment-variable mode remains available for developers and CI. Recommended
+default names are:
 
 | Variable | Logical ID | Requirement |
 | --- | --- | --- |
@@ -33,8 +40,7 @@ recommended defaults are:
 | `SEMANTIC_SCHOLAR_API_KEY` | `semantic-scholar.api-key` | Optional for academic paper acquisition. |
 
 The variable name can differ, but it must be explicitly bound in the immutable
-plan. Values must be non-trivial and remain in the owner process environment
-only until setup stores them. After a successful apply, later
+plan. Values must be non-trivial. After a successful apply, later
 status/doctor/run commands use the owner-only logical stores and do not require
 those source shell variables to remain exported. Do not put values in setup
 JSON files, CLI arguments, shell history, Skill files, capability declarations,
@@ -49,9 +55,21 @@ An explicitly reviewed replacement reconciles both stores to the new selection,
 so deselected logical entries do not invalidate the new configuration; values
 are never printed during reconciliation.
 
-Use the supported command to rotate one selected credential:
+Use exactly one supported source to rotate a selected credential:
 
 ```bash
+## Ordinary interactive use (hidden input)
+npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
+  --id brave.search.api-key --prompt \
+  --workspace /absolute/path/to/workspace --json
+
+## Password manager or CI stdin
+op read 'op://Research/Brave/api-key' | \
+  npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
+    --id brave.search.api-key --from-stdin \
+    --workspace /absolute/path/to/workspace --json
+
+## Existing owner environment
 export OWNER_NEW_BRAVE_KEY='new owner value'
 npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
   --id brave.search.api-key --from-env OWNER_NEW_BRAVE_KEY \
@@ -59,7 +77,8 @@ npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
 ```
 
 The value is never echoed. Journal events record only the logical ID, storage
-class, and a hash of the environment variable name.
+class, safe input method, and—only for environment mode—a hash of the variable
+name.
 
 ## Non-secret settings
 

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -11,9 +11,10 @@ Wizard confirmation or plan selection. The CLI:
 
 1. shows the complete recommendation catalog without writing files;
 2. records exact source commits, Skill tree hashes, installer version and npm
-   integrity, destinations, settings, credential environment names, licenses,
-   checks, and mutations in an immutable plan;
-3. checks required credentials before it downloads an installer or source;
+   integrity, destinations, settings, safe credential bindings, licenses,
+   checks, and mutations in an immutable plan; secret values never enter it;
+3. checks and persists supplied credentials to an owner-only store before it
+   downloads an installer or source;
 4. copies only the selected pinned trees, verifies the installed bytes, and
    configures their declared execution role;
 5. stores broker and adapter credentials in separate owner-only stores without
@@ -33,29 +34,49 @@ are placeholders, not defaults or repository requirements.
 Prerequisites are Node.js 24, `git`, `npx`, an agent-compatible sandbox
 (`/usr/bin/sandbox-exec` on macOS or `bwrap` on Linux), and normal Codex/Claude
 CLI authentication for the routes you intend to use. Create or choose the
-directory, export only the credentials for sources you may select, and start
-the Wizard:
+directory and start the Wizard; ordinary users do not need to export keys:
 
 ```bash
 mkdir -p /absolute/path/to/research-workspace
 cd /absolute/path/to/research-workspace
-
-# Required only when the corresponding source is selected.
-export BRAVE_API_KEY='owner Brave Search key'
-export TIANGONG_SCI_APIKEY='owner-authorized Tiangong SCI key'
-export UNSTRUCTURED_AUTH_TOKEN='owner Unstructure bearer token'
-
-# Optional; academic-paper-download can use Semantic Scholar anonymously.
-export SEMANTIC_SCHOLAR_API_KEY='optional Semantic Scholar key'
 
 npx --yes @tiangong-ai/cli@0.0.28 --version
 npx --yes @tiangong-ai/cli@0.0.28 research setup \
   --workspace /absolute/path/to/research-workspace
 ```
 
-Do not paste a secret when the Wizard asks for an environment variable name.
-It displays only whether the named variable is present. It then guides the
-user through:
+For every selected credential, the Wizard displays the logical ID, provider,
+and official acquisition/configuration URL, then offers:
+
+1. enter securely now (recommended for ordinary users; TTY input is hidden);
+2. read from a named owner environment variable;
+3. consume a value preloaded from stdin/password manager;
+4. skip for now.
+
+The stdin path is explicit and bounded. List logical IDs in the same order as
+their one-line values; `--yes` prevents `npx` from asking an install question on
+the secret pipe:
+
+```bash
+op read 'op://Research/Brave/api-key' | \
+  npx --yes @tiangong-ai/cli@0.0.28 research setup \
+    --credential-stdin brave.search.api-key \
+    --workspace /absolute/path/to/research-workspace
+
+{
+  op read 'op://Research/Brave/api-key'
+  op read 'op://Research/Tiangong SCI/api-key'
+} | npx --yes @tiangong-ai/cli@0.0.28 research setup \
+  --credential-stdin brave.search.api-key,tiangong.sci.api-key \
+  --workspace /absolute/path/to/research-workspace
+```
+
+The pipe is read before the remaining questions, which continue on the
+controlling terminal. A stdin value is used only if the matching option is
+chosen; unselected/preloaded logical IDs are rejected rather than ignored.
+Do not paste a value into the environment-variable-name prompt.
+
+The Wizard then guides the user through:
 
 - smoke-test versus production mode;
 - a Brave web/news public-internet baseline by default; bounded context and
@@ -67,7 +88,7 @@ user through:
   a compatible situational choice;
 - Codex/Claude install targets and project/global scope;
 - non-secret endpoints/settings;
-- credential environment names;
+- a source choice for every selected required or optional credential;
 - each pinned source/license notice and explicit acceptance;
 - optional model IDs and reviewed token prices;
 - live provider checks, a separately authorized synthetic Unstructure upload,
@@ -75,9 +96,13 @@ user through:
 - a full plan preview, network confirmation, immutable plan creation, and
   optional apply.
 
-If a required key is absent, the plan may be saved but apply stops before any
-network download. Set the named variable and resume the exact plan; do not
-recreate the plan merely to bypass preflight.
+Apply defaults to yes after all required values are available. Secure/stdin
+values live only for that apply, are persisted to the existing owner-only store
+before downloads, and are then discarded from Wizard memory. If the user saves
+only the plan, those transient values are discarded and the result supplies
+safe `credential set --prompt` recovery commands. If a required key is skipped,
+apply stops before any network download. Configure the logical ID and resume
+the exact plan; do not recreate the plan merely to bypass preflight.
 
 ## Read-only inspection and automation
 


### PR DESCRIPTION
Closes tiangong-ai/skills#55

## Summary
- document the four setup credential sources and make hidden entry the ordinary-user default
- document bounded stdin/password-manager automation, environment-variable compatibility, skip/recovery behavior, and owner-only storage
- keep SKILL.md concise while routing detailed behavior to setup and environment references

## Key Decisions
- external provider Skills remain separately selected and licensed
- examples never contain real credentials or encourage command-line secret arguments
- no Skill trigger semantics or generated agent metadata changed

## Validation
- skill-creator quick_validate.py tiangong-auto-research: passed
- docpact 0.1.9 validate-config --strict and worktree lint: passed
- git diff --check: passed
- matching CLI production canary completed with environment variables unset after initial credential storage

## Risks / Rollback
- documentation depends on the matching CLI 0.0.29 implementation; revert this commit and the workspace pin together if needed

## Follow-ups
- none required for this scope

## Workspace Integration
- required after merge: pin this commit with CLI 0.0.29 in tiangong-ai/workspace#110.