### PR TITLE
feat(auto-research): document evidence-first workflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-10"
-lastReviewedCommit: "20d4fbb8ffd35af110675f47a66b510d26577453"
+lastReviewedAt: "2026-08-11"
+lastReviewedCommit: "d51cced6a7eade5aba395c5742993089f7878302"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: d51cced6a7eade5aba395c5742993089f7878302
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-10
-lastReviewedCommit: 20d4fbb8ffd35af110675f47a66b510d26577453
+lastReviewedAt: 2026-08-11
+lastReviewedCommit: d51cced6a7eade5aba395c5742993089f7878302
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -183,10 +183,13 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 For `native-stage-required`, do not keep calling `research run`. Prepare the
 exact next stage, perform the returned prompt in this current app/session, and
 submit its JSON through the CLI. Discovery evidence must be fetched through the
-packet's broker command; acquisition must bind every exact selected file through
-the packet's artifact registry. Repeat for discover, acquire, analyze, and
-synthesize. Only then may `research run` launch the configured independent
-reviewer and perform mechanical closure. Follow
+packet's broker command. Record discovery assessments incrementally instead of
+returning all source metadata in the final stage output. Record native
+Web/Browser activity, formalize useful leads through the broker, and bind every
+network download to its exact download event before artifact registration.
+Repeat for discover, acquire, analyze, and synthesize. Only then may
+`research run` launch the configured independent reviewer and perform
+mechanical closure. Follow
 [references/native-execution.md](references/native-execution.md) for the exact
 commands and recovery rules.
 
@@ -197,9 +200,17 @@ downgrade a systematic task to a standalone SCI, report, patent, web, or paper
 operation; only the user may explicitly narrow the request to one isolated
 standalone operation.
 
-Inspect state with `research status`. Use the exact native stage `abort`,
-`research project retry`, or `research project fork` only with explicit user
-direction; do not reset or delete state. A complete project has a passing
-independent review, `outputs/report.md`, and `outputs/closure.json`. Return the
-permanent evidence locators, review-packet binding, usage/cost, decision, and
-material limitations.
+Inspect state with `research status`; the default list contains only
+authoritative work. A recovery fork supersedes its source. Archive completed or
+superseded history, and abandon unfinished history, instead of leaving ambiguous
+project variants. Use the exact native stage `abort`, `research project retry`,
+or `research project fork` only with explicit user direction; do not reset or
+delete state.
+
+When the next material step requires user authorization, login/MFA/challenge
+completion, or an external institution's response, request the packet's durable
+handoff and stop. Do not spend the remaining search budget on low-yield
+substitutes. Resume only after the handoff is explicitly resolved. A complete
+project has a passing independent review, `outputs/report.md`, and
+`outputs/closure.json`. Return the permanent evidence locators, review-packet
+binding, usage/cost, decision, and material limitations.

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -37,8 +37,10 @@ Do not reproduce control-plane contracts or edit control files by hand.
   agent authentication, provider checks, or wrappers.
 - Read [references/production-research.md](references/production-research.md)
   before production preflight, execution, recovery, or closure.
+- Read [references/evidence-pipeline.md](references/evidence-pipeline.md) before
+  discovery, acquisition, evidence refresh, or an addendum.
 - Read [references/native-execution.md](references/native-execution.md) before
-  preparing or submitting discover, analyze, or synthesize stages.
+  preparing or submitting discover, acquire, analyze, or synthesize stages.
 
 ## Choose the mode before spending budget
 
@@ -181,10 +183,12 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 For `native-stage-required`, do not keep calling `research run`. Prepare the
 exact next stage, perform the returned prompt in this current app/session, and
 submit its JSON through the CLI. Discovery evidence must be fetched through the
