### PR TITLE
feat(auto-research): add top-journal research policy

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-12"
-lastReviewedCommit: "3d5d85f41bac03b7b31208e89d6c5e56da320baf"
+lastReviewedAt: "2026-08-13"
+lastReviewedCommit: "126b3e177739064f5b4b29eb240930c9020bb2ef"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-12
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-13
+lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -118,3 +118,13 @@ bundled or installed by a research package. See
 `tiangong-auto-research/references/setup.md` and `external-skills.md`.
 For PPT creation, prefer PPT Master; Anthropic PPTX remains compatible and may
 be selected alongside it when its workflow fits the task.
+
+For a top-journal goal, the orchestrator includes a conservative Research
+Policy template pack for article type, field, journal class, project brief, and
+four independent final-review roles. The CLI Policy Wizard copies the selected
+Markdown into the research workspace for human review; it reports when generic
+defaults remain, requires explicit approval of the exact content hash, and
+invalidates approval after any edit or expiry. Exact-journal readiness requires
+current official guidance and substantive human customization. These gates can
+produce a reviewable submission candidate, never a promise of editorial
+acceptance. See `tiangong-auto-research/references/publication-policy.md`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,3 +113,11 @@ Anthropic 或 PPT Master 闭环后创作 Skills。workspace 可以是用户指�
 `tiangong-auto-research/references/setup.md` 和 `external-skills.md`。
 创建 PPT 时首选 PPT Master；Anthropic PPTX 仍是兼容的按场景选项，需要时可在
 同一显式计划中一起选择。
+
+当目标是顶刊论文时，orchestrator 提供保守的 Research Policy 默认模板，覆盖文章
+类型、学科、期刊类别、项目 publication brief，以及四个独立终稿审阅角色。CLI
+Policy Wizard 会把所选 Markdown 复制到研究 workspace 供人类审阅；仍在使用通用
+默认内容时会明确提示，审批必须绑定当前内容的精确哈希，任何后续修改或过期都会使
+审批失效。只有依据当前官方指南做出实质性人工定制，才可能达到精确目标期刊的就绪
+上限。这套门禁只能产出可复核的投稿候选稿，不能承诺编辑接受。详见
+`tiangong-auto-research/references/publication-policy.md`。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-12
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-13
+lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -45,6 +45,12 @@ copy/symlink installation. Some skills require environment variables for
 external APIs; those requirements belong in the relevant skill docs and the
 repository README when broadly useful.
 
+`tiangong-auto-research/assets/research-policy/defaults/**` is the versioned,
+generic source pack for top-journal Policy initialization. It is immutable
+source material, not a user Policy or journal endorsement. The CLI copies a
+selected stack into the user-selected research workspace, where a human may
+customize and explicitly approve the exact resolved content.
+
 ## Integration Points
 
 - The root workspace pins this repository as a submodule.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -34,6 +34,10 @@ marketplace grouping metadata.
   the workspace repository.
 - Runtime credentials and user-private data do not belong in skill assets,
   references, or scripts.
+- Default Research Policy assets must remain conservative, non-secret, and
+  visibly generic. They must not claim target-journal fit or acceptance; user
+  customization, approval, expiry, and hash enforcement belong to the CLI and
+  research workspace.
 
 ## Skill Surface
 

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -59,9 +59,10 @@ scripts/test-clean-container.sh
 
 It performs a no-cache build from the digest-pinned Node 24 image, copies only
 the secret-filtered repository context, and runs the routing, resolver, agent
-wrapper, and evidence-wrapper suites as a non-root user with isolated HOME and
-runtime networking disabled. Do not mount host agent directories, CLIs, caches,
-credentials, browser profiles, or source worktrees into the running container.
+wrapper, Research Policy pack, and evidence-wrapper suites as a non-root user
+with isolated HOME and runtime networking disabled. Do not mount host agent
+directories, CLIs, caches, credentials, browser profiles, or source worktrees
+into the running container.
 
 ## README And Marketplace Updates
 

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-12
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-13
+lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
 ---
 
 # Skills Documentation Standards

--- a/scripts/run-auto-research-tests.sh
+++ b/scripts/run-auto-research-tests.sh
@@ -14,6 +14,7 @@ fi
 
 node tiangong-auto-research/scripts/test-research-cli.mjs
 node tiangong-auto-research/scripts/test-routing-contract.mjs
+node tiangong-auto-research/scripts/test-research-policy-pack.mjs
 sh tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
 bash tiangong-kb-sci-search/scripts/test-sci-search.sh
 bash tiangong-kb-report-search/scripts/test-report-search.sh

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -50,6 +50,9 @@ detailed stop and recovery rules.
   discovery, acquisition, evidence refresh, or an addendum.
 - Read [references/native-execution.md](references/native-execution.md) before
   preparing or submitting discover, acquire, analyze, or synthesize stages.
+- Read [references/publication-policy.md](references/publication-policy.md)
+  before a top-journal project, Policy approval, final manuscript freeze,
+  four-role publication review, or readiness closure.
 
 ## Choose the mode before spending budget
 
@@ -125,6 +128,12 @@ required credentials must block before any source download.
   operation. Their failure never authorizes a standalone evidence downgrade.
 
 ## Preflight and initialize a project
+
+For `--goal top-journal`, first use the project-scoped Policy Wizard and stop
+unless its exact reviewed hash is approved. Generic defaults are bounded
+feasibility guidance, not journal endorsement. Follow
+[references/publication-policy.md](references/publication-policy.md); never
+invent a target-journal policy or bypass its status gate.
 
 Prepare evidence requirements with `dimensions`, `sourceTypes`,
 `requiredCapabilityIds`, `requiredCompanionIds`, `requiredDiscoveryScopes`,
@@ -226,3 +235,10 @@ substitutes. Resume only after the handoff is explicitly resolved. A complete
 project has a passing independent review, `outputs/report.md`, and
 `outputs/closure.json`. Return the permanent evidence locators, review-packet
 binding, usage/cost, decision, and material limitations.
+
+For a top-journal goal, that base closure is not publication closure. Author the
+final paper in this current native host, freeze its exact manuscript and
+assessment, obtain fresh evidence, methods/reproducibility, domain/novelty, and
+journal-editor reviews, then mechanically close the publication generation.
+Any Policy or manuscript change invalidates downstream approval/review. Return
+only the CLI-computed bounded readiness language; never promise acceptance.

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Run native-host research with independent review"
-  default_prompt: "Use $tiangong-auto-research for this open-ended or multi-source research task. Resolve the exact CLI from the workspace runtime lock, verify required capabilities and budget, perform producer stages in this current native host, and use the other agent family only for independent review."
+  short_description: "Run native research with policy-bound review"
+  default_prompt: "Use $tiangong-auto-research for this open-ended or multi-source research task. Resolve the exact CLI from the workspace runtime lock, verify required capabilities, budget, and any top-journal Research Policy, perform producer and manuscript work in this current native host, and use fresh independent reviewer sessions only through the controlled review workflow."

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/computational-modeling.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/computational-modeling.md
@@ -12,6 +12,12 @@ rules:
   - uncertainty-propagated
   - baseline-comparison-required
   - material-results-reproduced
