### PR TITLE
feat(auto-research): use native host for producer stages

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-09"
-lastReviewedCommit: "ca8ed0942820edc590700100ab4f0e41c166fec3"
+lastReviewedAt: "2026-08-10"
+lastReviewedCommit: "20d4fbb8ffd35af110675f47a66b510d26577453"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cb50e5c352fee5349e29a9d08b81a7bc05644452
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: ca8ed0942820edc590700100ab4f0e41c166fec3
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-auto-research
-description: Orchestrate open-ended, multi-source, evidence-backed research, especially when an ancestor directory contains `.tiangong-research` or the user asks to research, investigate, build on prior outputs, compare evidence, form a conclusion, or produce a reviewed research artifact. Also use for setup, preflight, execution, recovery, review, and closure. In an Auto Research workspace this Skill takes precedence over individual web, news, SCI, report, patent, download, or document Skills unless the user explicitly requests one isolated standalone operation outside the research workflow. Covers Chinese requests such as “研究一下”, “朝这个方向做一做”, “结合已有成果继续研究”, “查资料并形成结论”, and “系统梳理证据”.
+description: Orchestrate open-ended, multi-source, evidence-backed research in the current native Codex or Claude Code host, especially when an ancestor directory contains `.tiangong-research` or the user asks to research, investigate, build on prior outputs, compare evidence, form a conclusion, or produce a reviewed research artifact. Also use for setup, preflight, native producer execution, recovery, independent review, and closure. In an Auto Research workspace this Skill takes precedence over individual web, news, SCI, report, patent, download, or document Skills unless the user explicitly requests one isolated standalone operation outside the research workflow. Covers Chinese requests such as “研究一下”, “朝这个方向做一做”, “结合已有成果继续研究”, “查资料并形成结论”, and “系统梳理证据”.
 ---
 
 # Tiangong Auto Research
@@ -21,10 +21,11 @@ reviewed exact bootstrap CLI version. Never substitute `latest`, a range, a
 tag, a path, or a command fragment. After setup creates the runtime lock, use
 the resolver above.
 
-The CLI owns the setup catalog, immutable setup plan, capability policy, output
-schemas, coverage gates, budgets, retries, evidence promotion, review, and
-closure. Do not reproduce those contracts in an agent prompt or edit control
-files by hand.
+The CLI is the deterministic control plane: it owns setup, locks, brokered
+evidence, schemas, coverage, budgets, admission, the independent review process,
+the journal, and closure. The current interactive Codex or Claude Code session
+owns producer reasoning. The CLI must never launch a nested producer process.
+Do not reproduce control-plane contracts or edit control files by hand.
 
 ## Route to the right reference
 
@@ -36,6 +37,8 @@ files by hand.
   agent authentication, provider checks, or wrappers.
 - Read [references/production-research.md](references/production-research.md)
   before production preflight, execution, recovery, or closure.
+- Read [references/native-execution.md](references/native-execution.md) before
+  preparing or submitting discover, analyze, or synthesize stages.
 
 ## Choose the mode before spending budget
 
@@ -102,20 +105,26 @@ required credentials must block before any source download.
   analysis, review, or closure.
 - For PPT creation, prefer `hugohe3.ppt-master`. Keep `anthropic.pptx` as a
   compatible situational option; both may be selected explicitly in one plan.
+- Selected optional preprocessors, acquisition adapters, and authoring Skills
+  remain visible diagnostics. They become hard gates only when the current
+  project lists them in `requiredCompanionIds` or explicitly invokes that
+  operation. Their failure never authorizes a standalone evidence downgrade.
 
 ## Preflight and initialize a project
 
 Prepare evidence requirements with `dimensions`, `sourceTypes`,
-`requiredCapabilityIds`, `requiredDiscoveryScopes`, `minSources`,
-`minFullTextSources`, `minDatedSources`, and nullable date bounds. Require each
-owner database that the question must actually exercise; Brave or local files
-cannot mask an undeclared report, patent, or other whitelisted capability. For
-large local sources, create an immutable input plan with bounded context files
-or ranges.
+`requiredCapabilityIds`, `requiredCompanionIds`, `requiredDiscoveryScopes`,
+`minSources`, `minFullTextSources`, `minDatedSources`, and nullable date bounds.
+Require each owner database that the question must actually exercise; Brave or
+local files cannot mask an undeclared report, patent, or other whitelisted
+capability. For large local sources, create an immutable input plan with bounded
+context files or ranges.
 
 First require the current setup generation and its real production checks to