-packet's broker command. Repeat for discover, analyze, and synthesize. Only then
-may `research run` launch the configured independent reviewer and perform
-mechanical closure. Follow [references/native-execution.md](references/native-execution.md)
-for the exact commands and recovery rules.
+packet's broker command; acquisition must bind every exact selected file through
+the packet's artifact registry. Repeat for discover, acquire, analyze, and
+synthesize. Only then may `research run` launch the configured independent
+reviewer and perform mechanical closure. Follow
+[references/native-execution.md](references/native-execution.md) for the exact
+commands and recovery rules.
 
 Proceed only when doctor reports ready. Discovery uses only locked broker
 capabilities; later stages are tool-free. Doctor, preflight, dependency,

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -1,0 +1,154 @@
+# Evidence-first research pipeline
+
+Load this reference before discovery, acquisition, evidence refresh, or an
+addendum. The operating sequence is:
+
+```text
+broad search -> strict admission -> gap filling -> evidence freeze -> inference
+```
+
+The sequence is a correctness boundary, not merely a preferred writing style.
+Do not analyze while evidence is still mutable, and do not use analysis to
+decide what the evidence ledger claims was retrieved.
+
+## 1. Define the coverage contract
+
+Before spending provider or model budget, describe the question as reviewed
+evidence requirements: dimensions, source types, required capability IDs,
+required discovery scopes, minimum source/full-text/dated counts, and date
+boundaries. `research project preflight` is authoritative for capability,
+context, reservation, and expected-cost gaps.
+
+Production requires an independent public-internet capability. Add every
+owner-whitelisted database whose contents matter to the question as an exact
+required capability; a general web result cannot silently substitute for it.
+
+## 2. Search broadly in bounded batches
+
+The discover packet contains a mechanically derived `discovery.plan` and live
+progress. Treat its broker-view ceiling as a maximum, never a quota:
+
+1. Exercise required first-pass capabilities.
+2. Use broad, high-yield queries across distinct selected channels.
+3. Inspect registered candidate IDs and coverage after each batch.
+4. Stop early when the reviewed minimums are supportable.
+5. Spend the remaining calls only on explicit gaps, counterevidence, missing
+   dates, missing source types, applicability limits, or full-text candidates.
+
+Exact repeated requests reuse the project evidence cache without another
+provider network call. Every returned bounded view still consumes one reviewed
+broker-view slot and its context reservation, preventing cache/pagination from
+bypassing package limits. Use pagination or bounded JSON Pointers instead of
+placing a large response wholesale into model context. The permanent raw object
+remains content-addressed even when only a bounded view reaches the producer.
+
+Every formal network occurrence must pass through the packet's broker command.
+The broker owns endpoint policy, credentials, retries, response bounds,
+sanitization, immutable bytes, and receipts. A standalone search result can
+help find a lead but cannot replace a required broker occurrence.
+
+## 3. Keep one immutable evidence ledger
+
+Inputs, broker results, and native-app discoveries are normalized into stable
+candidate IDs and deduplicated by canonical public URL, DOI, or input hash.
+The append-only hash-chained ledger records discovery occurrences, admission or
+rejection judgments, artifact registration and assessment, snapshots, claim
+use, reviewer binding, and supersession.
+
+The current native Codex or Claude app may use its own Web/Browser experience
+to find an additional lead. Register only safe, non-secret metadata with the
+packet's `registerCandidate` command. Such a lead remains
+`supplemental-not-admitted` until the same URL/DOI has an immutable broker
+occurrence. Never cite or admit a native-only candidate. Registered inputs are
+already formal candidates under their own content-hash identity.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence candidate register PROJECT \
+  --record /absolute/path/to/candidate.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Discovery output contains compact judgments keyed by `candidateId`. The model
+does not generate locators, hashes, retrieval dates, URLs, or receipt identity;
+the control plane joins those deterministic fields from the ledger. Omitted
+candidates remain available for a later gap-fill pass. Record an explicit
+rejection only when it is meaningful and supportable.
+
+## 4. Audit acquisition before inference
+
+After provisional admission, the native `acquire` stage assesses every source
+exactly once. Use selected external acquisition/document Skills or an explicitly
+authorized browser, then register each exact output file from its absolute
+staging path. Never scan a directory for the newest file and never infer success
+from file existence.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence artifact register PROJECT \
+  --candidate CANDIDATE_ID --path /absolute/path/to/exact-file.pdf \
+  --source-url https://publisher.example/article \
+  --workspace /absolute/path/to/workspace --json
+```
+
+The registry verifies size, SHA-256, exact-file binding, and structure. PDF
+registration requires a parseable non-empty document with an EOF marker. ZIP
+and Office Open XML registration verifies the central directory, safe paths,
+supported compression, declared uncompressed sizes, and CRC; encrypted, ZIP64,
+or unsupported compression is rejected. XLSX also records declared sheet
+names. Optional license, license URL, host type, and article version are stored
+only when the source explicitly declares them.
+
+Keep these distinctions exact:
+
+- `registeredFullFile`: an exact full file is hash-bound for audit/review.
+- `producerContextLevel=full-input`: the registered input itself is available
+  through its reviewed input contract.
+- `producerContextLevel=bounded-text-artifact`: a registered UTF-8 text, JSON,
+  HTML, CSV, or Markdown derivative is embedded within the context limit.
+- `producerContextLevel=metadata-only`: no producer-readable full text was
+  admitted. A raw PDF/DOCX/PPTX/XLSX alone remains here.
+- `reviewerBoundFullFile`: the independent review packet binds the exact full
+  file; this does not mean the reviewer model read all binary bytes.
+- `visuallyVerified`: false unless a future explicit visual-verification event
+  records otherwise.
+
+An accepted source may remain metadata/abstract-only when the requirements
+allow it, but the audit must state that limitation. Unresolved blocking gaps
+stop snapshot creation.
+
+## 5. Freeze, then infer
+
+Successful acquisition creates `outputs/evidence-snapshot.json` plus an
+immutable project-local copy under `evidence/snapshots/`. The semantic snapshot
+hash binds the question, evidence and acquisition records, ledger head,
+receipts, selected artifacts, coverage, limitations, and parent/delta lineage.
+Analysis and synthesis may use only this verified snapshot. They cannot fetch,
+register, or silently substitute new evidence.
+
+The review packet binds the current snapshot chain, selected exact artifacts,
+permanent broker objects, bounded excerpts, analysis, and report. Claim and
+review bindings are appended to the ledger. Mechanical closure re-verifies all
+hashes and refuses a missing, changed, or stale snapshot, packet, context,
+receipt, artifact, or source.
+
+## 6. Refresh through an addendum
+
+Never mutate a closed project. When material new evidence exists, create a new
+addendum project:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project addendum CLOSED_PROJECT --to NEW_PROJECT \
+  --workspace /absolute/path/to/workspace --json
+```
+
+The original closure remains byte-for-byte unchanged. The addendum inherits
+the verified base ledger/evidence/audit/artifacts, starts again at discover,
+freezes a child snapshot with a mechanical added/changed/removed/unchanged
+delta, and reruns analysis, synthesis, independent review, and closure. The
+superseded project becomes stale and is hidden from default `research status`;
+use `research status --all` only for lineage audit.
+
+Use the status response's `discovery`, `snapshot`, `nativeStage`, `lineage`, and
+`recommendedAction` fields instead of inspecting control files manually.

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -26,7 +26,10 @@ required capability; a general web result cannot silently substitute for it.
 ## 2. Search broadly in bounded batches
 
 The discover packet contains a mechanically derived `discovery.plan` and live
