### PR TITLE
Fix Auto Research partial-setup routing and clean-container TDD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.docpact/runs
+.env
+.env.*
+node_modules
+dist
+build
+coverage
+*.log

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-11"
-lastReviewedCommit: "d51cced6a7eade5aba395c5742993089f7878302"
+lastReviewedAt: "2026-08-12"
+lastReviewedCommit: "6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c"
 
 repo:
   id: skills

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-12"
-lastReviewedCommit: "6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c"
+lastReviewedCommit: "3d5d85f41bac03b7b31208e89d6c5e56da320baf"
 
 repo:
   id: skills

--- a/.github/workflows/docpact.yml
+++ b/.github/workflows/docpact.yml
@@ -8,15 +8,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  clean-container-tdd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: sh scripts/test-clean-container.sh
+
   validate-config:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: Biaoo/docpact@v0.1.4
+      - uses: Biaoo/docpact@v0.1.9
         with:
-          version: 0.1.4
+          version: 0.1.9
           args: >
             validate-config
             --root .
@@ -29,9 +35,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: Biaoo/docpact@v0.1.4
+      - uses: Biaoo/docpact@v0.1.9
         with:
-          version: 0.1.4
+          version: 0.1.9
           args: >
             lint
             --root .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ skill 内容、skill 规范、marketplace 元数据和本仓文档治理属于�
 - route 命中的文档已 reviewed 或 updated。
 - 治理变更后 `docpact validate-config --root . --strict` 通过。
 - skill 变更按 `skill-creator` 流程运行对应校验。
+- Auto Research 及其直接 evidence wrapper 的变更必须先在
+  `scripts/test-clean-container.sh` 中观察回归测试失败，再在同一全新、
+  无宿主 HOME/全局 Skill/CLI/cache 的 Docker 契约中转绿；宿主测试不能替代。
 
 ## Skill-Creator Workflow
 

