### PR TITLE
test(auto-research): separate iterative and cold container gates

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -13,6 +13,9 @@ routing:
         - AGENTS.md
         - .docpact/**
         - .github/workflows/docpact.yml
+        - .dockerignore
+        - Dockerfile.clean-test
+        - scripts/**
         - _docs/**
         - README.md
         - README.zh-CN.md
@@ -34,6 +37,9 @@ coverage:
     - README.zh-CN.md
     - .docpact/**
     - .github/workflows/docpact.yml
+    - .dockerignore
+    - Dockerfile.clean-test
+    - scripts/**
     - _docs/**
     - .claude-plugin/**
     - "*/SKILL.md"
@@ -85,6 +91,12 @@ rules:
         kind: machine-contract
       - path: .github/workflows/docpact.yml
         kind: governance-ci
+      - path: .dockerignore
+        kind: clean-container-context-policy
+      - path: Dockerfile.clean-test
+        kind: clean-container-image
+      - path: scripts/**
+        kind: repository-validation-script
       - path: _docs/**
         kind: governed-docs
       - path: README.md
@@ -101,6 +113,8 @@ rules:
       - path: _docs/contracts/repo-contract.md
         mode: review_or_update
       - path: _docs/standards/documentation-standards.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
         mode: review_or_update
     reason: Repository entry guidance, governance config, and documentation standards must remain aligned.
   - id: skills-skill-surface

--- a/.github/workflows/docpact.yml
+++ b/.github/workflows/docpact.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - run: sh scripts/test-clean-container.sh
+      - run: sh scripts/test-clean-container.sh --cold-build
 
   validate-config:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,10 @@ whenToUpdate: "When skill creation workflow, validation commands, docpact config
 checkPaths:
   - AGENTS.md
   - .docpact/config.yaml
+  - .dockerignore
+  - Dockerfile.clean-test
   - .github/workflows/docpact.yml
+  - scripts/**
   - _docs/**
 lastReviewedAt: 2026-08-13
 lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
@@ -55,8 +58,11 @@ skill 内容、skill 规范、marketplace 元数据和本仓文档治理属于�
 - 治理变更后 `docpact validate-config --root . --strict` 通过。
 - skill 变更按 `skill-creator` 流程运行对应校验。
 - Auto Research 及其直接 evidence wrapper 的变更必须先在
-  `scripts/test-clean-container.sh` 中观察回归测试失败，再在同一全新、
-  无宿主 HOME/全局 Skill/CLI/cache 的 Docker 契约中转绿；宿主测试不能替代。
+  `scripts/test-clean-container.sh` 创建的独立、无宿主 HOME/全局
+  Skill/CLI/runtime cache 的容器中观察回归测试失败，再在另一个新容器中转绿；
+  构建可复用输入未变化的 Docker layer，宿主测试不能替代。
+- 修改 `.dockerignore`、`Dockerfile.clean-test`、依赖输入，或准备 PR/发布时，
+  必须额外运行 `scripts/test-clean-container.sh --cold-build` 验证冷构建路径。
 
 ## Skill-Creator Workflow
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-12
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 
 # Tiangong AI Skills
@@ -24,11 +24,13 @@ Repository: https://github.com/tiangong-ai/skills
 Use the `skills` CLI from https://github.com/vercel-labs/skills to install, update, and manage these skills.
 
 ## Install the CLI
+
 ```bash
 npm i skills -g
 ```
 
 ## Install
+
 - List available skills (no install):
   ```bash
   npx skills add https://github.com/tiangong-ai/skills --list
@@ -43,6 +45,7 @@ npm i skills -g
   ```
 
 ## Target agents and scope
+
 - Target specific agents:
   ```bash
   npx skills add https://github.com/tiangong-ai/skills -a codex -a claude-code
@@ -61,11 +64,13 @@ npm i skills -g
     the pinned `skills` CLI rather than deriving `~/<agent>/skills` by analogy.
 
 ## Install method
+
 - Interactive installs let you choose:
   - Symlink (recommended)
   - Copy
 
 ## Update and verify
+
 - List installed skills:
   ```bash
   npx skills list

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-12
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 
 # 天工 AI Skills
@@ -24,11 +24,13 @@ lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 请使用 https://github.com/vercel-labs/skills 提供的 `skills` CLI 来安装、更新和管理这些 skills。
 
 ## 安装 CLI
+
 ```bash
 npm i skills -g
 ```
 
 ## 安装
+
 - 仅列出可用技能（不安装）:
   ```bash
   npx skills add https://github.com/tiangong-ai/skills --list
@@ -43,6 +45,7 @@ npm i skills -g
   ```
 
 ## 目标 agent 与作用域
+
 - 指定 agent:
   ```bash
   npx skills add https://github.com/tiangong-ai/skills -a codex -a claude-code
@@ -60,11 +63,13 @@ npm i skills -g
     `~/<agent>/skills` 类推。
 
 ## 安装方式
+
 - 交互式安装可选:
   - Symlink (recommended)
   - Copy
 
 ## 更新与确认
+
 - 列出已安装技能:
   ```bash
   npx skills list

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-12
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -13,6 +13,9 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - .docpact/config.yaml
+  - .dockerignore
+  - Dockerfile.clean-test
+  - scripts/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-12
 lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
@@ -59,6 +62,9 @@ assets, generated `agents/**` files, or marketplace metadata require review of:
   including `scripts/quick_validate.py <skill-path>` from the `skill-creator`
   skill when available.
 - Regenerate or update agent config files when the skill workflow requires it.
+- Run Auto Research red/green cycles in separate clean runtime containers;
+  valid Docker build layers may be reused iteratively, while PR and release
+  evidence must include the explicit cold-build gate.
 - Do not leave install, validation, or trigger facts only in chat.
 
 `.claude-plugin/marketplace.json` is curated marketplace grouping metadata. It

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -11,6 +11,10 @@ checkPaths:
   - AGENTS.md
   - README.md
   - README.zh-CN.md
+  - .dockerignore
+  - Dockerfile.clean-test
+  - .github/workflows/docpact.yml
+  - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-12
@@ -57,12 +61,24 @@ for the red and green cycles:
 scripts/test-clean-container.sh
 ```
 
-It performs a no-cache build from the digest-pinned Node 24 image, copies only
-the secret-filtered repository context, and runs the routing, resolver, agent
+It builds from the digest-pinned Node 24 image, copies only the secret-filtered
+repository context, and runs the routing, resolver, agent
 wrapper, Research Policy pack, and evidence-wrapper suites as a non-root user
 with isolated HOME and runtime networking disabled. Do not mount host agent
-directories, CLIs, caches, credentials, browser profiles, or source worktrees
-into the running container.
+directories, CLIs, runtime caches, credentials, browser profiles, or source
+worktrees into the running container.
+
+The default entrypoint may reuse Docker layers whose declared inputs still
+match, while every test run uses a new container. Run the explicit cold mode
+after changing `.dockerignore`, `Dockerfile.clean-test`, or dependency inputs,
+and before PR or release delivery:
+
+```bash
+scripts/test-clean-container.sh --cold-build
+```
+
+Cold mode adds `--no-cache`; neither mode uses `--pull`, so the base image can
+change only through a reviewed digest update.
 
 ## README And Marketplace Updates
 

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-13
-lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
+lastReviewedAt: 2026-08-14
+lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 
 # Skills Documentation Standards

--- a/scripts/run-auto-research-tests.sh
+++ b/scripts/run-auto-research-tests.sh
@@ -12,6 +12,7 @@ if command -v tiangong-ai >/dev/null 2>&1; then
     exit 1
 fi
 
+sh scripts/test-clean-container-entrypoint.sh
 node tiangong-auto-research/scripts/test-research-cli.mjs
 node tiangong-auto-research/scripts/test-routing-contract.mjs
 node tiangong-auto-research/scripts/test-research-policy-pack.mjs

--- a/scripts/test-clean-container-entrypoint.sh
+++ b/scripts/test-clean-container-entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd -P)
+entrypoint="$script_dir/test-clean-container.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/tiangong-skills-clean-entrypoint.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+fake_bin="$test_root/bin"
+mkdir "$fake_bin"
+
+printf '%s\n' \
+    '#!/bin/sh' \
+    'set -eu' \
+    ': "${FAKE_DOCKER_LOG:?}"' \
+    'printf '\''%s'\'' "$1" >>"$FAKE_DOCKER_LOG"' \
+    'shift' \
+    'for argument do' \
+    '    printf '\''\t%s'\'' "$argument" >>"$FAKE_DOCKER_LOG"' \
+    'done' \
+    'printf '\''\n'\'' >>"$FAKE_DOCKER_LOG"' \
+    >"$fake_bin/docker"
+chmod 700 "$fake_bin/docker"
+
+default_log="$test_root/default.log"
+FAKE_DOCKER_LOG="$default_log" PATH="$fake_bin:$PATH" sh "$entrypoint"
+default_build=$(sed -n '1p' "$default_log")
+case "$default_build" in
+    *"$(printf '\t')--no-cache"*)
+        printf '%s\n' "default build unexpectedly disabled Docker layer caching" >&2
+        exit 1
+        ;;
+esac
+grep -F "$(printf 'run\t--rm')" "$default_log" >/dev/null
+grep -F "$(printf '\t--network\tnone')" "$default_log" >/dev/null
+grep -F "$(printf '\t--tmpfs\t/home/node:')" "$default_log" >/dev/null
+
+cold_log="$test_root/cold.log"
+FAKE_DOCKER_LOG="$cold_log" PATH="$fake_bin:$PATH" sh "$entrypoint" --cold-build
+cold_build=$(sed -n '1p' "$cold_log")
+case "$cold_build" in
+    *"$(printf '\t')--no-cache"*) ;;
+    *)
+        printf '%s\n' "cold build did not disable Docker layer caching" >&2
+        exit 1
+        ;;
+esac
+
+invalid_log="$test_root/invalid.log"
+if FAKE_DOCKER_LOG="$invalid_log" PATH="$fake_bin:$PATH" \
+    sh "$entrypoint" --unexpected >/dev/null 2>&1; then
+    printf '%s\n' "clean-container entrypoint accepted an unknown mode" >&2
+    exit 1
+fi
+if [ -e "$invalid_log" ]; then
+    printf '%s\n' "clean-container entrypoint invoked Docker for an unknown mode" >&2
+    exit 1
+fi
+
+grep -F 'run: sh scripts/test-clean-container.sh --cold-build' \
+    "$repo_root/.github/workflows/docpact.yml" >/dev/null
+
+printf '%s\n' "Skills clean-container entrypoint contract passed."

--- a/scripts/test-clean-container.sh
+++ b/scripts/test-clean-container.sh
@@ -6,16 +6,48 @@ script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd -P)
 image_tag="tiangong-ai-skills-clean-test:local-$$"
 
+usage() {
+    printf '%s\n' "Usage: scripts/test-clean-container.sh [--cold-build]"
+}
+
+build_mode=cached
+case "$#" in
+    0) ;;
+    1)
+        case "$1" in
+            --cold-build) build_mode=cold ;;
+            --help)
+                usage
+                exit 0
+                ;;
+            *)
+                printf '%s\n' "Unknown clean-container mode: $1" >&2
+                usage >&2
+                exit 2
+                ;;
+        esac
+        ;;
+    *)
+        printf '%s\n' "Only one clean-container mode may be selected." >&2
+        usage >&2
+        exit 2
+        ;;
+esac
+
 cleanup() {
     docker image rm --force "$image_tag" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT HUP INT TERM
 
-docker build \
-    --no-cache \
+set -- \
     --file "$repo_root/Dockerfile.clean-test" \
-    --tag "$image_tag" \
-    "$repo_root"
+    --tag "$image_tag"
+if [ "$build_mode" = "cold" ]; then
+    set -- --no-cache "$@"
+fi
+
+printf '%s\n' "Clean-container build mode: $build_mode"
+docker build "$@" "$repo_root"
 
 docker run \
     --rm \


### PR DESCRIPTION
Refs tiangong-ai/workspace#126

## Summary

- Add a cache-aware default clean-container TDD mode and an explicit `--cold-build` mode.
- Make hosted validation select cold mode explicitly.
- Add a POSIX fake-Docker contract for mode selection, runtime isolation, invalid arguments, and workflow wiring.
- Update repository development guidance and docpact coverage for clean-container assets.

## Key Decisions

- Every test invocation uses a new offline non-root runtime container even when valid image layers are reused.
- Cold mode adds `--no-cache` but never `--pull`; base refresh remains an explicit digest update.
- Entrypoint behavior is tested without requiring real Docker or external services.

## Validation

- Combined cached clean-container gate passed.
- Combined explicit cold-build gate passed.
- Skills resolver, routing, 25 Research Policy templates, POSIX wrapper, SCI, report, and patent suites passed.
- `docpact validate-config --root . --strict` passed.
- Enforced docpact lint passed with 0 findings and 0 uncovered files.
- Prettier, shell syntax, and `git diff --check` passed.

## Risks / Rollback

- Risk is limited to repository validation orchestration and CI selection; shipped Skill behavior is unchanged.
- Roll back by reverting this PR, which restores unconditional no-cache builds.

## Follow-ups

- Merge the matching CLI PR and pin both merged commits in the root workspace.

## Workspace Integration

Required. The root workspace must pin the merged Skills commit and update its repo graph before Issue #126 is complete.