+constraints:
+  minDirectPeerReviewedFullText: 5
+  minDirectModelFullText: 1
+  requireRecallAudit: true
+  requireCentralDimensionsCovered: true
+  requireIndependentReproduction: true
 requiredReviewers:
   - evidence
   - methods-reproducibility

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/computational-modeling.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/computational-modeling.md
@@ -1,0 +1,68 @@
+---
+schemaVersion: 1
+id: article.computational-modeling
+kind: article-type
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+articleType: computational-modeling
+rules:
+  - model-calibrated-or-justified
+  - independent-validation-required
+  - uncertainty-propagated
+  - baseline-comparison-required
+  - material-results-reproduced
+requiredReviewers:
+  - evidence
+  - methods-reproducibility
+  - domain-novelty
+  - journal-editor
+reviewAfterDays: 180
+---
+
+# Default computational and modeling research policy
+
+## Scope
+
+Use when the central contribution is a computational method, simulation,
+integrated model, forecast, or quantitatively tested mechanism.
+
+## Editorial significance
+
+Require a capability, mechanism, or decision insight unavailable from existing
+models, not merely a new scenario using familiar equations.
+
+## Evidence expectations
+
+Bind each parameter and calibration target to applicable evidence. Distinguish
+assumed, fitted, transferred, and independently measured values.
+
+## Methods and validation
+
+Require baseline comparisons, identifiability or sensitivity analysis,
+uncertainty propagation, failure cases, and independent empirical validation
+where the paper makes real-world claims.
+
+## Reproducibility
+
+Freeze executable code, environment, seeds, inputs, configuration, and the
+complete table and figure generation path.
+
+## Desk-reject triggers
+
+- The main result follows algebraically from assumptions.
+- Calibration and validation use the same evidence without justification.
+- A scenario analysis is presented as a forecast or observed effect.
+- Code or material parameters cannot be independently reconstructed.
+
+## Required reviewer questions
+
+- What observation could falsify the modeled mechanism?
+- Does the model outperform a credible simple baseline?
+- Are uncertainty and parameter dependence visible in the main conclusions?
+- Is validation independent of model construction?
+
+## Permitted pivots
+
+Narrow the claim to an illustrative framework, obtain validation data, publish
+the method or resource separately, or convert the work to a Perspective.

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/methods-data-resource.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/methods-data-resource.md
@@ -1,0 +1,64 @@
+---
+schemaVersion: 1
+id: article.methods-data-resource
+kind: article-type
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+articleType: methods-data-resource
+rules:
+  - benchmark-comparison-required
+  - reuse-value-demonstrated
+  - availability-contract-required
+  - material-results-reproduced
+requiredReviewers:
+  - evidence
+  - methods-reproducibility
+  - domain-novelty
+  - journal-editor
+reviewAfterDays: 180
+---
+
+# Default methods, data, and resource policy
+
+## Scope
+
+Use when the primary contribution is a reusable method, dataset, benchmark,
+software system, protocol, or community resource.
+
+## Editorial significance
+
+Require broad enabling value, a clear unmet need, and credible adoption or
+scientific impact beyond the authors' immediate application.
+
+## Evidence expectations
+
+Document provenance, coverage, missingness, bias, quality controls, licensing,
+and intended and prohibited uses of the resource.
+
+## Methods and validation
+
+Compare with strong baselines on representative tasks, report failure modes,
+and demonstrate reuse by an independent workflow or held-out application.
+
+## Reproducibility
+
+Provide exact versioned artifacts, schemas, environments, examples, and a
+verified path from raw inputs to released outputs.
+
+## Desk-reject triggers
+
+- The resource is unavailable, unstable, or insufficiently documented.
+- Evaluation uses weak baselines or only the construction dataset.
+- The contribution is engineering scale without a scientific advance.
+
+## Required reviewer questions
+
+- Can an independent group reproduce and reuse the contribution?
+- Does the benchmark measure the claimed capability without leakage?
+- Are licensing, governance, and maintenance credible?
+
+## Permitted pivots
+
+Release a validated resource first, narrow the application claim, add an
+independent benchmark, or target a specialist methods or data journal.

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/methods-data-resource.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/methods-data-resource.md
@@ -11,6 +11,11 @@ rules:
   - reuse-value-demonstrated
   - availability-contract-required
   - material-results-reproduced
+constraints:
+  minDirectPeerReviewedFullText: 3
+  minDirectEmpiricalFullText: 1
+  requireRecallAudit: true
+  requireIndependentReproduction: true
 requiredReviewers:
   - evidence
   - methods-reproducibility

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/original-empirical.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/original-empirical.md
@@ -1,0 +1,69 @@
+---
+schemaVersion: 1
+id: article.original-empirical
+kind: article-type
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+articleType: original-empirical
+rules:
+  - central-outcome-observed
+  - central-claim-directly-supported
+  - alternative-explanations-tested
+  - robustness-evidence-required
+  - material-results-reproduced
+requiredReviewers:
+  - evidence
+  - methods-reproducibility
+  - domain-novelty
+  - journal-editor
+reviewAfterDays: 180
+---
+
+# Default original empirical research policy
+
+## Scope
+
+Use for papers whose central contribution is a new observation, estimate,
+experiment, causal result, or empirically validated prediction.
+
+## Editorial significance
+
+Require a result that changes understanding, practice, or a material decision;
+sample size or a new setting alone is not sufficient novelty.
+
+## Evidence expectations
+
+Require direct data for the central outcome, a justified sampling frame, and
+evidence that supports the claimed population, place, and period.
+
+## Methods and validation
+
+Require an identified estimand or target quantity, a defensible design,
+diagnostics, uncertainty, robustness checks, and explicit tests of plausible
+alternative explanations. Prediction claims require external or genuinely
+held-out validation.
+
+## Reproducibility
+
+Recompute every material number, table, and figure from exact registered data
+and code in a clean environment. Unreproduced owner results are reference-only.
+
+## Desk-reject triggers
+
+- The central outcome is not observed or validated.
+- Main results are illustrative algebra or hard-coded statistics.
+- The title generalizes beyond the study design or evidence.
+- The closest prior empirical studies are absent from the novelty comparison.
+
+## Required reviewer questions
+
+- Is the central estimate identified by the design rather than asserted?
+- Which robustness result would most likely reverse the conclusion?
+- Does the evidence support the claimed external scope?
+- Is the empirical contribution clearly distinct from the closest prior work?
+
+## Permitted pivots
+
+Collect or obtain additional data, narrow the estimand and scope, convert the
+work to a methods or modeling paper, or recast it as a Perspective.

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/original-empirical.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/original-empirical.md
@@ -12,6 +12,12 @@ rules:
   - alternative-explanations-tested
   - robustness-evidence-required
   - material-results-reproduced
