### PR TITLE
Fix Auto Research routing and workspace runtime locking

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "cb50e5c352fee5349e29a9d08b81a7bc05644452"
+lastReviewedCommit: "ca8ed0942820edc590700100ab4f0e41c166fec3"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -95,11 +95,19 @@ environment variables and bounded stdin/password-manager input remain explicit
 alternatives. Start with the read-only catalog or the guided Wizard:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
+REVIEWED_BOOTSTRAP_CLI_VERSION=X.Y.Z # replace with one reviewed exact stable release
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.28 research setup \
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup \
   --workspace /absolute/path/to/workspace
 ```
+
+The bootstrap version is an explicit new-workspace choice, never `latest`, a
+tag, or a range. After apply creates `runtime-lock.json`, the installed
+orchestrator's bundled resolver runs exactly that locked version for all
+workspace operations.
 
 The catalog also offers the `tiangong-auto-research` workflow orchestrator,
 default-baseline Brave internet evidence, optional Tiangong SCI/document/paper

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,11 +92,18 @@ commit、Skill tree hash、目标目录、许可证选择、安全凭据绑定�
 显式可选方式。先查看只读目录，或启动交互式 Wizard：
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
+REVIEWED_BOOTSTRAP_CLI_VERSION=X.Y.Z # 替换为已审阅的精确稳定版本
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.28 research setup \
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup \
   --workspace /absolute/path/to/workspace
 ```
+
+bootstrap 版本是新 workspace 的显式选择，不得使用 `latest`、tag 或 range。
+apply 创建 `runtime-lock.json` 后，已安装 orchestrator 的内置 resolver 会让
+所有 workspace 操作只运行该锁定版本。
 
 目录还提供 `tiangong-auto-research` 工作流 orchestrator、默认基线 Brave
 互联网证据能力、可选的 Tiangong SCI/文档解析/论文获取 companion，以及可选的

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: tiangong-auto-research
-description: Set up or run smoke-test and production Tiangong research workspaces in any user-selected directory with an explicitly installed orchestrator and external Skill ecosystem; public-internet and owner-whitelisted broker evidence; immutable inputs and evidence; pre-call budgets; isolated producers; independent review; and mechanical closure. Use when a user asks to configure, plan, initialize, execute, recover, inspect, or close a traceable research project. Do not use for a single Tiangong edge-search request.
+description: Orchestrate open-ended, multi-source, evidence-backed research, especially when an ancestor directory contains `.tiangong-research` or the user asks to research, investigate, build on prior outputs, compare evidence, form a conclusion, or produce a reviewed research artifact. Also use for setup, preflight, execution, recovery, review, and closure. In an Auto Research workspace this Skill takes precedence over individual web, news, SCI, report, patent, download, or document Skills unless the user explicitly requests one isolated standalone operation outside the research workflow. Covers Chinese requests such as “研究一下”, “朝这个方向做一做”, “结合已有成果继续研究”, “查资料并形成结论”, and “系统梳理证据”.
 ---
 
 # Tiangong Auto Research
 
-Use the exact CLI release for all workspace operations:
+For an existing workspace, use the bundled resolver for every CLI operation.
+Resolve `AUTO_RESEARCH_CLI` from this loaded Skill's absolute directory; do not
+guess a global Skill path. The resolver accepts only the CLI package and exact
+stable version from the workspace's regular non-symlink runtime lock:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research --help
+AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/research_cli.mjs
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research --help
 ```
+
+For a clean directory without a runtime lock, read
+[references/setup.md](references/setup.md) and ask the user to choose one
+reviewed exact bootstrap CLI version. Never substitute `latest`, a range, a
+tag, a path, or a command fragment. After setup creates the runtime lock, use
+the resolver above.
 
 The CLI owns the setup catalog, immutable setup plan, capability policy, output
 schemas, coverage gates, budgets, retries, evidence promotion, review, and
@@ -42,7 +52,8 @@ placeholders, never defaults. Resolve paths to absolute paths, then inspect the
 directory:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research context inspect \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research context inspect \
   --path /absolute/path/to/workspace --json
 ```
 
@@ -53,9 +64,11 @@ For a clean directory, show the read-only ecosystem catalog and run the guided
 setup only after the user asks to configure it:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research setup catalog \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.28 research setup \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research setup \
   --workspace /absolute/path/to/workspace --json
 ```
 
@@ -72,10 +85,11 @@ required credentials must block before any source download.
 
 ## Preserve execution boundaries
 
-- Brave and Tiangong SCI are `evidence-capability` Skills. Discovery calls them
-  only through the scoped broker and the locked manifest method. Never execute
-  their shell examples from an agent capsule or expose their credentials to an
-  agent.
+- Brave and owner-whitelisted SCI/report/patent sources are
+  `evidence-capability` Skills only after their exact capabilities are locked.
+  Discovery calls them only through the scoped broker and locked manifest
+  method. Never execute their standalone shell examples from a research
+  workflow or expose broker credentials to an agent.
 - `document-granular-decompose` is an `input-preprocessor`. Run it explicitly
   through `research setup companion run`, then admit the exact hash-bound output
   as a project input. Its output is not evidence merely because parsing worked.
@@ -91,19 +105,24 @@ required credentials must block before any source download.
 
 ## Preflight and initialize a project
 
-Prepare evidence requirements with `dimensions`, `sourceTypes`, `minSources`,
-`minFullTextSources`, `minDatedSources`, and nullable date bounds. For large
-local sources, create an immutable input plan with bounded context files or
-ranges.
+Prepare evidence requirements with `dimensions`, `sourceTypes`,
+`requiredCapabilityIds`, `requiredDiscoveryScopes`, `minSources`,
+`minFullTextSources`, `minDatedSources`, and nullable date bounds. Require each
+owner database that the question must actually exercise; Brave or local files
+cannot mask an undeclared report, patent, or other whitelisted capability. For
+large local sources, create an immutable input plan with bounded context files
+or ranges.
 
 First require the current setup generation and its real production checks to
 pass. One setup doctor invocation performs the nested workspace/capability and
 agent capsule smokes, so do not repeat paid smokes unnecessarily:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup status \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research setup status \
   --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.28 research setup doctor \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research setup doctor \
   --workspace /absolute/path/to/workspace --live \
   --agent-smoke --confirm-agent-smoke-cost --json
 ```
@@ -112,13 +131,15 @@ Stop unless readiness is `READY`. An explicitly requested smoke failure is
 `BLOCKED`, not advisory.
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research project preflight \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project preflight \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json --json
 
-npx --yes @tiangong-ai/cli@0.0.28 research project init PROJECT \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project init PROJECT \
   --workspace /absolute/path/to/workspace \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
@@ -138,16 +159,21 @@ attestations. After successful preflight and initialization, use dry-run before
 the paid run:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research run \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research run \
   --workspace /absolute/path/to/workspace --project PROJECT --dry-run --json
-npx --yes @tiangong-ai/cli@0.0.28 research run \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research run \
   --workspace /absolute/path/to/workspace --project PROJECT \
   --max-cycles 20 --progress-jsonl --json
 ```
 
 Proceed only when doctor reports ready. Discovery uses only locked broker
-capabilities; later stages are tool-free. An evidence-coverage failure must stop
-analysis and synthesis rather than spend more budget.
+capabilities; later stages are tool-free. Doctor, preflight, dependency,
+provider, and evidence-coverage failures must stop the workflow. Never silently
+downgrade a systematic task to a standalone SCI, report, patent, web, or paper
+operation; only the user may explicitly narrow the request to one isolated
+standalone operation.
 
 Inspect state with `research status`. Use `research project retry` or
 `research project fork` only with explicit user direction; do not reset or

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Set up and run auditable internet research"
-  default_prompt: "Use $tiangong-auto-research to set up or run a traceable research workspace in my selected directory, verify external evidence coverage and budget, and stop on any unmet production gate."
+  short_description: "Orchestrate reviewed multi-source research"
+  default_prompt: "Use $tiangong-auto-research for this open-ended or multi-source research task, resolve the exact CLI from the workspace runtime lock, verify required capabilities and budget, and stop on every unmet production gate."

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -2,8 +2,10 @@
 
 ## Base prerequisites
 
-- Node.js 24, `git`, and `npx` access to
-  `@tiangong-ai/cli@0.0.28` and the exact setup-pinned `skills@1.5.22` package.
+- Node.js 24, `git`, and `npx` access to the exact CLI package version in the
+  workspace runtime lock and the setup-pinned `skills@1.5.22` package. A clean
+  directory needs one user-reviewed exact bootstrap CLI version before that
+  lock exists; never infer `latest` for an existing workspace.
 - Authenticated `codex` and `claude` executables for the configured producer and
   reviewer routes.
 - macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`).
@@ -58,20 +60,25 @@ are never printed during reconciliation.
 Use exactly one supported source to rotate a selected credential:
 
 ```bash
+AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/research_cli.mjs
+
 ## Ordinary interactive use (hidden input)
-npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research setup credential set \
   --id brave.search.api-key --prompt \
   --workspace /absolute/path/to/workspace --json
 
 ## Password manager or CI stdin
 op read 'op://Research/Brave/api-key' | \
-  npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
+  node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+    research setup credential set \
     --id brave.search.api-key --from-stdin \
     --workspace /absolute/path/to/workspace --json
 
 ## Existing owner environment
 export OWNER_NEW_BRAVE_KEY='new owner value'
-npx --yes @tiangong-ai/cli@0.0.28 research setup credential set \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research setup credential set \
   --id brave.search.api-key --from-env OWNER_NEW_BRAVE_KEY \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -115,9 +122,13 @@ wrapper uses the existing Tiangong CLI variables
 owner-only file and only documented Tiangong endpoint/key/region/timeout names
 are loaded. Credentials are forbidden in wrapper JSON and request files.
 
-Inside Auto Research, never run that wrapper. Setup maps the owner variable to
-logical ID `tiangong.sci.api-key`; discovery sends a non-secret POST
-`request_body` to the broker, which injects `x-api-key` for the exact host.
+Inside Auto Research, never run that wrapper. The wrapper detects an ancestor
+runtime lock and returns `AUTO_RESEARCH_BROKER_REQUIRED` before credentials or
+network unless the user explicitly narrowed the task and supplied
+`"execution_mode":"standalone"`. That explicit mode emits only a non-secret
+audit event and still cannot read the broker store. Setup maps the owner
+variable to logical ID `tiangong.sci.api-key`; discovery sends a non-secret
+POST `request_body` to the broker, which injects `x-api-key` for the exact host.
 
 ## Agent wrappers and capsule authentication
 

--- a/tiangong-auto-research/references/external-skills.md
+++ b/tiangong-auto-research/references/external-skills.md
@@ -5,7 +5,9 @@ allowed to do, which credentials it needs, and how installation is governed.
 The live machine-readable source of truth is:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
+AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/research_cli.mjs
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research setup catalog \
   --workspace /absolute/path/to/workspace --json
 ```
 

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -4,6 +4,12 @@ Load this reference for production initialization, a resumed/blocked project,
 broker configuration, or recovery. The CLI remains authoritative when this
 reference and runtime output differ.
 