-pass. One setup doctor invocation performs the nested workspace/capability and
-agent capsule smokes, so do not repeat paid smokes unnecessarily:
+pass. Doctor probes required capabilities once, then runs only the independent
+reviewer CLI smoke after all blocking zero/low-cost checks pass. It reuses an
+unexpired attestation and never smoke-tests the current native producer as a
+child process:
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
@@ -127,8 +136,9 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   --agent-smoke --confirm-agent-smoke-cost --json
 ```
 
-Stop unless readiness is `READY`. An explicitly requested smoke failure is
-`BLOCKED`, not advisory.
+Stop unless `researchReadiness` is `READY` and every companion explicitly
+required by this project or operation is `READY`. Keep degraded optional domains
+visible, but do not block unrelated research or weaken evidence coverage.
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
@@ -154,9 +164,9 @@ initialization.
 ## Validate, run, and recover
 
 Production requires explicit models/prices, different producer and reviewer
-agent families, a current setup doctor report, and real capsule/provider smoke
-attestations. After successful preflight and initialization, use dry-run before
-the paid run:
+agent families, a current setup doctor report, and real provider/reviewer
+attestations. After preflight, use dry-run, then let the control plane identify
+the next action:
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
@@ -168,6 +178,14 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   --max-cycles 20 --progress-jsonl --json
 ```
 
+For `native-stage-required`, do not keep calling `research run`. Prepare the
+exact next stage, perform the returned prompt in this current app/session, and
+submit its JSON through the CLI. Discovery evidence must be fetched through the
+packet's broker command. Repeat for discover, analyze, and synthesize. Only then
+may `research run` launch the configured independent reviewer and perform
+mechanical closure. Follow [references/native-execution.md](references/native-execution.md)
+for the exact commands and recovery rules.
+
 Proceed only when doctor reports ready. Discovery uses only locked broker
 capabilities; later stages are tool-free. Doctor, preflight, dependency,
 provider, and evidence-coverage failures must stop the workflow. Never silently
@@ -175,8 +193,9 @@ downgrade a systematic task to a standalone SCI, report, patent, web, or paper
 operation; only the user may explicitly narrow the request to one isolated
 standalone operation.
 
-Inspect state with `research status`. Use `research project retry` or
-`research project fork` only with explicit user direction; do not reset or
-delete state. A complete project has a passing independent review,
-`outputs/report.md`, and `outputs/closure.json`. Return the permanent evidence
-locators, review-packet binding, usage/cost, decision, and material limitations.
+Inspect state with `research status`. Use the exact native stage `abort`,
+`research project retry`, or `research project fork` only with explicit user
+direction; do not reset or delete state. A complete project has a passing
+independent review, `outputs/report.md`, and `outputs/closure.json`. Return the
+permanent evidence locators, review-packet binding, usage/cost, decision, and
+material limitations.

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Orchestrate reviewed multi-source research"
-  default_prompt: "Use $tiangong-auto-research for this open-ended or multi-source research task, resolve the exact CLI from the workspace runtime lock, verify required capabilities and budget, and stop on every unmet production gate."
+  short_description: "Run native-host research with independent review"
+  default_prompt: "Use $tiangong-auto-research for this open-ended or multi-source research task. Resolve the exact CLI from the workspace runtime lock, verify required capabilities and budget, perform producer stages in this current native host, and use the other agent family only for independent review."

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -6,21 +6,22 @@
   workspace runtime lock and the setup-pinned `skills@1.5.22` package. A clean
   directory needs one user-reviewed exact bootstrap CLI version before that
   lock exists; never infer `latest` for an existing workspace.