+constraints:
+  minDirectPeerReviewedFullText: 5
+  minDirectEmpiricalFullText: 1
+  requireRecallAudit: true
+  requireCentralDimensionsCovered: true
+  requireIndependentReproduction: true
 requiredReviewers:
   - evidence
   - methods-reproducibility

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/perspective-theory.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/perspective-theory.md
@@ -11,6 +11,9 @@ rules:
   - empirical-boundaries-explicit
   - counterargument-required
   - novelty-comparison-required
+constraints:
+  minDirectPeerReviewedFullText: 3
+  requireRecallAudit: true
 requiredReviewers:
   - evidence
   - domain-novelty

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/perspective-theory.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/perspective-theory.md
@@ -1,0 +1,66 @@
+---
+schemaVersion: 1
+id: article.perspective-theory
+kind: article-type
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+articleType: perspective-theory
+rules:
+  - conceptual-contribution-required
+  - empirical-boundaries-explicit
+  - counterargument-required
+  - novelty-comparison-required
+requiredReviewers:
+  - evidence
+  - domain-novelty
+  - journal-editor
+reviewAfterDays: 180
+---
+
+# Default Perspective and theory policy
+
+## Scope
+
+Use for a conceptual framework, theory, Perspective, agenda, or synthesis that
+does not claim a new empirical estimate.
+
+## Editorial significance
+
+Require a compelling reframing, mechanism, taxonomy, or agenda that changes how
+a broad expert audience understands or studies an important problem.
+
+## Evidence expectations
+
+Represent the strongest supporting and opposing literature. Clearly separate
+established findings, interpretation, conjecture, and proposed future tests.
+
+## Methods and validation
+
+Test internal coherence, boundary conditions, counterexamples, alternative
+frameworks, and falsifiable implications. Do not simulate empirical validation
+with illustrative arithmetic.
+
+## Reproducibility
+
+Freeze the evidence map, claim graph, conceptual derivations, and any scenario
+calculations used to illustrate the framework.
+
+## Desk-reject triggers
+
+- The framework merely renames known concepts.
+- Empirical language exceeds the admitted evidence.
+- Counterarguments and closest competing frameworks are omitted.
+- The journal has not invited or does not accept the proposed article type.
+
+## Required reviewer questions
+
+- What thinking or research decision changes if this framework is adopted?
+- Which observation would falsify or materially limit it?
+- Is the distinction from prior frameworks explicit and fair?
+
+## Permitted pivots
+
+Narrow the conceptual claim, add empirical validation, target an invited
+Perspective venue, or deliver the result as a research agenda rather than an
+original research article.

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/systematic-review-meta-analysis.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/systematic-review-meta-analysis.md
@@ -1,0 +1,68 @@
+---
+schemaVersion: 1
+id: article.systematic-review-meta-analysis
+kind: article-type
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+articleType: systematic-review-meta-analysis
+rules:
+  - protocol-required
+  - complete-candidate-disposition-required
+  - recall-audit-required
+  - risk-of-bias-required
+  - synthesis-method-justified
+requiredReviewers:
+  - evidence
+  - methods-reproducibility
+  - domain-novelty
+  - journal-editor
+reviewAfterDays: 180
+---
+
+# Default systematic review and meta-analysis policy
+
+## Scope
+
+Use for systematic reviews, scoping reviews that claim systematic coverage, and
+quantitative evidence synthesis.
+
+## Editorial significance
+
+Require a decision-relevant unresolved question, a defensible synthesis beyond
+listing studies, and a clear explanation of why an updated review matters.
+
+## Evidence expectations
+
+Define databases, date bounds, query families, eligibility criteria, duplicate
+handling, backward and forward citation search, and a disposition for every
+candidate. Metadata-only records cannot substitute for required full text.
+
+## Methods and validation
+
+Use an applicable reporting guideline, protocol, risk-of-bias assessment,
+heterogeneity analysis, sensitivity checks, and justified synthesis model.
+
+## Reproducibility
+
+Freeze all queries, dates, result sets, screening decisions, exclusion reasons,
+extractions, transformations, and analysis code.
+
+## Desk-reject triggers
+
+- Unassessed candidates remain when completeness is claimed.
+- Core databases or known landmark studies are missing.
+- Search stops at a source-count minimum rather than saturation and recall.
+- Heterogeneous evidence is pooled without a defensible model.
+
+## Required reviewer questions
+
+- Which omitted database, query synonym, or citation chain could change recall?
+- Are exclusion reasons complete and reproducible?
+- Is risk of bias propagated into the main conclusion?
+- Does the synthesis add knowledge beyond prior reviews?
+
+## Permitted pivots
+
+Narrow the review question, label the work as a scoping or narrative review,
+extend screening, or publish a protocol while evidence collection continues.

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/systematic-review-meta-analysis.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/systematic-review-meta-analysis.md
@@ -12,6 +12,11 @@ rules:
   - recall-audit-required
   - risk-of-bias-required
   - synthesis-method-justified
+constraints:
+  minDirectPeerReviewedFullText: 8
+  requireCompleteCandidateDisposition: true
+  requireRecallAudit: true
+  requireCentralDimensionsCovered: true
 requiredReviewers:
   - evidence
   - methods-reproducibility

--- a/tiangong-auto-research/assets/research-policy/defaults/baseline/top-journal.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/baseline/top-journal.md
@@ -11,6 +11,11 @@ rules:
   - material-results-reproduced
   - alternative-explanations-tested
   - final-manuscript-reviewed
+constraints:
+  minDirectPeerReviewedFullText: 3
+  requireRecallAudit: true
+  requireCentralDimensionsCovered: true
+  requireIndependentReproduction: true
 requiredReviewers:
   - evidence
   - methods-reproducibility