+Resolve every command through the existing workspace lock:
+
+```bash
+AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/research_cli.mjs
+```
+
 ## Production admission checklist
 
 Start from the user-selected workspace's current immutable setup generation.
@@ -16,7 +22,8 @@ must leave setup `BLOCKED`.
 Before `project init`, record and show the user:
 
 1. The research question and evidence dimensions.
-2. Required source types, minimum sources, minimum full-text sources, and any
+2. Required source types, exact capability IDs and discovery scopes that must
+   be exercised, minimum sources, minimum full-text sources, and any
    date/applicability boundaries.
 3. Available immutable inputs and locked capabilities that can satisfy each
    requirement, including the selected external internet profile and every
@@ -137,9 +144,12 @@ registered for review; it does not expose that entire file to discovery.
 Inspect, but never copy or fork, a current contract with:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research schema show discover --json
-npx --yes @tiangong-ai/cli@0.0.28 research schema show analyze --json
-npx --yes @tiangong-ai/cli@0.0.28 research schema show review --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show discover --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show analyze --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show review --json
 ```
 
 Evidence sources include stable ID/title/locator/provenance, URL or DOI when
@@ -284,9 +294,11 @@ Failures are classified:
 Use an explicit management command instead of editing state:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research project retry PROJECT \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project retry PROJECT \
   --package PACKAGE --workspace /absolute/path/to/workspace --json
-npx --yes @tiangong-ai/cli@0.0.28 research project fork SOURCE \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project fork SOURCE \
   --to TARGET --resume-through analyze \
   --workspace /absolute/path/to/workspace --json
 ```
@@ -299,7 +311,8 @@ and closure always run again.
 Run one recovered or canary project with an explicit scope:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research run \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research run \
   --project PROJECT --workspace /absolute/path/to/workspace \
   --progress-jsonl --json
 ```

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -34,14 +34,19 @@ are placeholders, not defaults or repository requirements.
 Prerequisites are Node.js 24, `git`, `npx`, an agent-compatible sandbox
 (`/usr/bin/sandbox-exec` on macOS or `bwrap` on Linux), and normal Codex/Claude
 CLI authentication for the routes you intend to use. Create or choose the
-directory and start the Wizard; ordinary users do not need to export keys:
+directory, review one exact stable CLI release, replace `X.Y.Z` below, and
+start the Wizard; ordinary users do not need to export keys. `latest`, tags,
+ranges, paths, and command fragments are not bootstrap versions:
 
 ```bash
 mkdir -p /absolute/path/to/research-workspace
 cd /absolute/path/to/research-workspace
 
-npx --yes @tiangong-ai/cli@0.0.28 --version
-npx --yes @tiangong-ai/cli@0.0.28 research setup \
+REVIEWED_BOOTSTRAP_CLI_VERSION=X.Y.Z
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai --version
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup \
   --workspace /absolute/path/to/research-workspace
 ```
 
@@ -59,14 +64,16 @@ the secret pipe:
 
 ```bash
 op read 'op://Research/Brave/api-key' | \
-  npx --yes @tiangong-ai/cli@0.0.28 research setup \
+  npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+    tiangong-ai research setup \
     --credential-stdin brave.search.api-key \
     --workspace /absolute/path/to/research-workspace
 
 {
   op read 'op://Research/Brave/api-key'
   op read 'op://Research/Tiangong SCI/api-key'
-} | npx --yes @tiangong-ai/cli@0.0.28 research setup \
+} | npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup \
   --credential-stdin brave.search.api-key,tiangong.sci.api-key \
   --workspace /absolute/path/to/research-workspace
 ```
@@ -109,7 +116,8 @@ the exact plan; do not recreate the plan merely to bypass preflight.
 The catalog command never creates workspace files:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup catalog \
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup catalog \
   --workspace /absolute/path/to/research-workspace \
   --scope project --agents codex --json
 ```
@@ -127,7 +135,8 @@ environment variable names, not values:
 Create and review a minimal production plan, then apply its exact path:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup plan \
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup plan \
   --workspace /absolute/path/to/research-workspace \
   --mode production-research \
   --evidence-profile brave-baseline \
@@ -137,7 +146,8 @@ npx --yes @tiangong-ai/cli@0.0.28 research setup plan \
   --accept-license brave-search-skills:MIT,tiangong-ai-skills:MIT \
   --confirm-network-downloads --json
 
-npx --yes @tiangong-ai/cli@0.0.28 research setup apply \
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup apply \
   --plan /absolute/path/to/research-workspace/.tiangong-research/setup-plan.json \
   --json
 ```
@@ -148,10 +158,17 @@ document; the CLI catalog is authoritative.
 
 ## Status, doctor, and recovery
 
+After apply creates the runtime lock, resolve every command through the bundled
+Skill helper. Set `AUTO_RESEARCH_CLI` to the absolute path of this installed
+Skill, not a guessed global location:
+
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup status \
+AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/research_cli.mjs
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
+  research setup status \
   --workspace /absolute/path/to/research-workspace --json
-npx --yes @tiangong-ai/cli@0.0.28 research setup doctor \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
+  research setup doctor \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -177,7 +194,8 @@ orchestrator selection, run the exact CLI again and choose its explicit
 replacement action:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
+  research setup \
   --workspace /absolute/path/to/research-workspace
 ```
 
@@ -194,7 +212,8 @@ subscription change; setup never switches profiles silently.
 `update --check` is read-only. The currently installed generation stays pinned:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup update --check \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
+  research setup update --check \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
@@ -202,7 +221,8 @@ An upgrade is a new immutable plan, never an in-place floating update. Review
 new licenses and pins, then apply the newly generated plan:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup upgrade \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
+  research setup upgrade \
   --plan --confirm-upgrade \
   --accept-license <every-selected-current-license-id> \
   --workspace /absolute/path/to/research-workspace --json
@@ -218,7 +238,8 @@ environment and verified Skill tree. Document output uses a unique temporary
 file and a no-overwrite atomic commit:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.28 research setup companion run \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
+  research setup companion run \
   --id tiangong.document-granular-decompose \
   --input /absolute/path/to/source.pdf \
   --output /absolute/path/to/source.fulltext.md \