-progress. Treat its broker-view ceiling as a maximum, never a quota:
+progress. The working call budget scales with reviewed dimensions, source
+types, required channels, minimum sources, and a separate gap-fill reserve. It
+is no longer a fixed six-call allowance, but it never exceeds the workspace
+hard ceiling of 24. Treat that ceiling as a maximum, never a quota:
 
 1. Exercise required first-pass capabilities.
 2. Use broad, high-yield queries across distinct selected channels.
@@ -56,11 +59,16 @@ rejection judgments, artifact registration and assessment, snapshots, claim
 use, reviewer binding, and supersession.
 
 The current native Codex or Claude app may use its own Web/Browser experience
-to find an additional lead. Register only safe, non-secret metadata with the
-packet's `registerCandidate` command. Such a lead remains
+to find additional leads. Record every material search, navigation, download,
+or file-inspection occurrence through the packet's `recordActivity` command.
+The control plane persists only a sanitized input hash, channel, counts, status,
+challenge class, and candidate IDs. Then register safe, non-secret candidate
+metadata through `registerCandidate`. Such a lead remains
 `supplemental-not-admitted` until the same URL/DOI has an immutable broker
 occurrence. Never cite or admit a native-only candidate. Registered inputs are
-already formal candidates under their own content-hash identity.
+already formal candidates under their own content-hash identity. The frozen
+snapshot includes the verified activity summary so native work and formal
+broker evidence remain one auditable ledger rather than two hidden work logs.
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
@@ -69,29 +77,54 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   --workspace /absolute/path/to/workspace --json
 ```
 
-Discovery output contains compact judgments keyed by `candidateId`. The model
-does not generate locators, hashes, retrieval dates, URLs, or receipt identity;
-the control plane joins those deterministic fields from the ledger. Omitted
+Assess candidates as they are found in batches of at most 25 through the
+packet's `recordAssessment` command. Each append-only batch may replace the
+latest judgment for a candidate without repeating deterministic source
+metadata. The model does not generate locators, hashes, retrieval dates, URLs,
+or receipt identity; the control plane joins those fields from the ledger. The
+final discover submission is therefore only a compact closeout containing one
+status per reviewed dimension, limitations, and remaining gaps. Omitted
 candidates remain available for a later gap-fill pass. Record an explicit
 rejection only when it is meaningful and supportable.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence assessment record PROJECT \
+  --record /absolute/path/to/assessment-batch.json \
+  --workspace /absolute/path/to/workspace --json
+```
 
 ## 4. Audit acquisition before inference
 
 After provisional admission, the native `acquire` stage assesses every source
 exactly once. Use selected external acquisition/document Skills or an explicitly