--- a/tiangong-auto-research/assets/research-policy/defaults/baseline/top-journal.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/baseline/top-journal.md
@@ -1,0 +1,80 @@
+---
+schemaVersion: 1
+id: baseline.top-journal
+kind: baseline
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+rules:
+  - central-claim-directly-supported
+  - contribution-non-incremental
+  - material-results-reproduced
+  - alternative-explanations-tested
+  - final-manuscript-reviewed
+requiredReviewers:
+  - evidence
+  - methods-reproducibility
+  - domain-novelty
+  - journal-editor
+reviewAfterDays: 180
+---
+
+# Default top-journal baseline
+
+This is a conservative generic default. It supports feasibility research but is
+not a journal-specific endorsement and cannot by itself establish submission
+readiness.
+
+## Scope
+
+Apply this baseline when the intended contribution targets a highly selective
+general or disciplinary journal. Combine it with one article-type policy, one
+field policy, one journal-class or exact-journal policy, and a project brief.
+
+## Editorial significance
+
+Require a consequential, timely, and non-incremental contribution whose value
+is legible beyond the immediate dataset or case. A technically correct result
+without a credible importance argument does not pass.
+
+## Evidence expectations
+
+Bind every central claim to direct, applicable evidence. Separate direct
+peer-reviewed full text from metadata, background, administrative material,
+owner input, and internal synthesis. A central partial or missing dimension is
+blocking for an original or systematic claim.
+
+## Methods and validation
+
+Require a research design capable of answering the central question, explicit
+assumptions, tested alternative explanations, uncertainty analysis, and
+validation appropriate to the claimed scope. Disclosed fatal gaps remain fatal.
+
+## Reproducibility
+
+Bind data, code, parameters, commands, tables, figures, and derived statistics
+to exact artifacts. Do not treat a provenance description or hard-coded value
+as computational reproduction.
+
+## Desk-reject triggers
+
+- The central result is an identity, illustrative sensitivity, or agenda item
+  presented as an empirical discovery.
+- The title or abstract promises an outcome that was not observed, calibrated,
+  or validated.
+- The contribution is incremental, outside scope, or unsupported by direct
+  evidence.
+- The final manuscript was created or materially changed after review.
+
+## Required reviewer questions
+
+- What is genuinely new, and which closest prior work could defeat that claim?
+- Which central claim has the weakest direct evidence or validation?
+- What plausible alternative explanation remains untested?
+- Would a target editor send this exact frozen manuscript to external review?
+
+## Permitted pivots
+
+Pivot to a Perspective, evidence report, research protocol, additional data or
+experiments, a different journal class, or an external-response handoff. Never
+preserve a top-journal verdict by relabeling a blocking gap as a limitation.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/earth-environment.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/earth-environment.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.earth-environment
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: earth-environment
+rules:
+  - spatial-temporal-applicability-required
+  - scale-and-boundary-effects-tested
+reviewAfterDays: 180
+---
+
+# Default earth and environmental sciences policy
+
+Require explicit spatial, temporal, system, and functional boundaries;
+measurement or model uncertainty; scale dependence; and validation across the
+conditions to which the conclusion is generalized. Separate scenario,
+attribution, forecasting, and causal claims.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/economics-management.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/economics-management.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.economics-management
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: economics-management
+rules:
+  - identification-strategy-required
+  - economic-significance-required
+reviewAfterDays: 180
+---
+
+# Default economics and management policy
+
+Require a clear estimand, identification assumptions, institutional context,
+economic as well as statistical significance, robustness to specification and
+sample choices, mechanisms, and a contribution compared fairly with the closest
+theoretical and empirical literature.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/engineering-computing.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/engineering-computing.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.engineering-computing
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: engineering-computing
+rules:
+  - strong-baseline-required
+  - realistic-operating-conditions-required
+reviewAfterDays: 180
+---
+
+# Default engineering and computing policy
+
+Require strong and current baselines, ablations, realistic operating
+conditions, resource and failure analysis, and a clear distinction between
+engineering scale and scientific novelty. Claims about deployment require
+evidence outside a curated benchmark or single laboratory configuration.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/humanities.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/humanities.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.humanities
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: humanities
+rules:
+  - primary-material-context-required
+  - interpretive-contribution-required
+reviewAfterDays: 180
+---
+
+# Default humanities policy
+
+Require authoritative primary materials, historical and linguistic context,
+transparent selection and interpretation, engagement with the strongest
+competing readings, and a non-incremental contribution to the relevant
+scholarly conversation. Customize discipline-specific source criticism.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/life-health.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/life-health.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.life-health
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: life-health
+rules:
+  - biological-or-clinical-relevance-required
+  - ethics-and-governance-reviewed
+reviewAfterDays: 180
+---
+
+# Default life and health sciences policy
+
+Require biologically or clinically meaningful endpoints, appropriate controls,
+population and model-system applicability, uncertainty, ethical approval where
+applicable, and explicit separation of exploratory and confirmatory findings.
+Customize the reporting guideline and study-design requirements.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/multidisciplinary.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/multidisciplinary.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.multidisciplinary
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: multidisciplinary
+rules:
+  - cross-field-significance-required
+  - terminology-accessible-across-fields
+reviewAfterDays: 180
+---
+
+# Default multidisciplinary field policy
+
+Require an advance whose significance survives outside one specialist
+community, accessible definitions, and validation credible to every discipline
+on which the central claim depends. Customize the disciplinary methods,
+reporting standards, and field-specific failure modes before analysis.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/physical-chemical-materials.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/physical-chemical-materials.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.physical-chemical-materials
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: physical-chemical-materials
+rules:
+  - physical-mechanism-tested
+  - characterization-and-uncertainty-required
+reviewAfterDays: 180
+---
+
+# Default physical, chemical, and materials sciences policy
+
+Require a defensible mechanism, calibrated instrumentation, characterization
+appropriate to the central claim, uncertainty and controls, comparison with the
+state of the art, and evidence that performance persists under relevant
+conditions rather than only an ideal laboratory setting.

--- a/tiangong-auto-research/assets/research-policy/defaults/fields/social-behavioral.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/fields/social-behavioral.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: field.social-behavioral
+kind: field
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+field: social-behavioral
+rules:
+  - construct-validity-required
+  - identification-and-context-required
+reviewAfterDays: 180
+---
+
+# Default social and behavioral sciences policy
+
+Require construct validity, sampling and measurement transparency, a defensible
+identification strategy for causal language, contextual applicability,
+alternative mechanisms, uncertainty, ethics, and a clear boundary between
+descriptive association, prediction, interpretation, and causation.

--- a/tiangong-auto-research/assets/research-policy/defaults/journal-classes/discipline-flagship.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/journal-classes/discipline-flagship.md
@@ -1,0 +1,19 @@
+---
+schemaVersion: 1
+id: journal-class.discipline-flagship
+kind: journal-class
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+journalClass: discipline-flagship
+rules:
+  - field-shaping-contribution-required
+  - specialist-methods-scrutiny-required
+reviewAfterDays: 90
+---
+
+# Default disciplinary flagship journal policy
+
+Require a field-shaping contribution, command of the closest specialist
+literature, and methods strong enough for expert scrutiny. The paper must matter
+to a substantial part of the discipline, not only one narrow application.