@@ -230,7 +251,8 @@ chooses the newest PDF in a directory:
 
 ```bash
 mkdir -p /absolute/path/to/papers
-npx --yes @tiangong-ai/cli@0.0.28 research setup companion run \
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
+  research setup companion run \
   --id tiangong.academic-paper-download \
   --doi 10.1234/example --out /absolute/path/to/papers \
   --workspace /absolute/path/to/research-workspace --json

--- a/tiangong-auto-research/scripts/research_cli.mjs
+++ b/tiangong-auto-research/scripts/research_cli.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { isAbsolute, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MAX_RUNTIME_LOCK_BYTES = 64 * 1024;
+const EXACT_STABLE_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const CLI_PACKAGE = "@tiangong-ai/cli";
+
+class ResolverError extends Error {
+  constructor(code, message, minimumAction) {
+    super(message);
+    this.name = "ResolverError";
+    this.code = code;
+    this.minimumAction = minimumAction;
+  }
+}
+
+function resolverError(code, message, minimumAction) {
+  return new ResolverError(code, message, minimumAction);
+}
+
+export async function resolveWorkspaceRuntime(workspaceInput) {
+  if (typeof workspaceInput !== "string" || !isAbsolute(workspaceInput) || workspaceInput.includes("\0")) {
+    throw resolverError(
+      "AUTO_RESEARCH_WORKSPACE_INVALID",
+      "The Auto Research workspace must be an absolute existing directory.",
+      "Pass the exact absolute workspace path selected by the user.",
+    );
+  }
+
+  let workspace;
+  try {
+    workspace = await realpath(workspaceInput);
+    const workspaceStat = await lstat(workspace);
+    if (!workspaceStat.isDirectory()) {
+      throw new Error("not-directory");
+    }
+  } catch {
+    throw resolverError(
+      "AUTO_RESEARCH_WORKSPACE_INVALID",
+      "The Auto Research workspace must be an absolute existing directory.",
+      "Create or select the workspace directory, then run the reviewed bootstrap CLI once.",
+    );
+  }
+
+  const lockPath = join(workspace, ".tiangong-research", "runtime-lock.json");
+  let lockStat;
+  try {
+    lockStat = await lstat(lockPath);
+  } catch {
+    throw resolverError(
+      "AUTO_RESEARCH_RUNTIME_LOCK_REQUIRED",
+      "No Auto Research runtime lock is available for this workspace.",
+      "For a new directory, explicitly choose a reviewed exact CLI version and run research setup. Do not use npm latest implicitly.",
+    );
+  }
+  if (lockStat.isSymbolicLink() || !lockStat.isFile() || lockStat.size < 2 || lockStat.size > MAX_RUNTIME_LOCK_BYTES) {
+    throw resolverError(
+      "AUTO_RESEARCH_RUNTIME_LOCK_INVALID",
+      "The Auto Research runtime lock must be a bounded regular non-symlink file.",
+      "Restore the CLI-created runtime-lock.json or perform a reviewed setup upgrade; do not edit the lock by hand.",
+    );
+  }
+
+  let lock;
+  try {
+    lock = JSON.parse(await readFile(lockPath, "utf8"));
+  } catch {
+    throw resolverError(
+      "AUTO_RESEARCH_RUNTIME_LOCK_INVALID",
+      "The Auto Research runtime lock is not valid JSON.",
+      "Restore the CLI-created runtime-lock.json or perform a reviewed setup upgrade; do not edit the lock by hand.",
+    );
+  }
+
+  if (
+    lock === null ||
+    typeof lock !== "object" ||
+    Array.isArray(lock) ||
+    lock.schemaVersion !== 1 ||
+    lock.packageName !== CLI_PACKAGE ||
+    typeof lock.packageVersion !== "string" ||
+    !EXACT_STABLE_SEMVER.test(lock.packageVersion)
+  ) {
+    throw resolverError(
+      "AUTO_RESEARCH_RUNTIME_VERSION_INVALID",
+      "The Auto Research runtime lock does not contain the supported exact CLI package and stable version.",
+      "Use the CLI setup upgrade workflow to create a reviewed exact runtime lock; tags, ranges, paths, and command fragments are forbidden.",
+    );
+  }
+
+  return {
+    packageName: CLI_PACKAGE,
+    packageVersion: lock.packageVersion,
+  };
+}
+
+function parseArguments(argv) {
+  const separator = argv.indexOf("--");
+  if (separator < 0 || separator === argv.length - 1) {
+    throw resolverError(
+      "AUTO_RESEARCH_RUNTIME_ARGUMENT_INVALID",
+      "The locked CLI resolver requires a command after `--`.",
+      "Use: research_cli.mjs --workspace /absolute/path -- research <command>.",
+    );
+  }
+  const resolverArgs = argv.slice(0, separator);
+  if (resolverArgs.length !== 2 || resolverArgs[0] !== "--workspace") {
+    throw resolverError(
+      "AUTO_RESEARCH_RUNTIME_ARGUMENT_INVALID",
+      "The locked CLI resolver accepts only one explicit --workspace argument before `--`.",
+      "Use: research_cli.mjs --workspace /absolute/path -- research <command>.",
+    );
+  }
+  return {
+    workspace: resolverArgs[1],
+    command: argv.slice(separator + 1),
+  };
+}
+
+function writeStructuredError(error) {
+  const normalized =
+    error instanceof ResolverError
+      ? error
+      : resolverError(
+          "AUTO_RESEARCH_RUNTIME_EXEC_FAILED",
+          "The locked Auto Research CLI could not be started.",
+          "Verify Node.js 24, npx availability, and registry access, then retry the same locked command.",
+        );
+  process.stderr.write(
+    `${JSON.stringify({
+      error: {
+        code: normalized.code,
+        message: normalized.message,
+        details: {
+          executionMode: "workspace-locked",
+          credentialScope: "broker",
+          networkAttempted: false,
+          minimumAction: normalized.minimumAction,
+        },
+      },
+    })}\n`,
+  );
+}
+
+async function run() {
+  const parsed = parseArguments(process.argv.slice(2));
+  const runtime = await resolveWorkspaceRuntime(parsed.workspace);
+  const executable = process.platform === "win32" ? "npx.cmd" : "npx";
+  const args = [
+    "--yes",
+    "--package",
+    `${runtime.packageName}@${runtime.packageVersion}`,
+    "--",
+    "tiangong-ai",
+    ...parsed.command,
+  ];
+
+  const exitCode = await new Promise((resolveExit, rejectExit) => {
+    const child = spawn(executable, args, {
+      env: { ...process.env, DO_NOT_TRACK: "1" },
+      shell: false,
+      stdio: "inherit",
+    });
+    child.once("error", rejectExit);
+    child.once("exit", (code, signal) => resolveExit(code ?? (signal ? 1 : 0)));
+  });
+  process.exitCode = exitCode;
+}
+
+const isEntrypoint =
+  process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isEntrypoint) {
+  try {
+    await run();
+  } catch (error) {
+    writeStructuredError(error);
+    process.exitCode = 2;
+  }
+}

--- a/tiangong-auto-research/scripts/test-research-cli.mjs
+++ b/tiangong-auto-research/scripts/test-research-cli.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const script = join(dirname(fileURLToPath(import.meta.url)), "research_cli.mjs");
+const root = await mkdtemp(join(tmpdir(), "tiangong-auto-research-resolver-"));
+const fakeBin = join(root, "bin");
+const auditPath = join(root, "npx-args.json");
+const cliPackage = "@tiangong-ai/cli";
+const lockedVersion = "0.0.30";
+await mkdir(fakeBin);
+const fakeNpx = join(fakeBin, "npx");
+await writeFile(
+  fakeNpx,
+  `#!/bin/sh\nprintf '%s\\n' \"$@\" | node -e 'const fs=require("node:fs"); const lines=fs.readFileSync(0,"utf8").trimEnd().split("\\n"); fs.writeFileSync(process.env.FAKE_NPX_AUDIT, JSON.stringify(lines));'\n`,
+  "utf8",
+);
+await chmod(fakeNpx, 0o700);
+
+async function createWorkspace(name, lock) {
+  const workspace = join(root, name);
+  const control = join(workspace, ".tiangong-research");
+  await mkdir(control, { recursive: true });
+  if (lock !== undefined) {
+    await writeFile(join(control, "runtime-lock.json"), JSON.stringify(lock), "utf8");
+  }
+  return workspace;
+}
+
+function invoke(workspace, extraEnv = {}) {
+  return spawnSync(
+    process.execPath,
+    [script, "--workspace", workspace, "--", "research", "setup", "status", "--json"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...extraEnv,
+        FAKE_NPX_AUDIT: auditPath,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      },
+    },
+  );
+}
+
+const validWorkspace = await createWorkspace("valid", {
+  schemaVersion: 1,
+  protocolVersion: 1,
+  packageName: cliPackage,
+  packageVersion: lockedVersion,
+  workspaceId: "resolver-test",
+});
+const valid = invoke(validWorkspace);
+assert.equal(valid.status, 0, valid.stderr);
+assert.deepEqual(JSON.parse(await readFile(auditPath, "utf8")), [
+  "--yes",
+  "--package",
+  `${cliPackage}@${lockedVersion}`,
+  "--",
+  "tiangong-ai",
+  "research",
+  "setup",
+  "status",
+  "--json",
+]);
+
+const injectionWorkspace = await createWorkspace("injection", {
+  schemaVersion: 1,
+  packageName: cliPackage,
+  packageVersion: "0.0.30;echo-token",
+});
+const injection = invoke(injectionWorkspace);
+assert.equal(injection.status, 2);
+assert.match(injection.stderr, /AUTO_RESEARCH_RUNTIME_VERSION_INVALID/);
+assert.doesNotMatch(injection.stderr, /echo-token/);
+
+const missingWorkspace = await createWorkspace("missing");
+const missing = invoke(missingWorkspace);
+assert.equal(missing.status, 2);
+assert.match(missing.stderr, /AUTO_RESEARCH_RUNTIME_LOCK_REQUIRED/);
+
+const symlinkWorkspace = await createWorkspace("symlink");
+const realLock = join(root, "real-lock.json");
+await writeFile(
+  realLock,
+  JSON.stringify({
+    schemaVersion: 1,
+    packageName: cliPackage,
+    packageVersion: lockedVersion,
+  }),
+  "utf8",
+);
+await symlink(realLock, join(symlinkWorkspace, ".tiangong-research", "runtime-lock.json"));
+const linked = invoke(symlinkWorkspace);
+assert.equal(linked.status, 2);
+assert.match(linked.stderr, /AUTO_RESEARCH_RUNTIME_LOCK_INVALID/);
+
+for (const result of [injection, missing, linked]) {
+  const parsed = JSON.parse(result.stderr);
+  assert.equal(parsed.error.details.executionMode, "workspace-locked");
+  assert.equal(parsed.error.details.credentialScope, "broker");
+  assert.equal(parsed.error.details.networkAttempted, false);
+  assert.equal(typeof parsed.error.details.minimumAction, "string");
+}
+
+process.stdout.write("tiangong-auto-research runtime resolver tests passed\n");

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const skillsRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const skillNames = [
+  "tiangong-auto-research",
+  "tiangong-kb-sci-search",
+  "tiangong-kb-report-search",
+  "tiangong-kb-patent-search",
+];
+
+async function description(skillName) {
+  const text = await readFile(join(skillsRoot, skillName, "SKILL.md"), "utf8");
+  const match = text.match(/^description:\s*(.+)$/m);
+  assert.ok(match, `${skillName} must have a one-line routing description`);
+  return match[1].toLowerCase();
+}
+
+const descriptions = Object.fromEntries(
+  await Promise.all(skillNames.map(async (name) => [name, await description(name)])),
+);
+
+for (const marker of [
+  "open-ended",
+  "multi-source",
+  ".tiangong-research",
+  "takes precedence",
+  "研究一下",
+  "朝这个方向做一做",
+  "结合已有成果继续研究",
+  "查资料并形成结论",
+  "系统梳理证据",
+]) {
+  assert.ok(
+    descriptions["tiangong-auto-research"].includes(marker),
+    `Auto Research routing description must include ${marker}`,
+  );
+}
+
+for (const source of ["sci", "report", "patent"]) {
+  const skill = `tiangong-kb-${source}-search`;
+  for (const marker of [
+    "one isolated",
+    ".tiangong-research",
+    "route to `tiangong-auto-research`",
+    "execution_mode=standalone",
+  ]) {
+    assert.ok(descriptions[skill].includes(marker), `${skill} must include ${marker}`);
+  }
+}
+
+function expectedRoute(prompt, managedWorkspace) {
+  const normalized = prompt.toLowerCase();
+  const source = normalized.includes("sci")
+    ? "sci"
+    : normalized.includes("报告") || normalized.includes("report")
+      ? "report"
+      : normalized.includes("专利") || normalized.includes("patent")
+        ? "patent"
+        : null;
+  const explicitlyIsolated =
+    source !== null &&
+    /(只|仅|one isolated|only).*(sci|报告|report|专利|patent)|(sci|报告|report|专利|patent).*(只|仅|only)/i.test(
+      normalized,
+    );
+  const systematic =
+    /(研究一下|朝这个方向做一做|结合.*已有成果|查资料.*结论|系统梳理|open-ended|multi-source|investigate|form a conclusion|reviewed research artifact)/i.test(
+      normalized,
+    );
+  if (explicitlyIsolated) {
+    return `tiangong-kb-${source}-search`;
+  }
+  if (managedWorkspace || systematic) {
+    return "tiangong-auto-research";
+  }
+  return source ? `tiangong-kb-${source}-search` : "unrelated";
+}
+
+const fixtures = [
+  ["研究一下新能源汽车变重是否增加道路损伤，并形成结论", true, "tiangong-auto-research"],
+  ["朝这个方向做一做", false, "tiangong-auto-research"],
+  ["结合这个目录中的已有成果继续研究", true, "tiangong-auto-research"],
+  ["查资料并形成结论/报告", false, "tiangong-auto-research"],
+  ["系统梳理证据和应对措施", false, "tiangong-auto-research"],
+  ["Investigate this as a multi-source reviewed research artifact", false, "tiangong-auto-research"],
+  ["只在 SCI 库查询标题 X，返回前 5 条", true, "tiangong-kb-sci-search"],
+  ["Only search the report database for title X", true, "tiangong-kb-report-search"],
+  ["仅查询专利库中的申请号 X", true, "tiangong-kb-patent-search"],
+];
+for (const [prompt, managed, expected] of fixtures) {
+  assert.equal(expectedRoute(prompt, managed), expected, prompt);
+}
+
+process.stdout.write("Auto Research routing contract tests passed\n");