-- Authenticated `codex` and `claude` executables for the configured producer and
-  reviewer routes.
+- A current interactive Codex or Claude Code producer host plus an authenticated
+  executable for the other-family independent reviewer route.
 - macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`).
 - Python 3.10+ only for selected Python-based companions. Setup reports missing
   Python dependencies but never installs them.
 
-Authenticate agent CLIs through their normal interactive login outside the
+Authenticate the reviewer CLI through its normal interactive login outside the
 research workspace. Do not copy browser profiles, keychains, full agent HOME
-directories, cookies, passwords, or session tokens into a workspace. The
-runtime creates a capsule HOME and copies/extracts only its documented minimal
-agent authentication material.
+directories, cookies, passwords, or session tokens into a workspace. Native
+producer preparation does not copy host authentication. Reviewer runtime creates
+a capsule HOME and copies/extracts only its documented minimal authentication
+material.
 
-Production doctor must run real agent and capability smokes before a costly
-package. These checks may use quota and therefore require explicit flags and
-cost confirmation.
+Production doctor must run real capability checks and a reviewer smoke before a
+costly review package. These checks may use quota and therefore require explicit
+flags and cost confirmation. It never launches the current native producer.
 
 ## Setup credential input
 
@@ -130,13 +131,13 @@ audit event and still cannot read the broker store. Setup maps the owner
 variable to logical ID `tiangong.sci.api-key`; discovery sends a non-secret
 POST `request_body` to the broker, which injects `x-api-key` for the exact host.
 
-## Agent wrappers and capsule authentication
+## Reviewer wrappers and capsule authentication
 
 The tested macOS/Linux template is
 `scripts/agent-wrapper-posix.sh`; validate it with
-`scripts/test-agent-wrapper-posix.sh`. A custom route must use absolute paths,
-an immutable wrapper for the run, explicit model ID and prices, and the real
-target binary:
+`scripts/test-agent-wrapper-posix.sh`. A custom reviewer route must use absolute
+paths, an immutable wrapper for the run, explicit model ID and prices, and the
+real target binary:
 
 ```json
 {
@@ -150,8 +151,8 @@ target binary:
 ```
 
 The CLI sets `TIANGONG_RESEARCH_AGENT_BINARY`; do not set or forward it
-yourself. Doctor attests target, wrapper, internal adapter, OS, and architecture
-and invalidates the attestation after relevant drift.
+yourself. Doctor attests the reviewer target, wrapper, internal adapter, OS, and
+architecture and invalidates the attestation after relevant drift.
 
 For Claude, the runtime does not copy an owner `settings.json`. It extracts only
 documented authentication values and a credential-free HTTPS base URL from the
@@ -159,10 +160,11 @@ supported environment object; hooks, permissions, extra directories, and other
 settings are excluded. On macOS, credentials held in the system keychain stay
 in the keychain.
 
-The outer sandbox is the execution boundary. Discovery has no shell or ambient
-filesystem/network access and can call only the scoped broker. Analyze,
-synthesize, and review are tool-free.
+The current host application is the producer execution boundary. Discovery
+uses only the CLI's hash-bound one-shot broker command for admitted evidence;
+analyze and synthesize use prepared bounded context and gather no new evidence.
+The outer CLI sandbox applies to independent review, which is tool-free.
 
-Codex also receives a capsule-local project-root marker override. Its project
-configuration walk stops inside the capsule and never requires read access to a
-parent workspace `.codex/config.toml`.
+When Codex is the reviewer, it receives a capsule-local project-root marker
+override. Its project configuration walk stops inside the capsule and never
+requires read access to a parent workspace `.codex/config.toml`.

--- a/tiangong-auto-research/references/external-skills.md
+++ b/tiangong-auto-research/references/external-skills.md
@@ -39,10 +39,11 @@ explicit operator choice.
 `tiangong.auto-research` installs the separately sourced
 `tiangong-auto-research` Skill. Its role is `orchestrator`: it routes ordinary
 research requests through context resolution, setup/status/doctor, preflight,
-initialization, dry-run, execution, review, and closure. It is not an evidence
-source and receives no provider credential. The Wizard recommends a
-project-local copy but asks for explicit confirmation; automation selects it
-with `--skills tiangong.auto-research`.
+initialization, native-host producer stages, independent review, and closure.
+It is instruction/control-plane guidance, not a nested producer launcher. It is
+not an evidence source and receives no provider credential. The Wizard
+recommends a project-local copy but asks for explicit confirmation; automation
+selects it with `--skills tiangong.auto-research`.
 
 ## Evidence capabilities
 
@@ -74,8 +75,9 @@ returned as actionable failures rather than holding the agent call open. The
 journal records only sanitized response metadata and a safe request ID; it
 never records the raw target or credentials.
 
-Do not run a staged Skill's shell/curl examples inside a research capsule. Agent
-processes never receive provider credentials. Authentication, authorization,
+Do not run a staged Skill's shell/curl examples from the native producer.
+Evidence requests must use the prepared one-shot broker command. Agent processes
+never receive provider credentials. Authentication, authorization,
 subscription, deterministic 4xx, unsafe response type, and source drift stop
 execution; no source or login barrier may be bypassed.
 
@@ -119,7 +121,7 @@ that workflow a better fit. Setup does not auto-select either Skill.
 
 | Logical configuration | Required when | How to obtain/configure |
 | --- | --- | --- |
-| `brave.search.api-key` | Any Brave profile | Create a key through the normal Brave Search API account flow; give setup only the environment variable name. |
+| `brave.search.api-key` | Any Brave profile | Create a key through the normal Brave Search API account flow; enter it with the Wizard's hidden prompt, preload it from a password manager/stdin, or bind an owner environment variable. |
 | `tiangong.sci.api-key` | Tiangong SCI selected | Ask the owner of the authorized deployment; do not reuse browser/session credentials. |
 | `tiangong.sci.endpoint`, `tiangong.sci.region` | Tiangong SCI selected | Review the exact HTTPS endpoint and non-secret region shown by the Wizard. |
 | `tiangong.unstructure.auth-token` | Document preprocessing selected | Ask the deployment owner; stored only in the adapter credential store. |
@@ -128,8 +130,9 @@ that workflow a better fit. Setup does not auto-select either Skill.
 | `unpaywall.contact-email` | Optional | A real contact email, stored as a non-secret setting. |
 
 No key is accepted as a command argument, JSON request field, manifest value, or
-chat value. Setup's `credential set` command reads a named owner environment
-variable and returns only the logical ID and storage class.
+chat value. Setup's `credential set` command uses hidden TTY input, bounded
+stdin, or a named owner environment variable and returns only the logical ID and
+storage class.
 
 ## Status and live checks
 
@@ -141,15 +144,25 @@ presence:
 - `drifted`: bytes differ; do not re-lock or overwrite them;
 - `blocked`: path, symlink, permissions, dependency, credential, or check
   policy failed;
-- `READY`: every selected required static/live check passed;
-- `PARTIALLY_READY`: deferred optional/cost/network checks remain;
-- `BLOCKED`: a selected required capability or dependency is unusable.
+- `researchReadiness=READY`: research-core, required evidence, and independent
+  review prerequisites passed;
+- optional `preprocessingReadiness`, `acquisitionReadiness`, and
+  `authoringReadiness` may be `DEGRADED` without blocking unrelated research;
+- `overallReadiness=PARTIALLY_READY`: one of those optional domains is degraded;
+- `BLOCKED`: a research-core requirement, or an exact component required by the
+  current project/operation, is unusable.
 
 Live checks are explicit because they use network/quota. A key that passes one
 Brave endpoint does not prove that LLM Context, image, or video access is
 included in the provider plan. The Unstructure live check uploads a generated
 one-page PDF only with its separate confirmation. Agent smoke is separately
 cost-confirmed.
+
+The Semantic Scholar resolver is one optional path inside the acquisition
+adapter's Unpaywall → Semantic Scholar OA → arXiv → browser-handoff sequence. A
+remaining 429 after its one bounded retry degrades acquisition, not global
+research readiness. Requiring the academic adapter gates its exact installation
+and dependencies, not this one resolver as if it were the only legal OA path.
 
 Capability doctor retains only a bounded sanitized provider code/detail and a
 safe request ID. `OPTION_NOT_IN_PLAN` is an operator decision: either create a

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -1,0 +1,104 @@
+# Native producer execution
+
+Discover, analyze, and synthesize are performed by the current interactive
+Codex app/session or Claude Code session. The CLI is not a producer-agent
+launcher. It prepares a hash-bound packet, brokers authorized evidence, admits
+the result, launches the other agent family only for independent review, and
+closes mechanically.
+
+## Identify the next action
+
+Run the control plane after project initialization:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research run --workspace /absolute/path/to/workspace \
+  --project PROJECT --max-cycles 20 --progress-jsonl --json
+```
+
+`stopReason=native-stage-required` means the current host must perform the next
+producer stage. It is not an error and must not trigger a nested `codex exec` or
+`claude -p` call.
+
+## Prepare the exact stage
+
+Use the host agent selected by the immutable setup plan:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project stage prepare PROJECT \
+  --stage discover --host-agent codex \
+  --workspace /absolute/path/to/workspace --json
+```
+
+The returned packet binds the project, stage, inputs, prior outputs, runtime and
+capability locks, schema, model, limits, prompt, and command argument arrays.
+Use the packet verbatim. Do not edit `project.json`, the active session, locks,
+journal, evidence store, or admitted outputs.
+
+Preparation is idempotent while its exact session remains active. If the wrong
+host, stage, model, project state, or hash is observed, stop on the structured
+error.
+
+## Fetch discovery evidence
+
+For each broker request, write one new bounded JSON object matching
+`commands.fetchEvidence.requestSchema`. It contains logical capability and
+credential IDs, never credential values. Invoke the returned argv, replacing
+only the request-file placeholder:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence fetch PROJECT \
+  --request /absolute/path/to/request.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Use only the returned bounded context and exact receipt fields. The broker
+enforces the locked endpoint/method/Accept policy, injects owner credentials,
+limits calls/bytes/items/tokens, persists content-addressed raw evidence, and
+records sanitized events. Standalone web/search/database tools cannot replace
+required broker receipts.
+
+## Submit producer output
+
+Save only the schema-conforming JSON object to a new regular non-symlink file.
+Then use the packet's exact session and expected model:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project stage submit PROJECT \
+  --session SESSION_ID \
+  --output /absolute/path/to/stage-output.json \
+  --confirm-model EXPECTED_MODEL \
+  --workspace /absolute/path/to/workspace --json
+```
+
+File existence is not success. Submit rechecks the session and all bindings,
+parses the authoritative schema, validates provenance and coverage, enforces
+byte/token/wall/cost reservations, computes hashes, writes a run record, and
+atomically promotes the output. Native-host usage is conservatively charged at
+the reviewed package reservation because the host app does not expose trusted
+per-stage usage telemetry to the CLI.
+
+A rejected submission leaves the active session intact so the current host can
+perform a bounded formatting correction or gather missing authorized evidence.
+It does not silently retry research or invoke another model.
+
+## Continue, review, or abort
+
+After each successful submit, call `research run` again. Prepare/submit the
+next native producer stage until synthesize completes. The same run command may
+then launch only the configured independent reviewer CLI and, after a passing
+review, perform mechanical closure.
+
+To discard an active native session explicitly:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project stage abort PROJECT --session SESSION_ID \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Abort removes only that CLI-created runtime capsule and active session. It
+consumes the prepared attempt and never deletes admitted evidence or outputs.

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -15,9 +15,12 @@ AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/res
 Start from the user-selected workspace's current immutable setup generation.
 Run `research setup status`, then one explicitly cost-confirmed
 `research setup doctor --live --agent-smoke --confirm-agent-smoke-cost` before
-project preflight. That command performs the nested capability and agent capsule
-smokes; do not repeat paid smokes without a reason. Any requested smoke failure
-must leave setup `BLOCKED`.
+project preflight. That command probes each required capability once and starts
+only the independent reviewer CLI smoke, after every blocking zero/low-cost
+prerequisite passes. It never starts the current native producer as a child.
+Do not repeat paid smokes without a reason. Continue when
+`researchReadiness=READY`; optional domain degradation blocks only a project or
+operation that explicitly requires the exact component.
 
 Before `project init`, record and show the user:
 
@@ -46,18 +49,18 @@ and the underlying absolute agent path in `wrapperTargetBinary`; never use a
 wrapper with an unpinned PATH lookup. The runtime separately records the target
 binary, route launcher/wrapper, and internal adapter SHA-256 values, plus the
 reported version, actual/configured model, OS, and architecture.
-`workspace doctor --agent-smoke` executes both routes in real capsules and
-writes a 24-hour attestation bound to those runtime fingerprints, workspace
-config, capability lock, and doctor schema. Expiry or drift blocks execution
-before the next agent invocation. During that validity window, plain
-`workspace doctor` rechecks all bound hashes and fingerprints the currently
-resolved producer/reviewer runtimes before reusing the attested agent and
-capability smoke results. Use explicit smoke flags to refresh the checks;
-missing, expired, or drifted attestations never receive an implicit pass.
+The producer route must declare `executionMode=native-host`; the reviewer route
+must declare `executionMode=headless-cli`. `workspace doctor --agent-smoke`
+executes only the reviewer in a real capsule and writes a 24-hour attestation
+bound to its runtime fingerprints, workspace config, capability lock, and
+doctor schema. Expiry or drift blocks review before invocation. During that
+validity window, plain `workspace doctor` rechecks all bound hashes and the
+resolved reviewer runtime before reuse. Use explicit smoke flags to refresh the
+check; missing, expired, or drifted attestations never receive an implicit pass.
 
-Within one package, a formatting repair may reuse the capsule-local agent auth
-copy only when it remains a regular owner-only file whose SHA-256 matches the
-owner source. Authentication drift stops the package; setup/runtime never
+Within a reviewer package, a formatting repair may reuse the capsule-local agent
+auth copy only when it remains a regular owner-only file whose SHA-256 matches
+the owner source. Authentication drift stops the package; setup/runtime never
 overwrite the capsule copy or silently choose another credential.
 
 The budget includes:
@@ -75,34 +78,25 @@ discovery package ceiling; analyze, synthesize, and review default to 60,000,
 4,000. These values are admission ceilings, not a target spend. Lower them only
 when preflight proves every complete reservation still fits.
 
-The CLI will not start a package unless its full token and conservative price
-reservation fits. Immediately before each call it accounts for prompt and
-schema bytes at three bytes per token, agent-specific protocol overhead,
-input repeated for every permitted API turn, the maximum bounded broker context
-for every permitted discovery turn, primary output, and a possible isolated
-repair's input and output. The provider cost cap is derived from that package
-reservation, not the project's remaining global allowance. Tool-free Codex
-primary stages reserve two protocol turns. Claude JSON Schema primary stages
-reserve and receive a three-turn provider cap, matching the current Claude Code
-structured-output exchange; external tools remain disabled. The
-repair path omits the provider schema tool, requests plain JSON in one turn,
-and still passes through the same CLI validators.
-Current Codex and Claude CLI adapters expose final output usage only after the
-call. Preflight therefore reports `outputTokenLimitEnforcement` as
-`post-execution`: captured bytes bound the process, and an over-limit result is
-rejected without promotion, but the limit is not a provider-side hard stop.
-Discovery capture allowance includes bounded broker tool-result events as well
-as the requested final output. Preflight and runtime share the reservation
-calculator, including the complete bounded capability-documentation allowance.
-The broker separately enforces at most six provider fetch calls per discovery
-run and returns the remaining call budget after each success.
-Reserve enough output for the discover schema and enough input context for the
-embedded prior-stage artifacts; preflight reports both gaps mechanically.
-It also reports per-stage `maxTurns` and route-specific
-`turnLimitEnforcement`. Claude receives its cap from the provider CLI. The
-current Codex CLI has no turn-limit flag, so its value is a conservative
-reservation assumption followed by actual-usage rejection; do not describe it
-as a provider hard stop.
+The CLI will not prepare or launch a package unless its full token and
+conservative price reservation fits. Native producer preparation reserves the
+prompt, schema, admitted input/prior-stage context, bounded broker allowance,
+and output ceiling. Because the current host app does not expose trusted
+per-stage usage telemetry to this control plane, successful submit charges the
+entire reviewed package reservation and records
+`accountingMode=reserved-native-host`. The submit boundary still rejects an
+oversized, invalid, stale, or over-budget result before promotion. Do not
+describe native-host turns or output tokens as provider-side hard limits.
+
+The independently launched reviewer retains pre-call prompt/schema/output and
+repair reservations plus provider-side structured-output/turn controls where
+the selected CLI supports them. Its formatting repair requests plain JSON in
+one tool-free turn and passes through the same validators. Preflight and runtime
+share the review-context reservation formula. The broker separately enforces at
+most six provider fetch calls across native discovery and returns the remaining
+call budget after each success. Reserve enough output for every producer schema
+and enough input context for prior-stage artifacts; preflight reports both gaps
+mechanically.
 
 ## Bounded local evidence
 
@@ -132,10 +126,10 @@ type, full-text claim, publication date, and either:
 }
 ```
 
-The producer receives only the derived bounded context. The full, hash-verified
-source is withheld until independent review and is then listed in the review
-packet. The CLI rejects symlinks, duplicate source content, overlapping or
-out-of-range slices, changed hashes, and aggregate context above
+The native producer packet contains only the derived bounded context. The full,
+hash-verified source is withheld until independent review and is then listed in
+the review packet. The CLI rejects symlinks, duplicate source content,
+overlapping or out-of-range slices, changed hashes, and aggregate context above
 `maxInputContextTokens`. Declaring `fullText: true` means the exact full file is
 registered for review; it does not expose that entire file to discovery.
 
@@ -158,12 +152,16 @@ an excerpt or JSON Pointer, quality rationale, applicability, and covered
 dimensions. The CLI verifies input locators and every broker object. Findings
 may cite only admitted source IDs.
 
-Codex receives `--output-schema`; Claude receives `--json-schema`. The CLI
-validates the final object and materializes it atomically. Invalid syntax or
-schema, or a mechanically diagnosed invalid provenance/finding binding, gets
-one low-budget formatting-only repair with no broker access or research tools.
-The repair may not add facts. A second failure stops the package instead of
-repeating the research call.
+For discover, analyze, and synthesize, `research project stage prepare` returns
+the authoritative schema and exact prompt to the current native host. Save one
+JSON object and pass it to `research project stage submit`; submit validates and
+materializes it atomically. A rejected native submission preserves the bound
+session for an explicit host correction and never launches a nested repair
+agent. For review, Codex receives `--output-schema` or Claude receives
+`--json-schema`; invalid reviewer syntax/schema or a mechanically diagnosed
+binding gets one low-budget formatting-only repair with no broker or research
+tools. The repair may not add facts. A second reviewer failure stops instead of
+repeating research.
 
 ## Broker evidence
 
@@ -263,14 +261,16 @@ called from one that was called but yielded no admissible receipt; the latter
 reports only sanitized failure kinds such as `rate-limit`, never request URLs or
 credentials.
 
-Discovery receives no shell or filesystem tools. The CLI embeds the locked
-capability manifest and each staged external Skill's top-level `SKILL.md`, and
-the scoped broker is its only execution tool. Broker results include the exact
-bounded view inline with the receipt. Analyze embeds the admitted evidence
-object; synthesize embeds admitted evidence and analysis. Both stages run with
-tools disabled. Review is also tool-free and embeds generated artifacts plus
-deterministic excerpts from bounded local/broker evidence views within the
-reviewer's route-specific structured-output turn cap. Preflight and runtime reserve the same
+Native discovery receives a packet containing the locked capability manifest
+and each staged external Skill's top-level `SKILL.md`. The current host must use
+the packet's `research project evidence fetch` argv for admitted network
+evidence; standalone web/search/database tools cannot replace required broker
+receipts. Broker results include the exact bounded view inline with the receipt.
+Analyze receives the admitted evidence object; synthesize receives evidence and
+analysis. Neither stage may gather new evidence. Review is tool-free and embeds
+generated artifacts plus deterministic excerpts from bounded local/broker
+evidence views within the reviewer's route-specific structured-output turn cap.
+Preflight and runtime reserve the same
 stage-specific ceiling: three maximum-size generated artifacts plus one
 `maxInputContextTokens` excerpt bundle. The complete packet, full files,
 original bounded contexts, and raw objects remain hash-bound for later
@@ -320,6 +320,11 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 The top-level result and run-level JSONL events then carry that `projectId`, and
 historical blocked siblings do not change its exit code. Omit `--project` only
 when the operator intends to schedule and summarize the whole workspace.
+`stopReason=native-stage-required` is the normal producer handoff: follow
+[native-execution.md](native-execution.md) to prepare and submit discover,
+analyze, and synthesize in the current host. Calling `research run` after
+synthesis may launch only the independently configured reviewer CLI and then
+close mechanically.
 
 ## Standard zero-cost eval before a real canary
 
@@ -333,6 +338,8 @@ Confirm the owning CLI release passed deterministic mock coverage for:
   local-only production rejection;
 - routing and smoke/production mode boundaries;
 - discover → analyze → synthesize → review → close;
+- public `research run` never launching a producer subprocess, with native
+  prepare/fetch/submit advancing the three producer stages;
 - permanent evidence and review-packet hash verification;
 - persistent bounded review-context verification and packet/context tamper
   rejection before closure;
@@ -340,16 +347,19 @@ Confirm the owning CLI release passed deterministic mock coverage for:
 - invalid provenance/finding binding repair without repeating research;
 - 429, deterministic 4xx/422, 5xx, redirect, oversized response, cache, and
   bounded offset extraction with raw-object reuse;
-- capsule HOME/sandbox startup and evidence/journal recovery;
-- bounded local producer context with full-source reviewer staging;
-- broker-only discovery with embedded locked Skill documentation and tool-free
-  analyze/synthesize/review stages;
+- reviewer capsule HOME/sandbox startup and evidence/journal recovery;
+- bounded native producer context with full-source reviewer staging;
+- explicit native broker discovery with embedded locked Skill documentation,
+  no new evidence in analyze/synthesize, and tool-free review;
 - a broker result larger than the historical 64 KiB capture floor;
 - capability drift and evidence tampering;
 - insufficient evidence blocking closure;
 - secret redaction across output, provider telemetry, errors, progress,
-  journal, and manifests.
-- project-scoped execution in a workspace containing historical blockers.
+  journal, and manifests;
+- project-scoped execution in a workspace containing historical blockers;
+- research-core readiness surviving optional acquisition/preprocessing
+  degradation, exact companion promotion, one-probe doctor behavior, and paid
+  reviewer smoke suppression after static blockers.
 
 Only then run a bounded real-model canary with reservations that pass preflight.
 Do not infer production readiness from a Crossref-only or single-source smoke

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -32,8 +32,9 @@ The workspace may be any ordinary user-selected directory. Example paths below
 are placeholders, not defaults or repository requirements.
 
 Prerequisites are Node.js 24, `git`, `npx`, an agent-compatible sandbox
-(`/usr/bin/sandbox-exec` on macOS or `bwrap` on Linux), and normal Codex/Claude
-CLI authentication for the routes you intend to use. Create or choose the
+(`/usr/bin/sandbox-exec` on macOS or `bwrap` on Linux) for independent review,
+the current interactive Codex or Claude Code host, and normal authentication for
+the other-family reviewer CLI. Create or choose the
 directory, review one exact stable CLI release, replace `X.Y.Z` below, and
 start the Wizard; ordinary users do not need to export keys. `latest`, tags,
 ranges, paths, and command fragments are not bootstrap versions:
@@ -93,7 +94,8 @@ The Wizard then guides the user through:
 - optional Tiangong companions and post-closure authoring Skills; for PPT
   creation it presents PPT Master as preferred while keeping Anthropic PPTX as
   a compatible situational choice;
-- Codex/Claude install targets and project/global scope;
+- the current native research host (Codex or interactive Claude Code), the
+  other-family reviewer CLI, matching Skill targets, and project/global scope;
 - non-secret endpoints/settings;
 - a source choice for every selected required or optional credential;
 - each pinned source/license notice and explicit acceptance;
@@ -173,15 +175,21 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
 ```
 
 Static doctor checks installed tree hashes, required settings, owner-only