--- a/tiangong-auto-research/assets/research-policy/defaults/journal-classes/methods-data-journal.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/journal-classes/methods-data-journal.md
@@ -1,0 +1,19 @@
+---
+schemaVersion: 1
+id: journal-class.methods-data-journal
+kind: journal-class
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+journalClass: methods-data-journal
+rules:
+  - availability-contract-required
+  - independent-reuse-demonstrated
+reviewAfterDays: 90
+---
+
+# Default top methods and data journal policy
+
+Require durable availability, precise metadata and interfaces, quality and bias
+audits, strong benchmark comparisons, and an independent reuse demonstration.
+Scientific utility must extend beyond the paper's motivating example.

--- a/tiangong-auto-research/assets/research-policy/defaults/journal-classes/multidisciplinary-selective.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/journal-classes/multidisciplinary-selective.md
@@ -1,0 +1,20 @@
+---
+schemaVersion: 1
+id: journal-class.multidisciplinary-selective
+kind: journal-class
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+journalClass: multidisciplinary-selective
+rules:
+  - broad-editorial-significance-required
+  - cross-field-accessibility-required
+reviewAfterDays: 90
+---
+
+# Default selective multidisciplinary journal policy
+
+Require a broad and timely advance, an opening that makes significance clear to
+non-specialists, and validation that survives scrutiny from every contributing
+discipline. This generic class policy cannot establish readiness for one named
+journal.

--- a/tiangong-auto-research/assets/research-policy/defaults/journal-classes/specialist-top-tier.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/journal-classes/specialist-top-tier.md
@@ -1,0 +1,19 @@
+---
+schemaVersion: 1
+id: journal-class.specialist-top-tier
+kind: journal-class
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+journalClass: specialist-top-tier
+rules:
+  - specialist-state-of-art-advance-required
+  - complete-domain-comparison-required
+reviewAfterDays: 90
+---
+
+# Default specialist top-tier journal policy
+
+Require a decisive advance over the strongest specialist state of the art,
+complete domain comparison, and sufficient technical depth for expert reuse.
+Narrow scope is acceptable only when importance within the specialty is high.

--- a/tiangong-auto-research/assets/research-policy/defaults/journal-classes/top-review-journal.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/journal-classes/top-review-journal.md
@@ -1,0 +1,19 @@
+---
+schemaVersion: 1
+id: journal-class.top-review-journal
+kind: journal-class
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+journalClass: top-review-journal
+rules:
+  - authoritative-synthesis-required
+  - field-agenda-contribution-required
+reviewAfterDays: 90
+---
+
+# Default top review journal policy
+
+Require an authoritative, balanced, and field-defining synthesis that resolves
+or reorganizes an important debate and identifies consequential next steps.
+Confirm that the venue accepts unsolicited work of the intended article type.

--- a/tiangong-auto-research/assets/research-policy/defaults/journals/exact-journal-template.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/journals/exact-journal-template.md
@@ -1,0 +1,64 @@
+---
+schemaVersion: 1
+id: journal.exact-template
+kind: exact-journal
+templateClass: exact-journal-template
+policyVersion: 1
+targetTier: top
+journalName: __REPLACE_JOURNAL_NAME__
+officialGuidelinesUrl: __REPLACE_OFFICIAL_HTTPS_URL__
+officialGuidelinesRetrievedAt: __REPLACE_YYYY-MM-DD__
+rules:
+  - exact-journal-scope-confirmed
+  - exact-journal-article-type-confirmed
+  - exact-journal-guidelines-verified
+requiredReviewers:
+  - journal-editor
+reviewAfterDays: 90
+---
+
+# Exact target-journal policy template
+
+Replace every placeholder using current official journal sources. Agent-drafted
+content requires explicit human approval and remains invalid while any
+placeholder is present.
+
+## Scope
+
+Describe the exact journal scope, audience, accepted article type, and why this
+project belongs there.
+
+## Editorial significance
+
+Define what this journal's editors are likely to regard as a sufficiently
+important and non-incremental contribution, supported by current official
+guidance and a bounded sample of recent representative articles.
+
+## Evidence expectations
+
+Record journal-specific evidence, data availability, reporting, ethics, and
+supplement requirements.
+
+## Methods and validation
+
+Record journal-specific study design, validation, statistics, and review
+expectations without weakening the baseline or article-type policy.
+
+## Reproducibility
+
+Record exact data, code, materials, repository, and availability requirements.
+
+## Desk-reject triggers
+
+List scope, article-type, significance, methods, length, presentation, and
+submission defects that would prevent external review.
+
+## Required reviewer questions
+
+List the questions a fresh editor for this exact journal should answer about the
+final frozen manuscript.
+
+## Permitted pivots
+
+List acceptable journal-class, article-type, additional-research, or external
+handoff routes when the exact target cannot be supported.

--- a/tiangong-auto-research/assets/research-policy/defaults/project/publication-brief.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/project/publication-brief.md
@@ -1,0 +1,60 @@
+---
+schemaVersion: 1
+id: project.publication-brief-template
+kind: publication-brief
+templateClass: project-template
+policyVersion: 1
+targetTier: top
+articleType: __SELECT_ARTICLE_TYPE__
+field: __SELECT_FIELD__
+journalClass: __SELECT_JOURNAL_CLASS__
+targetJournal: __SELECT_EXACT_JOURNAL_OR_NONE__
+centralQuestion: __DEFINE_CENTRAL_QUESTION__
+centralClaim: __DEFINE_CENTRAL_CLAIM__
+contributionType: __DEFINE_CONTRIBUTION_TYPE__
+centralOutcome: __DEFINE_CENTRAL_OUTCOME__
+rules:
+  - project-brief-complete
+reviewAfterDays: 365
+---
+
+# Project publication brief
+
+Replace every placeholder. The current native Codex or Claude host may draft
+this brief, but top-journal execution requires explicit human approval of the
+exact hash.
+
+## Contribution hypothesis
+
+Explain what is genuinely new and why the intended readership should care.
+
+## Central claim and result
+
+Define the central claim, the result that would support it, its units and scope,
+and the result class: observed, causal, calibrated, validated prediction,
+illustrative sensitivity, identity, conceptual proposition, or future work.
+
+## Required evidence
+
+Define direct evidence, source composition, full-text, date, database, data,
+counterevidence, and applicability requirements for each central claim.
+
+## Research design and validation
+
+Define data, methods, controls, baselines, alternatives, uncertainty,
+robustness, external validation, and computational reproduction.
+
+## Novelty and recall plan
+
+Define databases, query families, closest known work, citation searches,
+counterevidence, and the stopping or saturation rule.
+
+## Deliverables
+
+Define manuscript, figures, tables, supplement, data, code, reporting guideline,
+and journal-specific submission materials.
+
+## Stop, handoff, and pivot conditions
+
+Define conditions for additional autonomous work, user authorization, external
+response, research redesign, article-type change, or journal change.