--- a/tiangong-kb-patent-search/SKILL.md
+++ b/tiangong-kb-patent-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-kb-patent-search
-description: "Search Tiangong knowledge-base patent sources through the Tiangong AI CLI. Use for inventions, technical routes, claims, patent evidence, and prior art. This skill searches only the patent source, not sci or report."
+description: Perform one isolated owner-requested Tiangong patent search outside Auto Research, or provide patent-source method guidance for a separately reviewed locked broker capability. Searches only `patent`. If an ancestor contains `.tiangong-research` and the request is open-ended, multi-source, analytical, builds on prior outputs, or produces a conclusion/artifact, route to `tiangong-auto-research` and do not execute this standalone wrapper. Inside a managed workspace, standalone use requires the user's explicit isolated-query request and `execution_mode=standalone`.
 ---
 
 # Tiangong KB Patent Search
@@ -8,18 +8,26 @@ description: "Search Tiangong knowledge-base patent sources through the Tiangong
 Use this skill for Tiangong patent-source retrieval. It is intentionally
 single-source: always search `patent`, never `all`, `sci`, or `report`.
 
+In Auto Research, a patent-source requirement must name the reviewed patent
+capability in `requiredCapabilityIds`; Brave or SCI results cannot stand in for
+it. If that capability is absent, stop at preflight and have the owner import,
+configure, license, credential, lock, and smoke the exact patent capability.
+The standalone wrapper never reads the workspace broker credential store.
+
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
-  preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
-  override the CLI entrypoint.
-- Set the authentication environment variables expected by `tiangong-ai`, or
-  pass `api_key` / `patent_api_key` to the wrapper script.
+- The standalone wrapper defaults to its separately tested CLI version
+  `0.0.30`; this is not the Auto Research workspace runtime. Set
+  `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to intentionally override the
+  standalone entrypoint.
+- Set `TIANGONG_PATENT_APIKEY` or the common fallback
+  `TIANGONG_AI_APIKEY`. Credentials are rejected recursively in wrapper JSON,
+  request files, URL query parameters, and CLI arguments.
 - When `request_file` / `input_file` is provided, the wrapper loads `.env` from
   that file's directory by default. `env_file` can point to a different dotenv
-  file. Loaded dotenv values only fill unset environment variables; explicit
-  JSON fields such as `api_key`, `patent_api_key`, and `api_base_url` are passed
-  as CLI flags and take precedence.
+  file. It must be owner-only, regular, and non-symlinked; only documented
+  Tiangong patent credential, endpoint, region, and timeout variables are
+  loaded, and existing environment values win.
 - Optionally set `TIANGONG_AI_API_BASE_URL`; the CLI accepts a Supabase project
   root, `/functions/v1`, or `/rest/v1` and derives Functions URLs.
 
@@ -34,10 +42,15 @@ For normal searches, pass a query:
 }'
 ```
 
+When the current directory is inside a managed workspace, this command is
+blocked before credential loading or network. Only a user who explicitly asks
+for one isolated query may add `"execution_mode":"standalone"`; the wrapper
+then emits a non-secret audit event.
+
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 research search --query <query> --sources patent --json
+npx --yes @tiangong-ai/cli@0.0.30 research search --query <query> --sources patent --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:
@@ -81,11 +94,14 @@ forward them through the CLI `--input` path. The same payload can also be put in
 - `request_file` or `input_file`: JSON body forwarded unchanged.
 - `env_file`: optional dotenv file. Without it, `request_file` /
   `input_file` causes the wrapper to load `.env` from that file's directory.
+- `execution_mode`: only `standalone`, and only after an explicit isolated
+  owner request when a managed workspace is detected.
 - `filter`, `datefilter`, `topK`: optional inline raw payload fields for patent
   search.
 - `sources`: optional compatibility field; only `patent` or `default` is
   accepted.
 - `dry_run`: true to return the exact request plan with masked credentials.
-- `api_base_url`, `api_key`, `patent_api_key`.
+- `api_base_url`; credentials must come from allowed owner environment
+  variables or an owner-only env file.
 - `patent_url`, `region`, `timeout`.
 - `top_k`: only used in query mode.

--- a/tiangong-kb-patent-search/agents/openai.yaml
+++ b/tiangong-kb-patent-search/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong KB Patent Search"
-  short_description: "Search only Tiangong KB patent sources via CLI"
-  default_prompt: "Use $tiangong-kb-patent-search to search Tiangong KB patent sources only."
+  short_description: "Run one isolated authorized patent search"
+  default_prompt: "Use $tiangong-kb-patent-search only for one explicitly isolated owner-authorized patent query; route systematic work in an Auto Research workspace through $tiangong-auto-research and its broker."

--- a/tiangong-kb-patent-search/scripts/patent_search.sh
+++ b/tiangong-kb-patent-search/scripts/patent_search.sh
@@ -1,40 +1,83 @@
 #!/bin/bash
-# Patent-source search wrapper over Tiangong AI CLI.
+# Patent-source standalone search wrapper over Tiangong AI CLI.
 # Usage: ./patent_search.sh '{"query": "claim or topic", ...}' [output_file]
 
 set -euo pipefail
+umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
+STANDALONE_TESTED_CLI_VERSION="0.0.30"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
+    CLI_COMMAND=(npx --yes "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION")
 fi
 
 if [ -z "$JSON_INPUT" ]; then
     echo "Usage: ./patent_search.sh '<json>' [output_file]" >&2
     exit 1
 fi
-
 if ! command -v jq >/dev/null 2>&1; then
     echo "Error: jq is required" >&2
     exit 1
 fi
-
 if ! echo "$JSON_INPUT" | jq empty 2>/dev/null; then
     echo "Error: Invalid JSON input" >&2
     exit 1