-credential stores, Node/git/npx, sandbox, agent CLIs, Python, and pinned Python
-requirements. `--live` uses provider network/quota. A synthetic document upload
-also requires `--allow-synthetic-unstructure-upload`; model-agent smoke requires
-`--agent-smoke --confirm-agent-smoke-cost`. When one of those explicitly
-requested smoke checks fails, readiness is `BLOCKED`; it is never downgraded to
-an advisory warning. After both production smokes succeed, ordinary workspace
-doctor calls may reuse the unexpired hash-bound attestation only after checking
-the current agent runtime fingerprints. Explicit smoke flags refresh the
-attestation; expiry or drift remains blocking.
+credential stores, Node/git/npx, the reviewer sandbox/CLI, Python, and pinned
+Python requirements. `--live` uses provider network/quota. A synthetic document
+upload also requires `--allow-synthetic-unstructure-upload`; reviewer smoke
+requires `--agent-smoke --confirm-agent-smoke-cost`. Doctor does not launch the
+native producer. It probes a required capability only once and skips the paid
+reviewer smoke when an earlier blocking prerequisite fails.
+
+Read `researchReadiness` for admission. `preprocessingReadiness`,
+`acquisitionReadiness`, and `authoringReadiness` describe optional domains;
+`overallReadiness` may be `PARTIALLY_READY` while unrelated research remains
+ready. An optional component becomes blocking only when the current project or
+operation explicitly requires its exact catalog ID. After the reviewer smoke
+succeeds, ordinary workspace doctor calls may reuse its unexpired hash-bound
+attestation after checking the current reviewer runtime fingerprint. Explicit
+smoke flags refresh it; expiry or drift remains blocking.
 
 On a blocked apply, use the exact `retryCommand` in setup state. Clear a stale
 lock only with both stale-lock flags after confirming no setup process owns it.

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -27,6 +27,8 @@ const descriptions = Object.fromEntries(
 for (const marker of [
   "open-ended",
   "multi-source",
+  "current native",
+  "independent review",
   ".tiangong-research",
   "takes precedence",
   "研究一下",


### PR DESCRIPTION
Closes the Skills portion of tiangong-ai/workspace#116.

- makes the current interactive Codex or Claude Code host authoritative for discover/analyze/synthesize
- documents the hash-bound CLI prepare/fetch/submit control-plane protocol
- scopes optional companion readiness and independent reviewer behavior
- regenerates OpenAI Skill metadata and extends routing validation

Validation:
- routing contract, runtime resolver, POSIX wrapper tests
- skill-creator quick_validate
- docpact 0.1.9 validate/lint
- git diff --check