--- a/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/domain-novelty.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/domain-novelty.md
@@ -1,0 +1,59 @@
+---
+schemaVersion: 1
+id: reviewer.domain-novelty
+kind: reviewer-rubric
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+reviewerRole: domain-novelty
+rules:
+  - independent-recall-challenge-required
+  - closest-prior-work-compared
+  - contribution-non-incremental
+reviewAfterDays: 180
+---
+
+# Default domain and novelty reviewer rubric
+
+## Scope
+
+Independently challenge literature recall, domain correctness, contribution,
+and omitted prior work. New leads are challenge candidates, not admissible
+evidence until formalized and re-frozen.
+
+## Editorial significance
+
+Determine whether the exact contribution is important and non-incremental for
+the intended field and audience.
+
+## Evidence expectations
+
+Exercise independent query families, known-item recall, citation chains,
+counterevidence, recent work, and the closest direct studies.
+
+## Methods and validation
+
+Check domain assumptions, mechanisms, applicability, and whether the research
+design answers the question experts will infer from the title and abstract.
+
+## Reproducibility
+
+Require a frozen search and challenge record with safe query hashes, candidate
+IDs, dispositions, and policy-bound saturation rationale.
+
+## Desk-reject triggers
+
+- A directly relevant core study or competing method is omitted.
+- Novelty disappears when compared with the closest prior work.
+- The central domain mechanism is asserted but not modeled or tested.
+
+## Required reviewer questions
+
+- What closest paper could make this incremental?
+- Which community would dispute the central mechanism or applicability?
+- Has search stopped for a defensible reason rather than a count minimum?
+
+## Permitted pivots
+
+Reopen discovery through an addendum, narrow novelty, change the article type,
+or target a different specialist audience.

--- a/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/evidence.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/evidence.md
@@ -1,0 +1,58 @@
+---
+schemaVersion: 1
+id: reviewer.evidence
+kind: reviewer-rubric
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+reviewerRole: evidence
+rules:
+  - all-material-claims-traceable
+  - central-claims-directly-supported
+  - evidence-composition-reported
+reviewAfterDays: 180
+---
+
+# Default evidence reviewer rubric
+
+## Scope
+
+Audit the frozen claim graph, evidence snapshot, acquisitions, exclusions, and
+final manuscript. Do not infer access to material outside the packet.
+
+## Editorial significance
+
+Determine whether the evidence supports the importance and breadth claimed,
+not merely whether citations exist.
+
+## Evidence expectations
+
+Challenge directness, quality, applicability, source composition, contradictory
+evidence, full-text status, owner-input trust, and central partial dimensions.
+
+## Methods and validation
+
+Verify that evidence categories are not substituted for one another and that
+limitations do not launder a blocking gap.
+
+## Reproducibility
+
+Check immutable locators, hashes, candidate dispositions, artifact lineage, and
+claim bindings.
+
+## Desk-reject triggers
+
+- A central claim lacks direct applicable support.
+- Metadata or internal synthesis dominates the central evidence.
+- Material sources or exclusions cannot be audited.
+
+## Required reviewer questions
+
+- Which central claim is least supported?
+- What counterevidence or source class is missing?
+- Does the prose exceed the exact evidence category?
+
+## Permitted pivots
+
+Request gap filling, narrow claims, change article type, or require external
+data. Do not pass because a fatal gap was disclosed.

--- a/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/journal-editor.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/journal-editor.md
@@ -1,0 +1,60 @@
+---
+schemaVersion: 1
+id: reviewer.journal-editor
+kind: reviewer-rubric
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+reviewerRole: journal-editor
+rules:
+  - final-frozen-manuscript-required
+  - target-fit-reviewed
+  - readiness-language-bounded
+reviewAfterDays: 90
+---
+
+# Default target-journal editor rubric
+
+## Scope
+
+Review only the final frozen manuscript, figures, tables, supplement, policy
+stack, and preceding independent verdicts. Simulate editorial triage; do not
+upgrade unresolved scientific defects.
+
+## Editorial significance
+
+Judge whether the contribution, timing, audience, clarity, and scope merit
+external review at the exact target journal.
+
+## Evidence expectations
+
+Check that title, abstract, highlights, figures, conclusions, and significance
+language remain within the frozen evidence and result classifications.
+
+## Methods and validation
+
+Determine whether an editor can reasonably trust the design and whether obvious
+reviewer objections have been answered before submission.
+
+## Reproducibility
+
+Verify that the exact manuscript and supplement hashes match the reviewed
+packet and that availability statements point to bound artifacts.
+
+## Desk-reject triggers
+
+- Scope or article type does not match the journal.
+- The central contribution is incremental or unsupported.
+- Any blocking reviewer verdict remains unresolved.
+- The manuscript changed after its final review.
+
+## Required reviewer questions
+
+- Would this exact manuscript be sent to external review?
+- What single reason would most likely cause desk rejection?
+- Does every user-facing readiness statement match the strictest verdict?
+
+## Permitted pivots
+
+Return desk reject, redesign, major revision, minor revision, or submission
+ready. Recommend another article type or journal only as an explicit pivot.

--- a/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/methods-reproducibility.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/methods-reproducibility.md
@@ -1,0 +1,57 @@
+---
+schemaVersion: 1
+id: reviewer.methods-reproducibility
+kind: reviewer-rubric
+templateClass: bundled-default
+policyVersion: 1
+targetTier: top
+reviewerRole: methods-reproducibility
+rules:
+  - design-supports-central-claim
+  - material-results-reproduced
+  - robustness-and-uncertainty-reviewed
+reviewAfterDays: 180
+---
+
+# Default methods and reproducibility reviewer rubric
+
+## Scope
+
+Audit the design, data, code, parameters, computation, uncertainty, validation,
+and robustness for the central result.
+
+## Editorial significance
+
+Determine whether the methodological advance or empirical design is strong
+enough to support a top-journal contribution rather than a working example.
+
+## Evidence expectations
+
+Require every material parameter and validation target to have an admissible,
+applicable source or an explicit tested assumption.
+
+## Methods and validation
+
+Challenge identification, controls, leakage, baselines, sensitivity, external
+validity, uncertainty, failure cases, and alternative explanations.
+
+## Reproducibility
+
+Run or inspect the clean reproducibility record from exact data and code through
+every material table and figure.
+
+## Desk-reject triggers
+
+- A central statistic or figure cannot be recomputed.
+- Results are identities or scenarios presented as observed effects.
+- Validation is absent, circular, or outside the claimed population.
+
+## Required reviewer questions
+
+- Can an independent group reproduce the main result?
+- Which assumption most threatens the conclusion?
+- What baseline or falsification test is missing?
+
+## Permitted pivots
+
+Require redesign, more data, narrower claims, or a methods/Perspective route.

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -137,6 +137,12 @@ next native producer stage through discover, acquire, analyze, and synthesize.
 The same run command may then launch only the configured independent reviewer
 CLI and, after a passing review, perform mechanical closure.
 