+fi
+
+contains_sensitive_json() {
+    jq -e '[.. | objects | keys[]] | any(.[]; test("(^|[_-])(access[_-]?token|api[_-]?key|apikey|auth|authorization|cookie|credential|password|secret|session|token)([_-]|$)"; "i"))' >/dev/null
+}
+if echo "$JSON_INPUT" | contains_sensitive_json; then
+    echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
+    exit 2
+fi
+
+EXECUTION_MODE=$(echo "$JSON_INPUT" | jq -r '.execution_mode // empty')
+case "$EXECUTION_MODE" in
+    ""|"standalone") ;;
+    *)
+        printf '%s\n' '{"error":{"code":"INVALID_EXECUTION_MODE","message":"execution_mode must be standalone when explicitly supplied.","details":{"executionMode":"invalid","credentialScope":"none","networkAttempted":false,"minimumAction":"Remove execution_mode or set it to standalone for one isolated owner-requested query."}}}' >&2
+        exit 2
+        ;;
+esac
+
+find_auto_research_workspace() {
+    local search_dir
+    local lock_path
+    local parent_dir
+    search_dir="$(pwd -P)"
+    while :; do
+        lock_path="$search_dir/.tiangong-research/runtime-lock.json"
+        if [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+            return 0
+        fi
+        parent_dir="$(dirname "$search_dir")"
+        if [ "$parent_dir" = "$search_dir" ]; then
+            return 1
+        fi
+        search_dir="$parent_dir"
+    done
+}
+if find_auto_research_workspace; then
+    if [ "$EXECUTION_MODE" != "standalone" ]; then
+        printf '%s\n' '{"error":{"code":"AUTO_RESEARCH_BROKER_REQUIRED","message":"An Auto Research workspace was detected. Systematic research must call patents through the locked discovery broker.","details":{"source":"patent","executionMode":"managed-workspace","credentialScope":"broker","networkAttempted":false,"minimumAction":"Route to tiangong-auto-research. Use execution_mode=standalone only after the user explicitly narrows the task to one isolated patent query."}}}' >&2
+        exit 2
+    fi
+fi
+if [ "$EXECUTION_MODE" = "standalone" ]; then
+    printf '%s\n' '{"event":{"code":"STANDALONE_MODE_SELECTED","source":"patent","executionMode":"standalone","credentialScope":"ambient-or-explicit-owner-env","networkAttempted":false}}' >&2
 fi
 
 jq_value() {
     local key="$1"
     echo "$JSON_INPUT" | jq -r ".${key} // empty"
 }
-
 jq_bool() {
     local key="$1"
     [ "$(echo "$JSON_INPUT" | jq -r ".${key} // false")" = "true" ]
@@ -42,7 +85,28 @@ jq_bool() {
 
 load_env_file() {
     local env_file="$1"
-    [ -f "$env_file" ] || return 0
+    local required="${2:-false}"
+    if [ ! -e "$env_file" ]; then
+        if [ "$required" = "true" ]; then
+            echo "Error: explicit env_file does not exist" >&2
+            exit 2
+        fi
+        return 0
+    fi
+    if [ -L "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo "Error: env_file must be a regular non-symlink file" >&2
+        exit 2
+    fi
+    local mode=""
+    if stat -f '%Lp' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -f '%Lp' "$env_file")"
+    elif stat -c '%a' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -c '%a' "$env_file")"
+    fi
+    if [ -n "$mode" ] && [ $((10#$mode % 100)) -ne 0 ]; then
+        echo "Error: env_file must be owner-only (chmod 600)" >&2
+        exit 2
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
@@ -60,6 +124,11 @@ load_env_file() {
         value="${value#\"}"
         value="${value%\'}"
         value="${value#\'}"
+        case "$key" in
+            TIANGONG_AI_APIKEY|TIANGONG_PATENT_APIKEY|TIANGONG_RESEARCH_API_BASE_URL|TIANGONG_AI_SEARCH_API_BASE_URL|TIANGONG_AI_API_BASE_URL|TIANGONG_PATENT_SEARCH_URL|TIANGONG_REGION|TIANGONG_RESEARCH_TIMEOUT)
+                ;;
+            *) continue ;;
+        esac
         export "$key=$value"
     done < "$env_file"
 }
@@ -78,23 +147,33 @@ SOURCE_INPUT=$(echo "$JSON_INPUT" | jq -r '
         .sources // "default"
     end
 ')
-
 case "$SOURCE_INPUT" in
-    ""|"default"|"patent")
-        ;;
-    *)
-        echo "Error: tiangong-kb-patent-search searches only the patent source; use the sci or report skill for other sources" >&2
-        exit 2
-        ;;
+    ""|"default"|"patent") ;;
+    *) echo "Error: tiangong-kb-patent-search searches only the patent source" >&2; exit 2 ;;
 esac
 
 REQUEST_FILE=$(echo "$JSON_INPUT" | jq -r '.request_file // .input_file // empty')
 QUERY=$(echo "$JSON_INPUT" | jq -r '.query // .input // .claim // empty')
-TMP_REQUEST_FILE=""
 ENV_FILE=$(echo "$JSON_INPUT" | jq -r '.env_file // empty')
+TMP_REQUEST_FILE=""
+TMP_OUTPUT=""
 
+if [ -n "$REQUEST_FILE" ]; then
+    if [ -L "$REQUEST_FILE" ] || [ ! -f "$REQUEST_FILE" ]; then
+        echo "Error: request_file must be a regular non-symlink JSON file" >&2
+        exit 2
+    fi
+    if ! jq empty "$REQUEST_FILE" 2>/dev/null; then
+        echo "Error: request_file is not valid JSON" >&2
+        exit 2
+    fi
+    if contains_sensitive_json < "$REQUEST_FILE"; then
+        echo "Error: request_file contains credential-like fields; use owner environment variables" >&2
+        exit 2
+    fi
+fi
 if [ -n "$ENV_FILE" ]; then
-    load_env_file "$ENV_FILE"
+    load_env_file "$ENV_FILE" true
 elif [ -n "$REQUEST_FILE" ]; then
     load_env_near_file "$REQUEST_FILE"
 fi
@@ -103,23 +182,24 @@ cleanup() {
     if [ -n "$TMP_REQUEST_FILE" ]; then
         rm -f "$TMP_REQUEST_FILE"
     fi
+    if [ -n "$TMP_OUTPUT" ]; then
+        rm -f "$TMP_OUTPUT"
+    fi
 }
 trap cleanup EXIT
 
 if [ -z "$REQUEST_FILE" ]; then
     if echo "$JSON_INPUT" | jq -e 'has("extK") or has("ext_k") or has("getMeta") or has("get_meta")' >/dev/null; then
-        echo "Error: inline extK/ext_k/getMeta fields are not supported for tiangong-kb-patent-search" >&2
+        echo "Error: inline extK/getMeta fields are not supported for tiangong-kb-patent-search" >&2
         exit 2
     fi
     if echo "$JSON_INPUT" | jq -e 'has("filter") or has("datefilter") or has("topK")' >/dev/null; then
         if [ -z "$QUERY" ]; then
-            echo "Error: 'query', 'input', or 'claim' field is required when using inline raw payload fields" >&2
+            echo "Error: 'query', 'input', or 'claim' is required with inline raw fields" >&2
             exit 1
         fi
         TMP_REQUEST_FILE=$(mktemp "${TMPDIR:-/tmp}/tiangong-kb-patent.XXXXXX.json")
-        echo "$JSON_INPUT" | jq '{
-            query: (.query // .input // .claim)
-        }
+        echo "$JSON_INPUT" | jq '{query: (.query // .input // .claim)}
         + (if has("filter") then {filter: .filter} else {} end)
         + (if has("datefilter") then {datefilter: .datefilter} else {} end)
         + (if has("topK") then {topK: .topK} elif has("top_k") then {topK: .top_k} else {} end)' > "$TMP_REQUEST_FILE"
@@ -128,12 +208,11 @@ if [ -z "$REQUEST_FILE" ]; then
 fi
 
 ARGS=(research search --sources patent --json)
-
 if [ -n "$REQUEST_FILE" ]; then
     ARGS+=(--input "$REQUEST_FILE")
 else
     if [ -z "$QUERY" ]; then
-        echo "Error: 'query', 'input', 'claim', 'request_file', or 'input_file' field is required" >&2
+        echo "Error: a query or request_file is required" >&2
         exit 1
     fi
     ARGS+=(--query "$QUERY")
@@ -148,40 +227,54 @@ value_arg() {
         ARGS+=("$cli_flag" "$value")
     fi
 }
+safe_url_arg() {
+    local json_key="$1"
+    local cli_flag="$2"
+    local value
+    value=$(jq_value "$json_key")
+    if [ -z "$value" ]; then return 0; fi
+    case "$value" in
+        https://*) ;;
+        *) echo "Error: $json_key must be an HTTPS URL" >&2; exit 2 ;;
+    esac
+    case "$value" in
+        *\?*|*\#*|*@*) echo "Error: $json_key must not contain userinfo, query parameters, or fragments" >&2; exit 2 ;;
+    esac
+    ARGS+=("$cli_flag" "$value")
+}
 
-value_arg "api_base_url" "--api-base-url"
-value_arg "api_key" "--api-key"
-value_arg "patent_api_key" "--patent-api-key"
-value_arg "patent_url" "--patent-url"
+safe_url_arg "api_base_url" "--api-base-url"
+safe_url_arg "patent_url" "--patent-url"
 value_arg "region" "--region"
 value_arg "timeout" "--timeout"
-
 if [ -z "$REQUEST_FILE" ]; then
     value_arg "top_k" "--top-k"
 fi
-
 if jq_bool "dry_run"; then
     ARGS+=(--dry-run)
 fi
 
 run_cli() {
     if [[ "${CLI_COMMAND[0]}" == *.js ]]; then
-        node "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 node "${CLI_COMMAND[@]}" "${ARGS[@]}"
     else
-        "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 "${CLI_COMMAND[@]}" "${ARGS[@]}"
     fi
 }
-
 if [ -n "$OUTPUT_FILE" ]; then
-    TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
+    if [ -L "$OUTPUT_FILE" ]; then
+        echo "Error: output_file must not be a symbolic link" >&2
+        exit 2
+    fi
+    TMP_OUTPUT=$(mktemp "${OUTPUT_FILE}.tmp.XXXXXX")
     if run_cli > "$TMP_OUTPUT"; then
         mv "$TMP_OUTPUT" "$OUTPUT_FILE"
+        TMP_OUTPUT=""
         echo "Results saved to: $OUTPUT_FILE"
     else
-        STATUS=$?
-        cat "$TMP_OUTPUT" >&2 || true
-        rm -f "$TMP_OUTPUT"
-        exit "$STATUS"
+        status=$?
+        echo "Error: Tiangong CLI search failed; see its sanitized stderr diagnostic" >&2
+        exit "$status"
     fi
 else
     run_cli

--- a/tiangong-kb-patent-search/scripts/test-patent-search.sh
+++ b/tiangong-kb-patent-search/scripts/test-patent-search.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/patent_search.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tiangong-kb-patent-test.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+FAKE_CLI="$TEST_ROOT/fake-cli"
+AUDIT_ARGS="$TEST_ROOT/args.txt"
+AUDIT_ENV="$TEST_ROOT/env.txt"
+MARKER="$TEST_ROOT/invoked"
+STDOUT="$TEST_ROOT/stdout.txt"
+STDERR="$TEST_ROOT/stderr.txt"
+SECRET='owner-only-patent-key-value'
+
+printf '%s\n' \
+    '#!/bin/bash' \
+    'set -euo pipefail' \
+    ': > "$FAKE_MARKER"' \
+    'printf "%s\n" "$@" > "$FAKE_ARGS"' \
+    'printf "PATENT=%s\nTRACK=%s\n" "${TIANGONG_PATENT_APIKEY:-}" "${DO_NOT_TRACK:-}" > "$FAKE_ENV"' \
+    'printf "{\"ok\":true}\n"' \
+    > "$FAKE_CLI"
+chmod 700 "$FAKE_CLI"
+
+run_wrapper() {
+    FAKE_ARGS="$AUDIT_ARGS" \
+    FAKE_ENV="$AUDIT_ENV" \
+    FAKE_MARKER="$MARKER" \
+    TIANGONG_AI_CLI_BIN="$FAKE_CLI" \
+    "$WRAPPER" "$@"
+}
+
+TIANGONG_PATENT_APIKEY="$SECRET" \
+    run_wrapper '{"query":"isolated patent","dry_run":true}' > "$STDOUT" 2> "$STDERR"
+grep -Fx 'patent' "$AUDIT_ARGS" >/dev/null
+grep -Fx 'TRACK=1' "$AUDIT_ENV" >/dev/null
+if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'patent credential leaked into argv or output' >&2
+    exit 1
+fi
+
+rm -f "$MARKER"
+if run_wrapper "{\"query\":\"blocked\",\"patent_api_key\":\"$SECRET\"}" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'credential-like patent JSON was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+if grep -F "$SECRET" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'rejected patent credential was echoed' >&2
+    exit 1
+fi
+
+MANAGED_WORKSPACE="$TEST_ROOT/managed"
+MANAGED_NESTED="$MANAGED_WORKSPACE/nested"
+mkdir -p "$MANAGED_WORKSPACE/.tiangong-research" "$MANAGED_NESTED"
+printf '%s\n' '{"schemaVersion":1,"packageName":"@tiangong-ai/cli","packageVersion":"0.0.30"}' \
+    > "$MANAGED_WORKSPACE/.tiangong-research/runtime-lock.json"
+rm -f "$MARKER"
+if (cd "$MANAGED_NESTED" && run_wrapper '{"query":"systematic patent work"}') \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'managed patent wrapper bypassed the broker guard' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
+grep -F '"credentialScope":"broker"' "$STDERR" >/dev/null
+grep -F '"networkAttempted":false' "$STDERR" >/dev/null
+
+(cd "$MANAGED_NESTED" && \
+    TIANGONG_PATENT_APIKEY="$SECRET" \
+    run_wrapper '{"query":"isolated patent","execution_mode":"standalone","dry_run":true}') \
+    > "$STDOUT" 2> "$STDERR"
+grep -F 'STANDALONE_MODE_SELECTED' "$STDERR" >/dev/null
+grep -F '"credentialScope":"ambient-or-explicit-owner-env"' "$STDERR" >/dev/null
+if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'explicit patent standalone mode leaked a credential' >&2
+    exit 1
+fi
+
+echo 'tiangong-kb-patent-search wrapper tests passed'

--- a/tiangong-kb-report-search/SKILL.md
+++ b/tiangong-kb-report-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-kb-report-search
-description: "Search Tiangong knowledge-base report sources through the Tiangong AI CLI. Use for industry reports, policy reports, whitepapers, institutional reports, and technical reports. This skill searches only the report source, not sci or patent."
+description: Perform one isolated owner-requested Tiangong report search outside Auto Research, or provide report-source method guidance for a separately reviewed locked broker capability. Searches only `report`. If an ancestor contains `.tiangong-research` and the request is open-ended, multi-source, analytical, builds on prior outputs, or produces a conclusion/artifact, route to `tiangong-auto-research` and do not execute this standalone wrapper. Inside a managed workspace, standalone use requires the user's explicit isolated-query request and `execution_mode=standalone`.
 ---
 
 # Tiangong KB Report Search
@@ -8,18 +8,26 @@ description: "Search Tiangong knowledge-base report sources through the Tiangong
 Use this skill for Tiangong report-source retrieval. It is intentionally
 single-source: always search `report`, never `all`, `sci`, or `patent`.
 
+In Auto Research, an industry-report requirement must name the reviewed report
+capability in `requiredCapabilityIds`; Brave or SCI results cannot stand in for
+it. If that capability is absent, stop at preflight and have the owner import,
+configure, license, credential, lock, and smoke the exact report capability.
+The standalone wrapper never reads the workspace broker credential store.
+
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
-  preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
-  override the CLI entrypoint.
-- Set the authentication environment variables expected by `tiangong-ai`, or
-  pass `api_key` / `report_api_key` to the wrapper script.
+- The standalone wrapper defaults to its separately tested CLI version
+  `0.0.30`; this is not the Auto Research workspace runtime. Set
+  `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to intentionally override the
+  standalone entrypoint.
+- Set `TIANGONG_REPORT_APIKEY` or the common fallback
+  `TIANGONG_AI_APIKEY`. Credentials are rejected recursively in wrapper JSON,
+  request files, URL query parameters, and CLI arguments.
 - When `request_file` / `input_file` is provided, the wrapper loads `.env` from
   that file's directory by default. `env_file` can point to a different dotenv
-  file. Loaded dotenv values only fill unset environment variables; explicit
-  JSON fields such as `api_key`, `report_api_key`, and `api_base_url` are passed
-  as CLI flags and take precedence.
+  file. It must be owner-only, regular, and non-symlinked; only documented
+  Tiangong report credential, endpoint, region, and timeout variables are
+  loaded, and existing environment values win.
 - Optionally set `TIANGONG_AI_API_BASE_URL`; the CLI accepts a Supabase project
   root, `/functions/v1`, or `/rest/v1` and derives Functions URLs.
 
@@ -34,10 +42,15 @@ For normal searches, pass a query:
 }'
 ```
 
+When the current directory is inside a managed workspace, this command is
+blocked before credential loading or network. Only a user who explicitly asks
+for one isolated query may add `"execution_mode":"standalone"`; the wrapper
+then emits a non-secret audit event.
+
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 research search --query <query> --sources report --json
+npx --yes @tiangong-ai/cli@0.0.30 research search --query <query> --sources report --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:
@@ -77,11 +90,14 @@ forward them through the CLI `--input` path. The same payload can also be put in
 - `request_file` or `input_file`: JSON body forwarded unchanged.
 - `env_file`: optional dotenv file. Without it, `request_file` /
   `input_file` causes the wrapper to load `.env` from that file's directory.
+- `execution_mode`: only `standalone`, and only after an explicit isolated
+  owner request when a managed workspace is detected.
 - `filter`, `topK`, `extK`: optional inline raw payload fields for report
   search.
 - `sources`: optional compatibility field; only `report` or `default` is
   accepted.
 - `dry_run`: true to return the exact request plan with masked credentials.
-- `api_base_url`, `api_key`, `report_api_key`.
+- `api_base_url`; credentials must come from allowed owner environment
+  variables or an owner-only env file.
 - `report_url`, `region`, `timeout`.
 - `top_k`, `ext_k`: only used in query mode.

--- a/tiangong-kb-report-search/agents/openai.yaml
+++ b/tiangong-kb-report-search/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong KB Report Search"
-  short_description: "Search only Tiangong KB report sources via CLI"
-  default_prompt: "Use $tiangong-kb-report-search to search Tiangong KB report sources only."
+  short_description: "Run one isolated authorized report search"
+  default_prompt: "Use $tiangong-kb-report-search only for one explicitly isolated owner-authorized report query; route systematic work in an Auto Research workspace through $tiangong-auto-research and its broker."

--- a/tiangong-kb-report-search/scripts/report_search.sh
+++ b/tiangong-kb-report-search/scripts/report_search.sh
@@ -1,33 +1,80 @@
 #!/bin/bash
-# Report-source search wrapper over Tiangong AI CLI.
+# Report-source standalone search wrapper over Tiangong AI CLI.
 # Usage: ./report_search.sh '{"query": "claim or topic", ...}' [output_file]
 
 set -euo pipefail
+umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
+STANDALONE_TESTED_CLI_VERSION="0.0.30"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
+    CLI_COMMAND=(npx --yes "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION")
 fi
 
 if [ -z "$JSON_INPUT" ]; then
     echo "Usage: ./report_search.sh '<json>' [output_file]" >&2
     exit 1
 fi
-
 if ! command -v jq >/dev/null 2>&1; then
     echo "Error: jq is required" >&2
     exit 1
 fi
-
 if ! echo "$JSON_INPUT" | jq empty 2>/dev/null; then
     echo "Error: Invalid JSON input" >&2
     exit 1
+fi
+
+contains_sensitive_json() {
+    jq -e '[.. | objects | keys[]] | any(.[]; test("(^|[_-])(access[_-]?token|api[_-]?key|apikey|auth|authorization|cookie|credential|password|secret|session|token)([_-]|$)"; "i"))' >/dev/null
+}
+
+if echo "$JSON_INPUT" | contains_sensitive_json; then
+    echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
+    exit 2
+fi
+
+EXECUTION_MODE=$(echo "$JSON_INPUT" | jq -r '.execution_mode // empty')
+case "$EXECUTION_MODE" in
+    ""|"standalone")
+        ;;
+    *)
+        printf '%s\n' '{"error":{"code":"INVALID_EXECUTION_MODE","message":"execution_mode must be standalone when explicitly supplied.","details":{"executionMode":"invalid","credentialScope":"none","networkAttempted":false,"minimumAction":"Remove execution_mode or set it to standalone for one isolated owner-requested query."}}}' >&2
+        exit 2
+        ;;
+esac
+
+find_auto_research_workspace() {
+    local search_dir
+    local lock_path
+    local parent_dir
+    search_dir="$(pwd -P)"
+    while :; do
+        lock_path="$search_dir/.tiangong-research/runtime-lock.json"
+        if [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+            return 0
+        fi
+        parent_dir="$(dirname "$search_dir")"
+        if [ "$parent_dir" = "$search_dir" ]; then
+            return 1
+        fi
+        search_dir="$parent_dir"
+    done
+}
+
+if find_auto_research_workspace; then
+    if [ "$EXECUTION_MODE" != "standalone" ]; then
+        printf '%s\n' '{"error":{"code":"AUTO_RESEARCH_BROKER_REQUIRED","message":"An Auto Research workspace was detected. Systematic research must call reports through the locked discovery broker.","details":{"source":"report","executionMode":"managed-workspace","credentialScope":"broker","networkAttempted":false,"minimumAction":"Route to tiangong-auto-research. Use execution_mode=standalone only after the user explicitly narrows the task to one isolated report query."}}}' >&2
+        exit 2
+    fi
+fi
+if [ "$EXECUTION_MODE" = "standalone" ]; then
+    printf '%s\n' '{"event":{"code":"STANDALONE_MODE_SELECTED","source":"report","executionMode":"standalone","credentialScope":"ambient-or-explicit-owner-env","networkAttempted":false}}' >&2
 fi
 
 jq_value() {
@@ -42,7 +89,28 @@ jq_bool() {
 
 load_env_file() {
     local env_file="$1"
-    [ -f "$env_file" ] || return 0
+    local required="${2:-false}"
+    if [ ! -e "$env_file" ]; then
+        if [ "$required" = "true" ]; then
+            echo "Error: explicit env_file does not exist" >&2
+            exit 2
+        fi
+        return 0
+    fi
+    if [ -L "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo "Error: env_file must be a regular non-symlink file" >&2
+        exit 2
+    fi
+    local mode=""
+    if stat -f '%Lp' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -f '%Lp' "$env_file")"
+    elif stat -c '%a' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -c '%a' "$env_file")"
+    fi
+    if [ -n "$mode" ] && [ $((10#$mode % 100)) -ne 0 ]; then
+        echo "Error: env_file must be owner-only (chmod 600)" >&2
+        exit 2
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
@@ -60,6 +128,13 @@ load_env_file() {
         value="${value#\"}"
         value="${value%\'}"
         value="${value#\'}"
+        case "$key" in
+            TIANGONG_AI_APIKEY|TIANGONG_REPORT_APIKEY|TIANGONG_RESEARCH_API_BASE_URL|TIANGONG_AI_SEARCH_API_BASE_URL|TIANGONG_AI_API_BASE_URL|TIANGONG_REPORT_SEARCH_URL|TIANGONG_REGION|TIANGONG_RESEARCH_TIMEOUT)
+                ;;
+            *)
+                continue
+                ;;
+        esac
         export "$key=$value"
     done < "$env_file"
 }
@@ -78,23 +153,37 @@ SOURCE_INPUT=$(echo "$JSON_INPUT" | jq -r '
         .sources // "default"
     end
 ')
-
 case "$SOURCE_INPUT" in
     ""|"default"|"report")
         ;;
     *)
-        echo "Error: tiangong-kb-report-search searches only the report source; use the sci or patent skill for other sources" >&2
+        echo "Error: tiangong-kb-report-search searches only the report source" >&2
         exit 2
         ;;
 esac
 
 REQUEST_FILE=$(echo "$JSON_INPUT" | jq -r '.request_file // .input_file // empty')
 QUERY=$(echo "$JSON_INPUT" | jq -r '.query // .input // .claim // empty')
-TMP_REQUEST_FILE=""
 ENV_FILE=$(echo "$JSON_INPUT" | jq -r '.env_file // empty')
+TMP_REQUEST_FILE=""
+TMP_OUTPUT=""
 
+if [ -n "$REQUEST_FILE" ]; then
+    if [ -L "$REQUEST_FILE" ] || [ ! -f "$REQUEST_FILE" ]; then
+        echo "Error: request_file must be a regular non-symlink JSON file" >&2
+        exit 2
+    fi
+    if ! jq empty "$REQUEST_FILE" 2>/dev/null; then
+        echo "Error: request_file is not valid JSON" >&2
+        exit 2
+    fi
+    if contains_sensitive_json < "$REQUEST_FILE"; then
+        echo "Error: request_file contains credential-like fields; use owner environment variables" >&2
+        exit 2
+    fi
+fi
 if [ -n "$ENV_FILE" ]; then
-    load_env_file "$ENV_FILE"
+    load_env_file "$ENV_FILE" true
 elif [ -n "$REQUEST_FILE" ]; then
     load_env_near_file "$REQUEST_FILE"
 fi
@@ -102,6 +191,9 @@ fi
 cleanup() {
     if [ -n "$TMP_REQUEST_FILE" ]; then
         rm -f "$TMP_REQUEST_FILE"
+    fi
+    if [ -n "$TMP_OUTPUT" ]; then
+        rm -f "$TMP_OUTPUT"
     fi
 }
 trap cleanup EXIT
@@ -113,13 +205,11 @@ if [ -z "$REQUEST_FILE" ]; then
     fi
     if echo "$JSON_INPUT" | jq -e 'has("filter") or has("topK") or has("extK")' >/dev/null; then
         if [ -z "$QUERY" ]; then
-            echo "Error: 'query', 'input', or 'claim' field is required when using inline raw payload fields" >&2
+            echo "Error: 'query', 'input', or 'claim' is required with inline raw fields" >&2
             exit 1
         fi
         TMP_REQUEST_FILE=$(mktemp "${TMPDIR:-/tmp}/tiangong-kb-report.XXXXXX.json")
-        echo "$JSON_INPUT" | jq '{
-            query: (.query // .input // .claim)
-        }
+        echo "$JSON_INPUT" | jq '{query: (.query // .input // .claim)}
         + (if has("filter") then {filter: .filter} else {} end)
         + (if has("topK") then {topK: .topK} elif has("top_k") then {topK: .top_k} else {} end)
         + (if has("extK") then {extK: .extK} elif has("ext_k") then {extK: .ext_k} else {} end)' > "$TMP_REQUEST_FILE"
@@ -128,12 +218,11 @@ if [ -z "$REQUEST_FILE" ]; then
 fi
 
 ARGS=(research search --sources report --json)
-
 if [ -n "$REQUEST_FILE" ]; then
     ARGS+=(--input "$REQUEST_FILE")
 else
     if [ -z "$QUERY" ]; then
-        echo "Error: 'query', 'input', 'claim', 'request_file', or 'input_file' field is required" >&2
+        echo "Error: a query or request_file is required" >&2
         exit 1
     fi
     ARGS+=(--query "$QUERY")
@@ -149,40 +238,58 @@ value_arg() {
     fi
 }
 
-value_arg "api_base_url" "--api-base-url"
-value_arg "api_key" "--api-key"
-value_arg "report_api_key" "--report-api-key"
-value_arg "report_url" "--report-url"
+safe_url_arg() {
+    local json_key="$1"
+    local cli_flag="$2"
+    local value
+    value=$(jq_value "$json_key")
+    if [ -z "$value" ]; then
+        return 0
+    fi
+    case "$value" in
+        https://*) ;;
+        *) echo "Error: $json_key must be an HTTPS URL" >&2; exit 2 ;;
+    esac
+    case "$value" in
+        *\?*|*\#*|*@*) echo "Error: $json_key must not contain userinfo, query parameters, or fragments" >&2; exit 2 ;;
+    esac
+    ARGS+=("$cli_flag" "$value")
+}
+
+safe_url_arg "api_base_url" "--api-base-url"
+safe_url_arg "report_url" "--report-url"
 value_arg "region" "--region"
 value_arg "timeout" "--timeout"
-
 if [ -z "$REQUEST_FILE" ]; then
     value_arg "top_k" "--top-k"
     value_arg "ext_k" "--ext-k"
 fi
-
 if jq_bool "dry_run"; then
     ARGS+=(--dry-run)
 fi
 
 run_cli() {
     if [[ "${CLI_COMMAND[0]}" == *.js ]]; then
-        node "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 node "${CLI_COMMAND[@]}" "${ARGS[@]}"
     else
-        "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 "${CLI_COMMAND[@]}" "${ARGS[@]}"
     fi
 }
 
 if [ -n "$OUTPUT_FILE" ]; then
-    TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
+    if [ -L "$OUTPUT_FILE" ]; then
+        echo "Error: output_file must not be a symbolic link" >&2
+        exit 2
+    fi
+    TMP_OUTPUT=$(mktemp "${OUTPUT_FILE}.tmp.XXXXXX")
     if run_cli > "$TMP_OUTPUT"; then
         mv "$TMP_OUTPUT" "$OUTPUT_FILE"
+        TMP_OUTPUT=""
         echo "Results saved to: $OUTPUT_FILE"
     else
-        STATUS=$?
-        cat "$TMP_OUTPUT" >&2 || true
-        rm -f "$TMP_OUTPUT"
-        exit "$STATUS"
+        status=$?
+        echo "Error: Tiangong CLI search failed; see its sanitized stderr diagnostic" >&2
+        exit "$status"
     fi
 else
     run_cli

--- a/tiangong-kb-report-search/scripts/test-report-search.sh
+++ b/tiangong-kb-report-search/scripts/test-report-search.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/report_search.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tiangong-kb-report-test.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+FAKE_CLI="$TEST_ROOT/fake-cli"
+AUDIT_ARGS="$TEST_ROOT/args.txt"
+AUDIT_ENV="$TEST_ROOT/env.txt"
+MARKER="$TEST_ROOT/invoked"
+STDOUT="$TEST_ROOT/stdout.txt"
+STDERR="$TEST_ROOT/stderr.txt"
+SECRET='owner-only-report-key-value'
+
+printf '%s\n' \
+    '#!/bin/bash' \
+    'set -euo pipefail' \
+    ': > "$FAKE_MARKER"' \
+    'printf "%s\n" "$@" > "$FAKE_ARGS"' \
+    'printf "REPORT=%s\nTRACK=%s\n" "${TIANGONG_REPORT_APIKEY:-}" "${DO_NOT_TRACK:-}" > "$FAKE_ENV"' \
+    'printf "{\"ok\":true}\n"' \
+    > "$FAKE_CLI"
+chmod 700 "$FAKE_CLI"
+
+run_wrapper() {
+    FAKE_ARGS="$AUDIT_ARGS" \
+    FAKE_ENV="$AUDIT_ENV" \
+    FAKE_MARKER="$MARKER" \
+    TIANGONG_AI_CLI_BIN="$FAKE_CLI" \
+    "$WRAPPER" "$@"
+}
+
+TIANGONG_REPORT_APIKEY="$SECRET" \
+    run_wrapper '{"query":"isolated report","dry_run":true}' > "$STDOUT" 2> "$STDERR"
+grep -Fx 'report' "$AUDIT_ARGS" >/dev/null
+grep -Fx 'TRACK=1' "$AUDIT_ENV" >/dev/null
+if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'report credential leaked into argv or output' >&2
+    exit 1
+fi
+
+rm -f "$MARKER"
+if run_wrapper "{\"query\":\"blocked\",\"report_api_key\":\"$SECRET\"}" \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'credential-like report JSON was accepted' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+if grep -F "$SECRET" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'rejected report credential was echoed' >&2
+    exit 1
+fi
+
+MANAGED_WORKSPACE="$TEST_ROOT/managed"
+MANAGED_NESTED="$MANAGED_WORKSPACE/nested"
+mkdir -p "$MANAGED_WORKSPACE/.tiangong-research" "$MANAGED_NESTED"
+printf '%s\n' '{"schemaVersion":1,"packageName":"@tiangong-ai/cli","packageVersion":"0.0.30"}' \
+    > "$MANAGED_WORKSPACE/.tiangong-research/runtime-lock.json"
+rm -f "$MARKER"
+if (cd "$MANAGED_NESTED" && run_wrapper '{"query":"systematic report work"}') \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'managed report wrapper bypassed the broker guard' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
+grep -F '"credentialScope":"broker"' "$STDERR" >/dev/null
+grep -F '"networkAttempted":false' "$STDERR" >/dev/null
+
+(cd "$MANAGED_NESTED" && \
+    TIANGONG_REPORT_APIKEY="$SECRET" \
+    run_wrapper '{"query":"isolated report","execution_mode":"standalone","dry_run":true}') \
+    > "$STDOUT" 2> "$STDERR"
+grep -F 'STANDALONE_MODE_SELECTED' "$STDERR" >/dev/null
+grep -F '"credentialScope":"ambient-or-explicit-owner-env"' "$STDERR" >/dev/null
+if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'explicit report standalone mode leaked a credential' >&2
+    exit 1
+fi
+
+echo 'tiangong-kb-report-search wrapper tests passed'

--- a/tiangong-kb-sci-search/SKILL.md
+++ b/tiangong-kb-sci-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-kb-sci-search
-description: Search the owner-authorized Tiangong knowledge-base SCI source for academic papers, journal evidence, literature support, and research claims. Use directly through the Tiangong CLI wrapper, or as a locked JSON POST evidence capability in Tiangong Auto Research. Searches only `sci`, never report or patent sources.
+description: Perform one isolated owner-requested SCI search outside Tiangong Auto Research, or provide SCI method guidance when Auto Research discovery invokes the locked broker capability. Searches only `sci`. If an ancestor contains `.tiangong-research` and the request is open-ended, multi-source, analytical, builds on prior outputs, or produces a conclusion/artifact, route to `tiangong-auto-research` and do not execute this standalone wrapper. Inside a managed workspace, standalone use requires the user's explicit isolated-query request and `execution_mode=standalone`.
 ---
 
 # Tiangong KB SCI Search
@@ -12,8 +12,10 @@ service failure; do not try to bypass it.
 
 ## Choose the execution mode
 
-- For a direct standalone search, use `scripts/sci_search.sh` as described
-  below.
+- For a direct standalone search outside a managed workspace, use
+  `scripts/sci_search.sh` as described below. Inside a managed workspace, only
+  an explicit user-requested isolated query may set
+  `"execution_mode":"standalone"`; the wrapper records a non-secret mode event.
 - Inside a Tiangong Auto Research discovery package, do **not** execute this
   script or its CLI/curl examples. Use locked capability ID
   `database.tiangong.sci-search` through `fetch_candidate_source`. The broker
@@ -22,10 +24,12 @@ service failure; do not try to bypass it.
 
 ## Direct-search prerequisites
 
-- The wrapper defaults to
-  `npx --yes @tiangong-ai/cli@0.0.24`. Set `TIANGONG_AI_CLI_BIN` to one exact
-  executable path, or `TIANGONG_AI_CLI` to an explicitly reviewed command, only
-  when overriding it intentionally.
+- The standalone wrapper defaults to its separately tested CLI version
+  `0.0.30`. This is not the Auto Research workspace runtime. Managed research
+  resolves its exact version from `runtime-lock.json` and must use the broker.
+  Set `TIANGONG_AI_CLI_BIN` to one exact executable path, or
+  `TIANGONG_AI_CLI` to an explicitly reviewed command, only when overriding the
+  standalone entrypoint intentionally.
 - Put the source-specific key in `TIANGONG_SCI_APIKEY`, or use
   `TIANGONG_AI_APIKEY` as the common fallback. Credentials are never accepted in
   wrapper JSON, a request file, or CLI arguments.
@@ -49,7 +53,7 @@ export TIANGONG_SCI_APIKEY='owner-authorized key'
 The wrapper invokes the pinned CLI equivalent of:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.24 research search \
+npx --yes @tiangong-ai/cli@0.0.30 research search \
   --query <query> --sources sci --json
 ```
 
@@ -107,6 +111,8 @@ password, or unrelated secret in this file.
 - `query`, `input`, or `claim`;
 - `request_file` or `input_file`;
 - `env_file`;
+- `execution_mode`, only `standalone` and only after an explicit isolated-query
+  request when a managed workspace is detected;
 - `filter`, `datefilter`, `topK`, `extK`, `getMeta`;
 - `top_k`, `ext_k`, `get_meta` in query mode;
 - `sources`, only `sci` or `default`;

--- a/tiangong-kb-sci-search/agents/openai.yaml
+++ b/tiangong-kb-sci-search/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong KB SCI Search"
-  short_description: "Search an authorized Tiangong SCI database"
-  default_prompt: "Use $tiangong-kb-sci-search to search only the owner-authorized Tiangong SCI source without exposing credentials."
+  short_description: "Run one isolated authorized SCI search"
+  default_prompt: "Use $tiangong-kb-sci-search only for one explicitly isolated owner-authorized SCI query; route systematic work in an Auto Research workspace through $tiangong-auto-research and its broker."

--- a/tiangong-kb-sci-search/scripts/sci_search.sh
+++ b/tiangong-kb-sci-search/scripts/sci_search.sh
@@ -7,13 +7,14 @@ umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
+STANDALONE_TESTED_CLI_VERSION="0.0.30"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx --yes @tiangong-ai/cli@0.0.24)
+    CLI_COMMAND=(npx --yes "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION")
 fi
 
 if [ -z "$JSON_INPUT" ]; then
@@ -38,6 +39,45 @@ contains_sensitive_json() {
 if echo "$JSON_INPUT" | contains_sensitive_json; then
     echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
     exit 2
+fi
+
+EXECUTION_MODE=$(echo "$JSON_INPUT" | jq -r '.execution_mode // empty')
+case "$EXECUTION_MODE" in
+    ""|"standalone")
+        ;;
+    *)
+        printf '%s\n' '{"error":{"code":"INVALID_EXECUTION_MODE","message":"execution_mode must be standalone when explicitly supplied.","details":{"executionMode":"invalid","credentialScope":"none","networkAttempted":false,"minimumAction":"Remove execution_mode or set it to standalone for one isolated owner-requested query."}}}' >&2
+        exit 2
+        ;;
+esac
+
+find_auto_research_workspace() {
+    local search_dir
+    local lock_path
+    local parent_dir
+    search_dir="$(pwd -P)"
+    while :; do
+        lock_path="$search_dir/.tiangong-research/runtime-lock.json"
+        if [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+            return 0
+        fi
+        parent_dir="$(dirname "$search_dir")"
+        if [ "$parent_dir" = "$search_dir" ]; then
+            return 1
+        fi
+        search_dir="$parent_dir"
+    done
+}
+
+if find_auto_research_workspace; then
+    if [ "$EXECUTION_MODE" != "standalone" ]; then
+        printf '%s\n' '{"error":{"code":"AUTO_RESEARCH_BROKER_REQUIRED","message":"An Auto Research workspace was detected. Systematic research must call SCI through the locked discovery broker.","details":{"source":"sci","executionMode":"managed-workspace","credentialScope":"broker","networkAttempted":false,"minimumAction":"Route to tiangong-auto-research. Use execution_mode=standalone only after the user explicitly narrows the task to one isolated SCI query."}}}' >&2
+        exit 2
+    fi
+fi
+
+if [ "$EXECUTION_MODE" = "standalone" ]; then
+    printf '%s\n' '{"event":{"code":"STANDALONE_MODE_SELECTED","source":"sci","executionMode":"standalone","credentialScope":"ambient-or-explicit-owner-env","networkAttempted":false}}' >&2
 fi
 
 jq_value() {

--- a/tiangong-kb-sci-search/scripts/test-sci-search.sh
+++ b/tiangong-kb-sci-search/scripts/test-sci-search.sh
@@ -48,6 +48,35 @@ if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
     exit 1
 fi
 
+MANAGED_WORKSPACE="$TEST_ROOT/managed-workspace"
+MANAGED_NESTED="$MANAGED_WORKSPACE/nested/path"
+mkdir -p "$MANAGED_WORKSPACE/.tiangong-research" "$MANAGED_NESTED"
+printf '%s\n' '{"schemaVersion":1,"packageName":"@tiangong-ai/cli","packageVersion":"0.0.30"}' \
+    > "$MANAGED_WORKSPACE/.tiangong-research/runtime-lock.json"
+rm -f "$MARKER"
+if (cd "$MANAGED_NESTED" && run_wrapper '{"query":"managed query"}') \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'managed workspace bypassed the Auto Research broker guard' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
+grep -F '"credentialScope":"broker"' "$STDERR" >/dev/null
+grep -F '"networkAttempted":false' "$STDERR" >/dev/null
+
+(cd "$MANAGED_NESTED" && \
+    TIANGONG_SCI_APIKEY="$SECRET" \
+    run_wrapper '{"query":"isolated query","execution_mode":"standalone","dry_run":true}') \
+    > "$STDOUT" 2> "$STDERR"
+grep -F 'STANDALONE_MODE_SELECTED' "$STDERR" >/dev/null
+grep -F '"executionMode":"standalone"' "$STDERR" >/dev/null
+grep -F '"credentialScope":"ambient-or-explicit-owner-env"' "$STDERR" >/dev/null
+grep -F '"networkAttempted":false' "$STDERR" >/dev/null
+if grep -F "$SECRET" "$AUDIT_ARGS" "$STDOUT" "$STDERR" >/dev/null; then
+    echo 'explicit standalone mode leaked a credential' >&2
+    exit 1
+fi
+
 rm -f "$MARKER"
 if run_wrapper "{\"query\":\"blocked\",\"sci_api_key\":\"$SECRET\"}" \
     > "$STDOUT" 2> "$STDERR"; then


### PR DESCRIPTION
Closes #57
Parent: https://github.com/tiangong-ai/workspace/issues/114

## Outcome

- makes open-ended Chinese/English and managed-workspace research route to `tiangong-auto-research` before individual source Skills;
- adds a fail-closed Node resolver that launches only the exact stable `@tiangong-ai/cli` version in regular non-symlink `runtime-lock.json`;
- blocks SCI/report/patent standalone wrappers inside managed workspaces unless the user explicitly selected one isolated `execution_mode=standalone` operation;
- records non-secret standalone mode diagnostics and hardens report/patent credential, env-file, URL, request-file, and atomic-output boundaries;
- removes stale exact CLI literals from the orchestrator tree, regenerates OpenAI interface metadata, and adds deterministic routing/resolver/wrapper tests.

## Validation

- `node tiangong-auto-research/scripts/test-research-cli.mjs`
- `node tiangong-auto-research/scripts/test-routing-contract.mjs`
- `bash tiangong-auto-research/scripts/test-agent-wrapper-posix.sh`
- SCI/report/patent wrapper test scripts
- skill-creator `quick_validate.py` for all four changed Skills using isolated `PyYAML==6.0.3`
- `../scripts/docpact validate-config --root . --strict`
- `../scripts/docpact lint --root . --files <complete changed set> --format json`
- `git diff --check`

## Risk and rollback

The standalone guard is intentionally fail-closed in a managed workspace and removes credential fields from report/patent JSON. An explicit isolated query remains available with owner environment credentials. Roll back by reverting this PR and restoring the previous exact Skills pin; no workspace broker secrets are migrated or exposed.