-authorized browser, then register each exact output file from its absolute
-staging path. Never scan a directory for the newest file and never infer success
-from file existence.
+authorized browser. For every network file, capture the exact browser Download
+object or equivalent transport completion, save it to a unique planned staging
+path, and first bind that event through `bindDownload`. A failed or cancelled
+event creates no successful binding and cannot register an artifact. Never scan
+a directory for the newest file and never infer success from file existence.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence download bind PROJECT \
+  --candidate CANDIDATE_ID --record /absolute/path/to/download.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Register the exact downloaded file with the returned binding ID. A text or
+structured derivative must instead name the same-candidate parent artifact;
+this preserves a mechanical chain back to the bound network file.
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   research project evidence artifact register PROJECT \
   --candidate CANDIDATE_ID --path /absolute/path/to/exact-file.pdf \
+  --download-binding DOWNLOAD_BINDING_ID \
   --source-url https://publisher.example/article \
   --workspace /absolute/path/to/workspace --json
 ```
 
-The registry verifies size, SHA-256, exact-file binding, and structure. PDF
+The registry verifies size, SHA-256, exact event/file binding, and structure. PDF
 registration requires a parseable non-empty document with an EOF marker. ZIP
 and Office Open XML registration verifies the central directory, safe paths,
 supported compression, declared uncompressed sizes, and CRC; encrypted, ZIP64,
@@ -105,7 +138,9 @@ Keep these distinctions exact:
 - `producerContextLevel=full-input`: the registered input itself is available
   through its reviewed input contract.
 - `producerContextLevel=bounded-text-artifact`: a registered UTF-8 text, JSON,
-  HTML, CSV, or Markdown derivative is embedded within the context limit.
+  CSV, or Markdown derivative is embedded within the context limit. HTML stays
+  metadata-only because an error or challenge page must not masquerade as
+  acquired full text.
 - `producerContextLevel=metadata-only`: no producer-readable full text was
   admitted. A raw PDF/DOCX/PPTX/XLSX alone remains here.
 - `reviewerBoundFullFile`: the independent review packet binds the exact full
@@ -148,7 +183,11 @@ the verified base ledger/evidence/audit/artifacts, starts again at discover,
 freezes a child snapshot with a mechanical added/changed/removed/unchanged
 delta, and reruns analysis, synthesis, independent review, and closure. The
 superseded project becomes stale and is hidden from default `research status`;
-use `research status --all` only for lineage audit.
+use `research status --all` only for lineage audit. Recovery forks have the
+same single-authority rule: the new fork supersedes its source immediately.
+Use `research project archive` for complete/stale history and
+`research project abandon` for unfinished history; never infer the latest
+project from its name or version suffix.
 
 Use the status response's `discovery`, `snapshot`, `nativeStage`, `lineage`, and
 `recommendedAction` fields instead of inspecting control files manually.

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -29,7 +29,8 @@ The discover packet contains a mechanically derived `discovery.plan` and live
 progress. The working call budget scales with reviewed dimensions, source
 types, required channels, minimum sources, and a separate gap-fill reserve. It
 is no longer a fixed six-call allowance, but it never exceeds the workspace
-hard ceiling of 24. Treat that ceiling as a maximum, never a quota:
+hard ceiling of 256 in a new production workspace. Treat that ceiling as a
+runaway guard, never a quota:
 
 1. Exercise required first-pass capabilities.
 2. Use broad, high-yield queries across distinct selected channels.

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -60,20 +60,39 @@ limits calls/bytes/items/tokens, persists content-addressed raw evidence, and
 records sanitized events. Standalone web/search/database tools cannot replace
 required broker receipts.
 
-Native Web or Browser results may be recorded only as supplemental leads with
-the packet's `registerCandidate` argv. They remain inadmissible until a broker
-receipt formalizes the same canonical URL/DOI. Registered inputs are already
-formal candidates under their own content-hash identity.
+Native Web or Browser work must first use the packet's `recordActivity` argv.
+Its search/navigation input is sanitized and persisted only by SHA-256; counts,
+challenge class, status, and linked candidate IDs remain auditable. Register
+useful results as supplemental leads with `registerCandidate`. They remain
+inadmissible until a broker receipt formalizes the same canonical URL/DOI.
+Registered inputs are already formal candidates under their own content-hash
+identity.
+
+After each useful discovery batch, write at most 25 candidate judgments through
+the packet's `recordAssessment` argv. The ledger keeps the latest judgment per
+candidate and the CLI joins all deterministic provenance fields. The final
+discover output must contain only the compact closeout schema returned by the
+packet; do not repeat a source-sized evidence array.
 
 ## Register exact acquisition artifacts
 
-When the next stage is `acquire`, follow the packet's `registerArtifact` argv
-for each exact selected file. Pass its candidate ID and absolute staging path;
-add source/license metadata only when explicitly declared by the source. The
-registry accepts no directory and performs no “latest download” selection.
+When the next stage is `acquire`, use the packet's `bindDownload` argv before
+registering every file obtained from a network source. Bind the exact completed
+Download object or equivalent to one unique planned staging path, safe final
+URL, suggested filename, and available non-secret identifier. A cancelled or
+failed download must be recorded as such and cannot be promoted. Then follow
+`registerArtifact`, passing the candidate, exact absolute path, and returned
+download binding. The registry accepts no directory and performs no “latest
+download” selection.
+
+For a producer-readable derivative, register the exact output with
+`--derived-from-artifact` naming its same-candidate parent instead of claiming a
+second network download. Add source/license metadata only when explicitly
+declared by the source.
+
 Binary registration makes the exact file review-bound, but PDF/DOCX/PPTX/XLSX
 alone does not claim producer-readable full text. Register a separately derived
-UTF-8 text/JSON/HTML/CSV/Markdown artifact when one was legitimately produced
+UTF-8 text/JSON/CSV/Markdown artifact when one was legitimately produced
 and should be embedded within the bounded producer context.
 
 ## Submit producer output
@@ -101,6 +120,16 @@ A rejected submission leaves the active session intact so the current host can
 perform a bounded formatting correction or gather missing authorized evidence.
 It does not silently retry research or invoke another model.
 
+Login, MFA, CAPTCHA, Turnstile, paywall, security-warning, or authorization
+activity cannot be submitted as ordinary completion. Record it as `blocked`
+through `recordActivity`, create a `user-action-required` record with the
+packet's `requestHandoff` argv, and stop. When the missing material requires an
+institution or another third party to respond, request
+`external-response-required` instead of searching indefinite substitutes. Both
+states are durable and do not burn the prepared attempt. Resume only after an
+operator explicitly runs `research project handoff resolve` with a non-secret
+resolution note.
+
 ## Continue, review, or abort
 
 After each successful submit, call `research run` again. Prepare/submit the
@@ -118,3 +147,8 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 
 Abort removes only that CLI-created runtime capsule and active session. It
 consumes the prepared attempt and never deletes admitted evidence or outputs.
+
+Use `research status` to follow the authoritative project. A recovery fork
+supersedes its source and is the only default-runnable descendant. Use
+`research status --all` for lineage audit, `research project archive` for
+complete/stale history, and `research project abandon` for unfinished history.

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -1,10 +1,10 @@
 # Native producer execution
 
-Discover, analyze, and synthesize are performed by the current interactive
-Codex app/session or Claude Code session. The CLI is not a producer-agent
-launcher. It prepares a hash-bound packet, brokers authorized evidence, admits
-the result, launches the other agent family only for independent review, and
-closes mechanically.
+Discover, acquire, analyze, and synthesize are performed by the current
+interactive Codex app/session or Claude Code session. The CLI is not a
+producer-agent launcher. It prepares a hash-bound packet, brokers authorized
+evidence, registers exact acquired artifacts, admits the result, launches the
+other agent family only for independent review, and closes mechanically.
 
 ## Identify the next action
 
@@ -60,6 +60,22 @@ limits calls/bytes/items/tokens, persists content-addressed raw evidence, and
 records sanitized events. Standalone web/search/database tools cannot replace
 required broker receipts.
 
+Native Web or Browser results may be recorded only as supplemental leads with
+the packet's `registerCandidate` argv. They remain inadmissible until a broker
+receipt formalizes the same canonical URL/DOI. Registered inputs are already
+formal candidates under their own content-hash identity.
+
+## Register exact acquisition artifacts
+
+When the next stage is `acquire`, follow the packet's `registerArtifact` argv
+for each exact selected file. Pass its candidate ID and absolute staging path;
+add source/license metadata only when explicitly declared by the source. The
+registry accepts no directory and performs no “latest download” selection.
+Binary registration makes the exact file review-bound, but PDF/DOCX/PPTX/XLSX
+alone does not claim producer-readable full text. Register a separately derived
+UTF-8 text/JSON/HTML/CSV/Markdown artifact when one was legitimately produced
+and should be embedded within the bounded producer context.
+
 ## Submit producer output
 
 Save only the schema-conforming JSON object to a new regular non-symlink file.
@@ -88,9 +104,9 @@ It does not silently retry research or invoke another model.
 ## Continue, review, or abort
 
 After each successful submit, call `research run` again. Prepare/submit the
-next native producer stage until synthesize completes. The same run command may
-then launch only the configured independent reviewer CLI and, after a passing
-review, perform mechanical closure.
+next native producer stage through discover, acquire, analyze, and synthesize.
+The same run command may then launch only the configured independent reviewer
+CLI and, after a passing review, perform mechanical closure.
 
 To discard an active native session explicitly:
 

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -72,11 +72,11 @@ The budget includes:
 - broker calls, response bytes, context items, and estimated context tokens;
 - the cost-confirmation threshold.
 
-New workspaces default to 550,000 total tokens, with 230,000 reserved as the
-discovery package ceiling; analyze, synthesize, and review default to 60,000,
-70,000, and 175,000. Primary output is bounded at 6,000 tokens and repair at
-4,000. These values are admission ceilings, not a target spend. Lower them only
-when preflight proves every complete reservation still fits.
+New workspaces default to 650,000 total tokens. Package ceilings are 230,000
+for discovery, 80,000 for acquisition, 70,000 for analysis, 70,000 for
+synthesis, and 190,000 for review. Primary output is bounded at 6,000 tokens
+and repair at 4,000. These values are admission ceilings, not a target spend.
+Lower them only when preflight proves every complete reservation still fits.
 
 The CLI will not prepare or launch a package unless its full token and
 conservative price reservation fits. Native producer preparation reserves the
@@ -92,11 +92,13 @@ The independently launched reviewer retains pre-call prompt/schema/output and
 repair reservations plus provider-side structured-output/turn controls where
 the selected CLI supports them. Its formatting repair requests plain JSON in
 one tool-free turn and passes through the same validators. Preflight and runtime
-share the review-context reservation formula. The broker separately enforces at
-most six provider fetch calls across native discovery and returns the remaining
-call budget after each success. Reserve enough output for every producer schema
-and enough input context for prior-stage artifacts; preflight reports both gaps
-mechanically.
+share the review-context reservation formula. The broker separately derives a
+working broker-view budget from the reviewed coverage requirements, never above
+the workspace hard ceiling of 24, and returns the remaining budget after each
+success. Network/cache status is reported separately; a cached view avoids a
+provider call but still consumes one view and its context reservation. Reserve
+enough output for every producer schema and enough input context for prior-stage
+artifacts; preflight reports both gaps mechanically.
 
 ## Bounded local evidence
 
@@ -152,12 +154,13 @@ an excerpt or JSON Pointer, quality rationale, applicability, and covered
 dimensions. The CLI verifies input locators and every broker object. Findings
 may cite only admitted source IDs.
 
-For discover, analyze, and synthesize, `research project stage prepare` returns
-the authoritative schema and exact prompt to the current native host. Save one
-JSON object and pass it to `research project stage submit`; submit validates and
-materializes it atomically. A rejected native submission preserves the bound
-session for an explicit host correction and never launches a nested repair
-agent. For review, Codex receives `--output-schema` or Claude receives
+For discover, acquire, analyze, and synthesize,
+`research project stage prepare` returns the authoritative schema and exact
+prompt to the current native host. Save one JSON object and pass it to
+`research project stage submit`; submit validates and materializes it
+atomically. A rejected native submission preserves the bound session for an
+explicit host correction and never launches a nested repair agent. For review,
+Codex receives `--output-schema` or Claude receives
 `--json-schema`; invalid reviewer syntax/schema or a mechanically diagnosed
 binding gets one low-budget formatting-only repair with no broker or research
 tools. The repair may not add facts. A second reviewer failure stops instead of
@@ -247,13 +250,16 @@ body. GET remains the default method inside an explicit HTTP endpoint policy.
 
 ## Coverage, retry, and recovery
 
-Discovery output is promoted for diagnosis, then checked mechanically. The CLI
-derives local full-text availability, source types, source counts, dated counts,
-date range, per-dimension source IDs, and the pass/insufficient decision from
-admitted sources and declared minimums. `partial` is usable but incomplete;
-`missing` or any unmet source/full-text/date minimum blocks all downstream
-packages. Model-provided qualitative gaps remain visible but cannot override
-those derived fields.
+Discovery output is promoted for diagnosis, then acquisition audits every
+provisionally admitted source. The CLI freezes only accepted/limited sources
+and their explicitly selected artifacts, then derives producer-readable
+full-text availability, source types, source counts, dated counts, date range,
+per-dimension source IDs, and the pass/insufficient decision from that snapshot.
+`partial` is usable but incomplete; `missing`, an acquisition gap, or any unmet
+source/full-text/date minimum blocks analysis. Model-provided qualitative gaps
+remain visible but cannot override those derived fields. See
+[evidence-pipeline.md](evidence-pipeline.md) for exact full-file versus
+producer-readable semantics and addendum lineage.
 
 Every manifest capability marked `requiredForDiscovery=true` must produce a
 verified broker receipt. The gate distinguishes a capability that was never
@@ -266,8 +272,10 @@ and each staged external Skill's top-level `SKILL.md`. The current host must use
 the packet's `research project evidence fetch` argv for admitted network
 evidence; standalone web/search/database tools cannot replace required broker
 receipts. Broker results include the exact bounded view inline with the receipt.
-Analyze receives the admitted evidence object; synthesize receives evidence and
-analysis. Neither stage may gather new evidence. Review is tool-free and embeds
+Acquire receives the provisional evidence record and exact artifact registry
+command, then produces a complete audit. Analyze receives the frozen evidence
+snapshot; synthesize receives the snapshot and analysis. Neither later stage
+may gather new evidence. Review is tool-free and embeds
 generated artifacts plus deterministic excerpts from bounded local/broker
 evidence views within the reviewer's route-specific structured-output turn cap.
 Preflight and runtime reserve the same
@@ -305,8 +313,9 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 
 Retry grants one auditable extra attempt and resets downstream scheduling while
 preserving promoted files. Fork starts a new budget/accounting history and may
-inherit only verified completed discovery/analysis/synthesis artifacts; review
-and closure always run again.
+inherit only verified completed discovery/acquisition/analysis/synthesis
+artifacts; review and closure always run again. A closed-project evidence
+refresh uses `research project addendum`, not a fork or in-place mutation.
 
 Run one recovered or canary project with an explicit scope:
 
@@ -322,9 +331,9 @@ historical blocked siblings do not change its exit code. Omit `--project` only
 when the operator intends to schedule and summarize the whole workspace.
 `stopReason=native-stage-required` is the normal producer handoff: follow
 [native-execution.md](native-execution.md) to prepare and submit discover,
-analyze, and synthesize in the current host. Calling `research run` after
-synthesis may launch only the independently configured reviewer CLI and then
-close mechanically.
+acquire, analyze, and synthesize in the current host. Calling `research run`
+after synthesis may launch only the independently configured reviewer CLI and
+then close mechanically.
 
 ## Standard zero-cost eval before a real canary
 
@@ -337,9 +346,13 @@ Confirm the owning CLI release passed deterministic mock coverage for:
 - explicit owner-database import, required-discovery receipt enforcement, and
   local-only production rejection;
 - routing and smoke/production mode boundaries;
-- discover → analyze → synthesize → review → close;
+- discover → acquire → freeze → analyze → synthesize → review → close;
 - public `research run` never launching a producer subprocess, with native
-  prepare/fetch/submit advancing the three producer stages;
+  prepare/fetch/register/submit advancing the four producer stages;
+- native-only leads remaining supplemental until an immutable broker
+  occurrence formalizes the same candidate;
+- exact artifact registration, binary-only full-text semantics, immutable
+  snapshot/delta lineage, and addendum supersession;
 - permanent evidence and review-packet hash verification;
 - persistent bounded review-context verification and packet/context tamper
   rejection before closure;

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -72,11 +72,15 @@ The budget includes:
 - broker calls, response bytes, context items, and estimated context tokens;
 - the cost-confirmation threshold.
 
-New workspaces default to 650,000 total tokens. Package ceilings are 230,000
-for discovery, 80,000 for acquisition, 70,000 for analysis, 70,000 for
-synthesis, and 190,000 for review. Primary output is bounded at 6,000 tokens
-and repair at 4,000. These values are admission ceilings, not a target spend.
-Lower them only when preflight proves every complete reservation still fits.
+New production workspaces use finite runaway ceilings of 20,000,000 total
+tokens and USD 2,000. Package ceilings are 12,000,000 for discovery, 2,000,000
+for acquisition, 1,500,000 each for analysis and synthesis, and 2,500,000 for
+review. Primary output is bounded at 32,000 tokens and repair at 16,000. Input
+context is bounded at 128,000 tokens. These values are not a target spend:
+coverage-driven working plans, early stop, three attempts per package, and
+explicit confirmation above USD 10 control ordinary execution. Smoke-test
+workspaces retain smaller low-cost defaults. Lower production ceilings only
+when preflight proves every complete reservation still fits.
 
 The CLI will not prepare or launch a package unless its full token and
 conservative price reservation fits. Native producer preparation reserves the
@@ -95,9 +99,10 @@ one tool-free turn and passes through the same validators. Preflight and runtime
 share the review-context reservation formula. The broker separately derives a
 coverage-scaled working broker-view budget from dimensions, source types,
 required channels, minimum sources, and a gap-fill reserve. It is not a fixed
-six-call allowance and never exceeds the workspace hard ceiling of 24. The
-packet returns live progress and remaining budget after each success; stop
-early once coverage is supportable. Network/cache status is reported
+six-call allowance and never exceeds the new-production hard ceiling of 256
+bounded views, each with at most 32,000 context tokens. The packet returns live
+progress and remaining working budget after each success; stop early once
+coverage is supportable. Network/cache status is reported
 separately; a cached view avoids a provider call but still consumes one view and
 its context reservation. Candidate assessments are appended in batches of at
 most 25, so the final discovery output remains a compact closeout instead of

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -93,12 +93,17 @@ repair reservations plus provider-side structured-output/turn controls where
 the selected CLI supports them. Its formatting repair requests plain JSON in
 one tool-free turn and passes through the same validators. Preflight and runtime
 share the review-context reservation formula. The broker separately derives a
-working broker-view budget from the reviewed coverage requirements, never above
-the workspace hard ceiling of 24, and returns the remaining budget after each
-success. Network/cache status is reported separately; a cached view avoids a
-provider call but still consumes one view and its context reservation. Reserve
-enough output for every producer schema and enough input context for prior-stage
-artifacts; preflight reports both gaps mechanically.
+coverage-scaled working broker-view budget from dimensions, source types,
+required channels, minimum sources, and a gap-fill reserve. It is not a fixed
+six-call allowance and never exceeds the workspace hard ceiling of 24. The
+packet returns live progress and remaining budget after each success; stop
+early once coverage is supportable. Network/cache status is reported
+separately; a cached view avoids a provider call but still consumes one view and
+its context reservation. Candidate assessments are appended in batches of at
+most 25, so the final discovery output remains a compact closeout instead of
+growing with source count. Reserve enough output for every producer schema and
+enough input context for prior-stage artifacts; preflight reports both gaps
+mechanically.
 
 ## Bounded local evidence
 
@@ -316,6 +321,24 @@ preserving promoted files. Fork starts a new budget/accounting history and may
 inherit only verified completed discovery/acquisition/analysis/synthesis
 artifacts; review and closure always run again. A closed-project evidence
 refresh uses `research project addendum`, not a fork or in-place mutation.
+
+The fork becomes authoritative immediately and its source becomes stale. The
+default status/run path excludes superseded, archived, and abandoned projects;
+`research status --all` is the audit view. Archive complete/stale history and
+abandon unfinished history with an explicit reason.
+
+When the next material step cannot be performed autonomously, use one of two
+durable states rather than another retry:
+
+- `user-action-required`: authorized login, SSO/MFA, CAPTCHA, security warning,
+  paywall/entitlement decision, VPN, or another explicit user operation;
+- `external-response-required`: a government, institution, owner database, or
+  other third party must provide non-public material or permission.
+
+The handoff record states the non-secret reason, exact requested actions, and
+remaining evidence gaps. `research run` returns `handoff-required` and does not
+schedule more work. Resolve it explicitly only after the action or response has
+been registered; never treat continued substitute searching as resolution.
 
 Run one recovered or canary project with an explicit scope:
 


### PR DESCRIPTION
## Summary

Updates `tiangong-auto-research` to orchestrate the evidence-first production workflow tracked by tiangong-ai/workspace#118.

- documents `wide discovery -> strict admission -> gap fill -> evidence freeze -> reasoning`
- directs discovery, acquisition, analysis, and synthesis through the current native Codex or Claude app
- uses the CLI only as the deterministic control plane and independent reviewer launcher
- explains authoritative project lineage, native discovery formalization, exact-file acquisition, durable handoffs, and generous finite production ceilings

## Key decisions

- The Skill coordinates the native producer and does not spawn a nested producer CLI.
- Native Web/Browser findings must be formally registered before they become reviewed evidence.
- Search stops when the remaining gap requires user authorization or an external institution response.
- Authoring begins only after an immutable evidence snapshot passes independent review.

## Validation

- complete repository test suite passed
- Skill quick validation passed
- `git diff --check` passed
- `docpact 0.1.9 lint --worktree --mode enforce` passed
- clean-directory production canary with real configured providers passed

## Risk and rollback

The changes are procedural and version-locked to the CLI runtime contract. Reverting this PR restores the previous orchestration guidance without altering user evidence stores.

## Workspace integration

The root workspace pin and release manifest will be updated after this PR and the CLI PR merge.