+For a top-journal project, this is the base research closure, not the final
+publication verdict. Continue in the same current native host to author and
+freeze the manuscript, then use four fresh independent publication-review
+sessions. Follow [publication-policy.md](publication-policy.md). Do not ask
+`research run` to launch a producer for manuscript authoring.
+
 To discard an active native session explicitly:
 
 ```bash

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -35,6 +35,13 @@ Before `project init`, record and show the user:
 5. Package token reservations, configured price basis, maximum cost, and
    whether the confirmation threshold is crossed.
 
+For a top-journal goal, initialize and explicitly approve the applicable
+Research Policy first. Use `research policy wizard PROJECT`; it reads the
+verified project-installed orchestrator, warns when generic defaults remain,
+and never treats them as exact-journal endorsement. See
+[publication-policy.md](publication-policy.md) for policy states, verdict
+ceilings, final manuscript freeze, and four-role review.
+
 Use `research project preflight`; do not calculate a competing checklist in the
 skill. Production `project init` requires its evidence-requirements file and,
 when the configured threshold is crossed, explicit `--confirm-budget`.
@@ -375,6 +382,8 @@ Confirm the owning CLI release passed deterministic mock coverage for:
   local-only production rejection;
 - routing and smoke/production mode boundaries;
 - discover → acquire → freeze → analyze → synthesize → review → close;
+- top-journal Policy approval, publication assessment, frozen final manuscript,
+  four fresh role-bound reviews, revision invalidation, and publication closure;
 - public `research run` never launching a producer subprocess, with native
   prepare/fetch/register/submit advancing the four producer stages;
 - native-only leads remaining supplemental until an immutable broker

--- a/tiangong-auto-research/references/publication-policy.md
+++ b/tiangong-auto-research/references/publication-policy.md
@@ -1,0 +1,140 @@
+# Top-journal Research Policy and final publication gate
+
+Load this reference for a top-journal paper, target-journal readiness claim,
+final manuscript review, or publication closure. The goal is a truthful,
+reviewable submission candidate; no policy or reviewer can guarantee acceptance.
+
+## Initialize Policy before project admission
+
+Run the guided Policy Wizard only after project-scoped setup is `READY` and the
+installed orchestrator matches the immutable setup plan:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research policy wizard PROJECT --workspace /absolute/path/to/workspace
+```
+
+The Wizard loads only that verified project installation. It selects one
+article type, field, and journal class, copies conservative Markdown defaults,
+completes the publication brief, and optionally creates an exact-journal
+policy. It always warns that defaults are generic. Approval requires a separate
+acknowledgement and binds the exact current content hash.
+
+Use deterministic commands for automation or audit:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research policy catalog --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research policy status PROJECT --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research policy approve PROJECT --confirm --acknowledge-defaults \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Do not hand-copy a policy pack or use an ambient/global Skill as an implicit
+source. `--source-root` is an explicit automation escape hatch and remains
+subject to non-symlink validation; the Wizard never uses it.
+
+## Human-maintained Markdown
+
+The editable project stack is `research-policy/PROJECT/`. A human may update:
+
+- `publication-brief.md`: central question, claim, outcome, contribution, and
+  evidence, method, novelty, deliverable, stop, and handoff conditions;
+- `article-type.md`, `field.md`, and `journal-class.md`: stricter applicable
+  requirements for this study;
+- `journal.md`, when present: current official scope, editorial threshold,
+  evidence, methods, reproducibility, desk-reject, reviewer, and pivot rules;
+- reviewer rubrics for evidence, methods/reproducibility, domain/novelty, and
+  the journal editor.
+
+An exact-journal policy cannot be approved by changing only its header. Name
+the journal, cite a current official HTTPS guideline URL and retrieval date,
+and replace every substantive generic section. Never infer journal rules from
+memory or weaken the baseline with a less strict local rule.
+
+Status is mechanical: `missing`, `default-unapproved`, `custom-draft`,
+`default-approved`, `custom-approved`, `conflict`, `stale`, `changed`, or
+`invalid`. Any content edit after approval yields `changed`; expiry yields
+`stale`. Both stop project stages and publication review until re-approved.
+
+## Verdict ceilings
+
+Defaults support feasibility and planning but are not journal endorsement. The
+CLI computes the maximum permitted language:
+
+- generic stack: `top-journal-candidate`;
+- human-customized article, field, journal class, and project brief:
+  `top-journal-class-ready`;
+- the above plus a complete exact-journal policy:
+  `target-journal-submission-ready`.
+
+Mechanical evidence or review failures can only lower the result. An editor
+cannot raise a ceiling or override an unobserved central outcome, incomplete
+recall, missing direct evidence, or unreproduced result.
+
+## Author in the current native host
+
+After the base `discover → acquire → analyze → synthesize → review → close`
+project is complete, write the final manuscript and assessment in the current
+Codex app/session or interactive Claude Code session. The CLI remains a control
+plane and must not launch a nested producer. Inspect the schema, then freeze:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show publication-assessment --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research publication freeze PROJECT \
+  --manuscript /absolute/path/to/final-manuscript.md \
+  --assessment /absolute/path/to/publication-assessment.json \
+  --producer-agent codex --producer-session OPAQUE_NATIVE_SESSION \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Freeze content-addresses the manuscript, assessment, supplements, approved
+Policy, final evidence snapshot, and base outputs. It evaluates central claims,
+outcomes, result classes, evidence composition, owner-input trust, recall,
+novelty, reproduction, and pivots. File existence alone is never success.
+
+## Four fresh independent final reviews
+
+Prepare and submit exactly one review for each role: `evidence`,
+`methods-reproducibility`, `domain-novelty`, and `journal-editor`.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research publication review prepare PROJECT --role evidence \
+  --reviewer-agent claude --reviewer-session FRESH_OPAQUE_SESSION \
+  --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show publication-review-evidence --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research publication review submit PROJECT --role evidence \
+  --review /absolute/path/to/review.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Repeat with fresh sessions. A reviewer may use the configured headless Codex or
+Claude CLI, but must not be the producer session or any prior project reviewer
+session. The append-only journal stores only its SHA-256 for reuse detection;
+deleting a mutable cache does not permit reuse.
+
+Each packet binds the exact Policy, evidence snapshot, base closure, manuscript,
+assessment, supplements, mechanical result, role, reviewer, and schema. Review
+cannot add evidence. A manuscript revision creates a new generation and
+invalidates every old review; a Policy change or expiry blocks publication.
+
+## Close and report bounded language
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research publication status PROJECT --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research publication close PROJECT --workspace /absolute/path/to/workspace --json
+```
+
+Closure re-verifies every hash and requires all four reviews. Report only the
+returned verdict, bounded statement, limitations, and pivots.
+`target-journal-submission-ready` means the frozen artifact passed its declared
+gates; it does not predict or guarantee editorial acceptance.

--- a/tiangong-auto-research/scripts/test-research-policy-pack.mjs
+++ b/tiangong-auto-research/scripts/test-research-policy-pack.mjs
@@ -94,4 +94,22 @@ for (const relative of [
 }
 
 assert.equal(ids.size, Object.values(expected).flat().length);
+
+const skill = await readFile(join(skillRoot, "SKILL.md"), "utf8");
+const publicationReference = await readFile(join(skillRoot, "references", "publication-policy.md"), "utf8");
+assert.match(
+  skill,
+  /references\/publication-policy\.md/,
+  "SKILL.md must route top-journal publication work to the detailed reference",
+);
+assert.match(skill, /current native host/i, "final manuscript authoring must remain in the native host");
+for (const role of [
+  "evidence",
+  "methods-reproducibility",
+  "domain-novelty",
+  "journal-editor",
+]) {
+  assert.match(publicationReference, new RegExp(`\\b${role}\\b`));
+}
+assert.match(publicationReference, /does not predict or guarantee editorial acceptance/i);
 process.stdout.write(`Research Policy default pack tests passed (${ids.size} templates)\n`);

--- a/tiangong-auto-research/scripts/test-research-policy-pack.mjs
+++ b/tiangong-auto-research/scripts/test-research-policy-pack.mjs
@@ -80,5 +80,18 @@ for (const relative of [
   }
 }
 
+for (const relative of [
+  ["baseline", "top-journal.md"],
+  ...expected["article-types"].map((file) => ["article-types", file]),
+]) {
+  const text = await readFile(join(policyRoot, ...relative), "utf8");
+  assert.match(text, /^constraints:$/m, `${relative.join("/")} lacks mechanical constraints`);
+  assert.match(
+    text,
+    /^  minDirectPeerReviewedFullText:\s*[1-9][0-9]*$/m,
+    `${relative.join("/")} lacks a positive direct full-text floor`,
+  );
+}
+
 assert.equal(ids.size, Object.values(expected).flat().length);
 process.stdout.write(`Research Policy default pack tests passed (${ids.size} templates)\n`);

--- a/tiangong-auto-research/scripts/test-research-policy-pack.mjs
+++ b/tiangong-auto-research/scripts/test-research-policy-pack.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const skillRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const policyRoot = join(skillRoot, "assets", "research-policy", "defaults");
+const expected = {
+  baseline: ["top-journal.md"],
+  "article-types": [
+    "computational-modeling.md",
+    "methods-data-resource.md",
+    "original-empirical.md",
+    "perspective-theory.md",
+    "systematic-review-meta-analysis.md",
+  ],
+  fields: [
+    "earth-environment.md",
+    "economics-management.md",
+    "engineering-computing.md",
+    "humanities.md",
+    "life-health.md",
+    "multidisciplinary.md",
+    "physical-chemical-materials.md",
+    "social-behavioral.md",
+  ],
+  "journal-classes": [
+    "discipline-flagship.md",
+    "methods-data-journal.md",
+    "multidisciplinary-selective.md",
+    "specialist-top-tier.md",
+    "top-review-journal.md",
+  ],
+  journals: ["exact-journal-template.md"],
+  "reviewer-rubrics": [
+    "domain-novelty.md",
+    "evidence.md",
+    "journal-editor.md",
+    "methods-reproducibility.md",
+  ],
+  project: ["publication-brief.md"],
+};
+
+const ids = new Set();
+for (const [category, files] of Object.entries(expected)) {
+  for (const file of files) {
+    const path = join(policyRoot, category, file);
+    const text = await readFile(path, "utf8");
+    assert.match(text, /^---\n[\s\S]+?\n---\n/, `${path} must have frontmatter`);
+    const id = text.match(/^id:\s*([a-z0-9.-]+)$/m)?.[1];
+    assert.ok(id, `${path} must declare a stable id`);
+    assert.equal(ids.has(id), false, `duplicate policy id ${id}`);
+    ids.add(id);
+    assert.match(text, /^schemaVersion:\s*1$/m, `${path} must use policy schema v1`);
+    assert.match(text, /^kind:\s*[a-z-]+$/m, `${path} must declare kind`);
+    assert.match(text, /^templateClass:\s*(bundled-default|exact-journal-template|project-template)$/m);
+    assert.match(text, /^#\s+\S/m, `${path} must have a title`);
+  }
+}
+
+for (const relative of [
+  ["baseline", "top-journal.md"],
+  ["article-types", "original-empirical.md"],
+  ["reviewer-rubrics", "journal-editor.md"],
+]) {
+  const text = await readFile(join(policyRoot, ...relative), "utf8");
+  for (const heading of [
+    "Scope",
+    "Editorial significance",
+    "Evidence expectations",
+    "Methods and validation",
+    "Reproducibility",
+    "Desk-reject triggers",
+    "Required reviewer questions",
+    "Permitted pivots",
+  ]) {
+    assert.match(text, new RegExp(`^## ${heading}$`, "m"), `${relative.join("/")} lacks ${heading}`);
+  }
+}
+
+assert.equal(ids.size, Object.values(expected).flat().length);
+process.stdout.write(`Research Policy default pack tests passed (${ids.size} templates)\n`);


### PR DESCRIPTION
Closes the Skills portion of tiangong-ai/workspace#123.

## Scope
- add 25 conservative top-journal Research Policy Markdown defaults
- route top-journal work through a detailed publication-policy reference
- preserve native-host producer/manuscript authoring and four fresh independent review roles
- document that readiness never guarantees editorial acceptance

## Validation
- fresh no-cache clean Docker container: resolver, routing, 25-template Policy pack, POSIX wrapper, SCI/report/patent suites passed
- Skill Creator quick_validate.py passed with PyYAML 6.0.3 in an isolated uvx environment
- docpact 0.1.9 strict validation and worktree lint passed
- git diff --check passed

## Dependency order
Merge this PR before updating and releasing the CLI immutable Skills pin.