--- a/Dockerfile.clean-test
+++ b/Dockerfile.clean-test
@@ -1,0 +1,15 @@
+FROM node:24.19.0-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /skills
+RUN chown node:node /skills
+USER node
+COPY --chown=node:node . .
+
+ENV CI_CLEAN_CONTAINER=1
+ENV HOME=/home/node
+
+CMD ["sh", "scripts/run-auto-research-tests.sh"]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
 ---
 
 # Tiangong AI Skills

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # 天工 AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: d51cced6a7eade5aba395c5742993089f7878302
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
 ---
 
 # Skills Documentation

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
 ---
 
 # Skills Repository Architecture

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -14,8 +14,8 @@ checkPaths:
   - .claude-plugin/**
   - .docpact/config.yaml
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
 ---
 
 # Skills Repository Contract

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -15,7 +15,7 @@ checkPaths:
   - .docpact/config.yaml
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -49,6 +49,20 @@ scripts/quick_validate.py <skill-path>
 
 Run representative script tests when a skill script changes.
 
+For `tiangong-auto-research` or its direct SCI/report/patent wrappers, use
+test-driven development exclusively through the mandatory clean-room entrypoint
+for the red and green cycles:
+
+```bash
+scripts/test-clean-container.sh
+```
+
+It performs a no-cache build from the digest-pinned Node 24 image, copies only
+the secret-filtered repository context, and runs the routing, resolver, agent
+wrapper, and evidence-wrapper suites as a non-root user with isolated HOME and
+runtime networking disabled. Do not mount host agent directories, CLIs, caches,
+credentials, browser profiles, or source worktrees into the running container.
+
 ## README And Marketplace Updates
 
 Update `README.md` and `README.zh-CN.md` when installation, environment

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: a5877c2b6520af97397e4ea6d82277a8de1de41a
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
+lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
 # Skills Documentation Standards

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: d51cced6a7eade5aba395c5742993089f7878302
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 6436ad9df81e7b1f7f0e0a2b8f8bb3129f27598c
 ---
 
 # Skills Documentation Standards

--- a/scripts/run-auto-research-tests.sh
+++ b/scripts/run-auto-research-tests.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+[ "${CI_CLEAN_CONTAINER:-}" = "1" ]
+[ -f /.dockerenv ]
+[ "$(id -u)" -ne 0 ]
+[ "${HOME:-}" = "/home/node" ]
+[ ! -e "$HOME/.agents" ]
+if command -v tiangong-ai >/dev/null 2>&1; then
+    echo "global tiangong-ai must not exist in the clean test image" >&2
+    exit 1
+fi
+
+node tiangong-auto-research/scripts/test-research-cli.mjs
+node tiangong-auto-research/scripts/test-routing-contract.mjs
+sh tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
+bash tiangong-kb-sci-search/scripts/test-sci-search.sh
+bash tiangong-kb-report-search/scripts/test-report-search.sh
+bash tiangong-kb-patent-search/scripts/test-patent-search.sh

--- a/scripts/test-clean-container.sh
+++ b/scripts/test-clean-container.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd -P)
+image_tag="tiangong-ai-skills-clean-test:local-$$"
+
+cleanup() {
+    docker image rm --force "$image_tag" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT HUP INT TERM
+
+docker build \
+    --no-cache \
+    --file "$repo_root/Dockerfile.clean-test" \
+    --tag "$image_tag" \
+    "$repo_root"
+
+docker run \
+    --rm \
+    --init \
+    --network none \
+    --cap-drop ALL \
+    --security-opt no-new-privileges \
+    --tmpfs /tmp:rw,exec,nosuid,nodev,uid=1000,gid=1000,mode=1777 \
+    --tmpfs /home/node:rw,nosuid,nodev,uid=1000,gid=1000,mode=0700 \
+    "$image_tag"

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -5,17 +5,18 @@ description: Orchestrate open-ended, multi-source, evidence-backed research in t
 
 # Tiangong Auto Research
 
-For an existing workspace, use the bundled resolver for every CLI operation.
+For an existing managed directory, use the bundled resolver for every CLI operation.
 Resolve `AUTO_RESEARCH_CLI` from this loaded Skill's absolute directory; do not
 guess a global Skill path. The resolver accepts only the CLI package and exact
-stable version from the workspace's regular non-symlink runtime lock:
+stable version from the regular non-symlink runtime lock, or from the immutable
+setup plan while installation is still pending or blocked:
 
 ```bash
 AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/research_cli.mjs
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research --help
 ```
 
-For a clean directory without a runtime lock, read
+For a clean directory without a runtime lock or setup plan, read
 [references/setup.md](references/setup.md) and ask the user to choose one
 reviewed exact bootstrap CLI version. Never substitute `latest`, a range, a
 tag, a path, or a command fragment. After setup creates the runtime lock, use
@@ -62,7 +63,10 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   --path /absolute/path/to/workspace --json
 ```
 
-Follow `role` and `allowedOperations`. Stop on `invalid`; never repair immutable
+Follow `role`, `allowedOperations`, and the structured `setup` preflight.
+For `setup` or a blocked `workspace`, execute only its exact-version-pinned
+`next.retryCommand`; never fall through to a standalone provider wrapper.
+Stop on `invalid`; never repair immutable
 state, locks, journal events, evidence objects, receipts, or outputs manually.
 
 For a clean directory, show the read-only ecosystem catalog and run the guided

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -28,6 +28,14 @@ the journal, and closure. The current interactive Codex or Claude Code session
 owns producer reasoning. The CLI must never launch a nested producer process.
 Do not reproduce control-plane contracts or edit control files by hand.
 
+During an accepted apply, the CLI may temporarily create the project Skill
+`tiangong-auto-research-recovery`. That generated recovery-only entry can inspect
+context and setup status and execute only the exact pinned retry command. It must
+never perform research or standalone evidence search. The CLI removes only its
+own exact plan-bound recovery bytes after this full external orchestrator matches
+the reviewed tree hash; follow [references/setup.md](references/setup.md) for the
+detailed stop and recovery rules.
+
 ## Route to the right reference
 
 - Read [references/setup.md](references/setup.md) for a new or clean directory,

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -124,8 +124,9 @@ owner-only file and only documented Tiangong endpoint/key/region/timeout names
 are loaded. Credentials are forbidden in wrapper JSON and request files.
 
 Inside Auto Research, never run that wrapper. The wrapper detects an ancestor
-runtime lock and returns `AUTO_RESEARCH_BROKER_REQUIRED` before credentials or
-network unless the user explicitly narrowed the task and supplied
+immutable setup plan or runtime lock and returns
+`AUTO_RESEARCH_BROKER_REQUIRED` before credentials or network unless the user
+explicitly narrowed the task and supplied
 `"execution_mode":"standalone"`. That explicit mode emits only a non-secret
 audit event and still cannot read the broker store. Setup maps the owner
 variable to logical ID `tiangong.sci.api-key`; discovery sends a non-secret

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -160,9 +160,11 @@ document; the CLI catalog is authoritative.
 
 ## Status, doctor, and recovery
 
-After apply creates the runtime lock, resolve every command through the bundled
-Skill helper. Set `AUTO_RESEARCH_CLI` to the absolute path of this installed
-Skill, not a guessed global location:
+After the immutable plan exists, resolve every command through the bundled
+Skill helper. During a partial installation it uses the reviewed plan version;
+after apply creates the runtime lock it requires the matching locked version.
+Set `AUTO_RESEARCH_CLI` to the absolute path of this selected Skill, not a
+guessed global location:
 
 ```bash
 AUTO_RESEARCH_CLI=/absolute/path/to/installed/tiangong-auto-research/scripts/research_cli.mjs
@@ -191,7 +193,15 @@ succeeds, ordinary workspace doctor calls may reuse its unexpired hash-bound
 attestation after checking the current reviewer runtime fingerprint. Explicit
 smoke flags refresh it; expiry or drift remains blocking.
 
-On a blocked apply, use the exact `retryCommand` in setup state. Clear a stale
+Status reports credential persistence separately from overall readiness and
+includes the effective CLI package/version/root plus the selected orchestrator
+path and install status. A stored broker or adapter credential is not an
+ambient shell credential, and a readiness blocker must not be reported as a
+missing ambient key.
+
+On a blocked apply, use the exact-version-pinned `retryCommand` in setup state.
+For a failed step this command is `research setup retry --step <recorded-step>`,
+not a read-only status or doctor command. Clear a stale
 lock only with both stale-lock flags after confirming no setup process owns it.
 Do not delete plan/state/source-cache directories or overwrite installed trees.
 

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -160,6 +160,18 @@ document; the CLI catalog is authoritative.
 
 ## Status, doctor, and recovery
 
+After credentials are safely stored and before external source checkout, apply
+creates a small project-scoped `tiangong-auto-research-recovery` Skill when the
+full orchestrator was selected. Its immutable-plan-bound instructions allow only
+`research context inspect`, `research setup status`, and the exact
+`setup.next.retryCommand`; they prohibit research execution, standalone evidence,
+credential access, global Skill fallback, and ambient CLI fallback. This closes
+the bootstrap gap if source checkout or installation fails. Once the full
+external orchestrator matches its reviewed tree hash, the CLI verifies the
+generated files byte-for-byte and removes only that recovery directory. A
+changed, symlinked, or ambiguous recovery directory blocks cleanup and is never
+overwritten or deleted automatically.
+
 After the immutable plan exists, resolve every command through the bundled
 Skill helper. During a partial installation it uses the reviewed plan version;
 after apply creates the runtime lock it requires the matching locked version.

--- a/tiangong-auto-research/scripts/research_cli.mjs
+++ b/tiangong-auto-research/scripts/research_cli.mjs
@@ -51,11 +51,7 @@ export async function resolveWorkspaceRuntime(workspaceInput) {
   try {
     lockStat = await lstat(lockPath);
   } catch {
-    throw resolverError(
-      "AUTO_RESEARCH_RUNTIME_LOCK_REQUIRED",
-      "No Auto Research runtime lock is available for this workspace.",
-      "For a new directory, explicitly choose a reviewed exact CLI version and run research setup. Do not use npm latest implicitly.",
-    );
+    return resolvePlannedRuntime(workspace);
   }
   if (lockStat.isSymbolicLink() || !lockStat.isFile() || lockStat.size < 2 || lockStat.size > MAX_RUNTIME_LOCK_BYTES) {
     throw resolverError(
@@ -95,6 +91,69 @@ export async function resolveWorkspaceRuntime(workspaceInput) {
   return {
     packageName: CLI_PACKAGE,
     packageVersion: lock.packageVersion,
+    source: "runtime-lock",
+  };
+}
+
+async function resolvePlannedRuntime(workspace) {
+  const planPath = join(workspace, ".tiangong-research", "setup-plan.json");
+  let planStat;
+  try {
+    planStat = await lstat(planPath);
+  } catch {
+    throw resolverError(
+      "AUTO_RESEARCH_RUNTIME_LOCK_REQUIRED",
+      "No Auto Research runtime lock or reviewed setup plan is available for this workspace.",
+      "For a new directory, explicitly choose a reviewed exact CLI version and run research setup. Do not use npm latest implicitly.",
+    );
+  }
+  if (
+    planStat.isSymbolicLink() ||
+    !planStat.isFile() ||
+    planStat.size < 2 ||
+    planStat.size > MAX_RUNTIME_LOCK_BYTES
+  ) {
+    throw resolverError(
+      "AUTO_RESEARCH_SETUP_PLAN_INVALID",
+      "The Auto Research setup plan must be a bounded regular non-symlink file.",
+      "Restore the CLI-created setup-plan.json or create a new reviewed plan; do not edit the plan by hand.",
+    );
+  }
+  let plan;
+  try {
+    plan = JSON.parse(await readFile(planPath, "utf8"));
+  } catch {
+    throw resolverError(
+      "AUTO_RESEARCH_SETUP_PLAN_INVALID",
+      "The Auto Research setup plan is not valid JSON.",
+      "Restore the CLI-created setup-plan.json or create a new reviewed plan; do not edit the plan by hand.",
+    );
+  }
+  if (
+    plan === null ||
+    typeof plan !== "object" ||
+    Array.isArray(plan) ||
+    plan.schemaVersion !== 1 ||
+    plan.kind !== "tiangong-research-setup-plan" ||
+    plan.cli === null ||
+    typeof plan.cli !== "object" ||
+    Array.isArray(plan.cli) ||
+    plan.cli.package !== CLI_PACKAGE ||
+    typeof plan.cli.version !== "string" ||
+    !EXACT_STABLE_SEMVER.test(plan.cli.version) ||
+    typeof plan.planSha256 !== "string" ||
+    !/^[0-9a-f]{64}$/.test(plan.planSha256)
+  ) {
+    throw resolverError(
+      "AUTO_RESEARCH_SETUP_PLAN_INVALID",
+      "The Auto Research setup plan does not declare the supported exact CLI runtime.",
+      "Create a new immutable plan with a reviewed exact CLI version; tags, ranges, paths, and command fragments are forbidden.",
+    );
+  }
+  return {
+    packageName: CLI_PACKAGE,
+    packageVersion: plan.cli.version,
+    source: "setup-plan",
   };
 }
 

--- a/tiangong-auto-research/scripts/test-research-cli.mjs
+++ b/tiangong-auto-research/scripts/test-research-cli.mjs
@@ -12,7 +12,7 @@ const root = await mkdtemp(join(tmpdir(), "tiangong-auto-research-resolver-"));
 const fakeBin = join(root, "bin");
 const auditPath = join(root, "npx-args.json");
 const cliPackage = "@tiangong-ai/cli";
-const lockedVersion = "0.0.30";
+const lockedVersion = "9.8.7";
 await mkdir(fakeBin);
 const fakeNpx = join(fakeBin, "npx");
 await writeFile(
@@ -69,10 +69,45 @@ assert.deepEqual(JSON.parse(await readFile(auditPath, "utf8")), [
   "--json",
 ]);
 
+const plannedWorkspace = await createWorkspace("planned");
+await writeFile(
+  join(plannedWorkspace, ".tiangong-research", "setup-plan.json"),
+  JSON.stringify({
+    schemaVersion: 1,
+    kind: "tiangong-research-setup-plan",
+    cli: { package: cliPackage, version: "8.7.6" },
+    planSha256: "a".repeat(64),
+  }),
+  "utf8",
+);
+await writeFile(
+  join(plannedWorkspace, ".tiangong-research", "setup-state.json"),
+  JSON.stringify({
+    schemaVersion: 1,
+    status: "pending",
+    currentStep: null,
+    lastError: null,
+  }),
+  "utf8",
+);
+const planned = invoke(plannedWorkspace);
+assert.equal(planned.status, 0, planned.stderr);
+assert.deepEqual(JSON.parse(await readFile(auditPath, "utf8")), [
+  "--yes",
+  "--package",
+  `${cliPackage}@8.7.6`,
+  "--",
+  "tiangong-ai",
+  "research",
+  "setup",
+  "status",
+  "--json",
+]);
+
 const injectionWorkspace = await createWorkspace("injection", {
-  schemaVersion: 1,
-  packageName: cliPackage,
-  packageVersion: "0.0.30;echo-token",
+    schemaVersion: 1,
+    packageName: cliPackage,
+    packageVersion: "9.8.7;echo-token",
 });
 const injection = invoke(injectionWorkspace);
 assert.equal(injection.status, 2);

--- a/tiangong-kb-patent-search/scripts/patent_search.sh
+++ b/tiangong-kb-patent-search/scripts/patent_search.sh
@@ -50,11 +50,13 @@ esac
 find_auto_research_workspace() {
     local search_dir
     local lock_path
+    local plan_path
     local parent_dir
     search_dir="$(pwd -P)"
     while :; do
         lock_path="$search_dir/.tiangong-research/runtime-lock.json"
-        if [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+        plan_path="$search_dir/.tiangong-research/setup-plan.json"
+        if [ -e "$lock_path" ] || [ -L "$lock_path" ] || [ -e "$plan_path" ] || [ -L "$plan_path" ]; then
             return 0
         fi
         parent_dir="$(dirname "$search_dir")"

--- a/tiangong-kb-patent-search/scripts/test-patent-search.sh
+++ b/tiangong-kb-patent-search/scripts/test-patent-search.sh
@@ -71,6 +71,17 @@ grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
 grep -F '"credentialScope":"broker"' "$STDERR" >/dev/null
 grep -F '"networkAttempted":false' "$STDERR" >/dev/null
 
+rm "$MANAGED_WORKSPACE/.tiangong-research/runtime-lock.json"
+printf '%s\n' '{"schemaVersion":1,"kind":"tiangong-research-setup-plan","cli":{"package":"@tiangong-ai/cli","version":"9.8.7"},"planSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' \
+    > "$MANAGED_WORKSPACE/.tiangong-research/setup-plan.json"
+if (cd "$MANAGED_NESTED" && run_wrapper '{"query":"planned patent work"}') \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'plan-only patent workspace bypassed the broker guard' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
+
 (cd "$MANAGED_NESTED" && \
     TIANGONG_PATENT_APIKEY="$SECRET" \
     run_wrapper '{"query":"isolated patent","execution_mode":"standalone","dry_run":true}') \

--- a/tiangong-kb-report-search/scripts/report_search.sh
+++ b/tiangong-kb-report-search/scripts/report_search.sh
@@ -52,11 +52,13 @@ esac
 find_auto_research_workspace() {
     local search_dir
     local lock_path
+    local plan_path
     local parent_dir
     search_dir="$(pwd -P)"
     while :; do
         lock_path="$search_dir/.tiangong-research/runtime-lock.json"
-        if [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+        plan_path="$search_dir/.tiangong-research/setup-plan.json"
+        if [ -e "$lock_path" ] || [ -L "$lock_path" ] || [ -e "$plan_path" ] || [ -L "$plan_path" ]; then
             return 0
         fi
         parent_dir="$(dirname "$search_dir")"

--- a/tiangong-kb-report-search/scripts/test-report-search.sh
+++ b/tiangong-kb-report-search/scripts/test-report-search.sh
@@ -71,6 +71,17 @@ grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
 grep -F '"credentialScope":"broker"' "$STDERR" >/dev/null
 grep -F '"networkAttempted":false' "$STDERR" >/dev/null
 
+rm "$MANAGED_WORKSPACE/.tiangong-research/runtime-lock.json"
+printf '%s\n' '{"schemaVersion":1,"kind":"tiangong-research-setup-plan","cli":{"package":"@tiangong-ai/cli","version":"9.8.7"},"planSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' \
+    > "$MANAGED_WORKSPACE/.tiangong-research/setup-plan.json"
+if (cd "$MANAGED_NESTED" && run_wrapper '{"query":"planned report work"}') \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'plan-only report workspace bypassed the broker guard' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
+
 (cd "$MANAGED_NESTED" && \
     TIANGONG_REPORT_APIKEY="$SECRET" \
     run_wrapper '{"query":"isolated report","execution_mode":"standalone","dry_run":true}') \

--- a/tiangong-kb-sci-search/SKILL.md
+++ b/tiangong-kb-sci-search/SKILL.md
@@ -26,7 +26,8 @@ service failure; do not try to bypass it.
 
 - The standalone wrapper defaults to its separately tested CLI version
   `0.0.30`. This is not the Auto Research workspace runtime. Managed research
-  resolves its exact version from `runtime-lock.json` and must use the broker.
+  resolves its exact version from the immutable setup plan or
+  `runtime-lock.json` and must use the broker.
   Set `TIANGONG_AI_CLI_BIN` to one exact executable path, or
   `TIANGONG_AI_CLI` to an explicitly reviewed command, only when overriding the
   standalone entrypoint intentionally.

--- a/tiangong-kb-sci-search/scripts/sci_search.sh
+++ b/tiangong-kb-sci-search/scripts/sci_search.sh
@@ -54,11 +54,13 @@ esac
 find_auto_research_workspace() {
     local search_dir
     local lock_path
+    local plan_path
     local parent_dir
     search_dir="$(pwd -P)"
     while :; do
         lock_path="$search_dir/.tiangong-research/runtime-lock.json"
-        if [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+        plan_path="$search_dir/.tiangong-research/setup-plan.json"
+        if [ -e "$lock_path" ] || [ -L "$lock_path" ] || [ -e "$plan_path" ] || [ -L "$plan_path" ]; then
             return 0
         fi
         parent_dir="$(dirname "$search_dir")"

--- a/tiangong-kb-sci-search/scripts/test-sci-search.sh
+++ b/tiangong-kb-sci-search/scripts/test-sci-search.sh
@@ -64,6 +64,17 @@ grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
 grep -F '"credentialScope":"broker"' "$STDERR" >/dev/null
 grep -F '"networkAttempted":false' "$STDERR" >/dev/null
 
+rm "$MANAGED_WORKSPACE/.tiangong-research/runtime-lock.json"
+printf '%s\n' '{"schemaVersion":1,"kind":"tiangong-research-setup-plan","cli":{"package":"@tiangong-ai/cli","version":"9.8.7"},"planSha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}' \
+    > "$MANAGED_WORKSPACE/.tiangong-research/setup-plan.json"
+if (cd "$MANAGED_NESTED" && run_wrapper '{"query":"planned managed query"}') \
+    > "$STDOUT" 2> "$STDERR"; then
+    echo 'plan-only workspace bypassed the Auto Research broker guard' >&2
+    exit 1
+fi
+[ ! -e "$MARKER" ]
+grep -F 'AUTO_RESEARCH_BROKER_REQUIRED' "$STDERR" >/dev/null
+
 (cd "$MANAGED_NESTED" && \
     TIANGONG_SCI_APIKEY="$SECRET" \
     run_wrapper '{"query":"isolated query","execution_mode":"standalone","dry_run":true}') \


### PR DESCRIPTION
Refs tiangong-ai/workspace#120

## Summary
- let the orchestrator resolver use the immutable setup plan while runtime-lock is not available
- make SCI/report/patent wrappers fail closed for plan-only managed workspaces
- document the CLI-generated recovery-only routing Skill
- require no-cache, non-root, runtime-offline Docker validation for Auto Research and direct wrappers
- align docpact CI with 0.1.9

## Validation
- `scripts/test-clean-container.sh`
- Skill Creator `quick_validate.py` for auto-research and SCI/report/patent Skills in a clean Debian container
- docpact 0.1.9 strict validation and worktree lint
- `git diff --check`

## Delivery dependency
Merge this PR before publishing the paired CLI release. The CLI release audit requires its pinned first-party Skills commit to be reachable from `main`.