### PR TITLE
feat(auto-research): enforce scientific design lifecycle

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,6 +1,6 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-13"
+lastReviewedAt: "2026-08-15"
 lastReviewedCommit: "126b3e177739064f5b4b29eb240930c9020bb2ef"
 
 repo:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-08-13
+lastReviewedAt: 2026-08-15
 lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,4 +132,16 @@ defaults remain, requires explicit approval of the exact content hash, and
 invalidates approval after any edit or expiry. Exact-journal readiness requires
 current official guidance and substantive human customization. These gates can
 produce a reviewable submission candidate, never a promise of editorial
-acceptance. See `tiangong-auto-research/references/publication-policy.md`.
+acceptance.
+
+Before discovery, the current native Codex or Claude host must also provide a
+closed, target-specific scientific design. The CLI validates and freezes the
+design, then enforces independent `research-design`, real-record
+`evidence-construct`, and `pilot-methods` reviews before discovery, acquisition,
+and analysis respectively. It reserves the complete early/final-review and
+revision lifecycle, requires reapproval for every authoritative recovery
+generation, and exports a portable audit directory containing exact formal
+evidence rather than host-local pointers. The CLI remains the deterministic
+control plane; it never launches a nested producer to invent the science. See
+`tiangong-auto-research/references/publication-policy.md` and
+`tiangong-auto-research/references/scientific-design.md`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,3 +126,11 @@ Policy Wizard 会把所选 Markdown 复制到研究 workspace 供人类审阅；
 审批失效。只有依据当前官方指南做出实质性人工定制，才可能达到精确目标期刊的就绪
 上限。这套门禁只能产出可复核的投稿候选稿，不能承诺编辑接受。详见
 `tiangong-auto-research/references/publication-policy.md`。
+
+在 discovery 之前，当前原生 Codex 或 Claude host 还必须给出封闭、目标特定的科学
+设计。CLI 只负责验证和冻结设计，并依次在 discovery、acquisition、analysis 前强制
+独立的 `research-design`、真实记录 `evidence-construct`、`pilot-methods` 审查；它
+会为全部早期审查、终稿审查和一次修订预留预算，每个权威恢复世代都必须重新审批，
+并可导出包含正式证据原文而不是宿主本地路径的可移植审计目录。CLI 仍是确定性控制
+平面，不会启动嵌套 producer 来替用户发明科学设计。详见
+`tiangong-auto-research/references/scientific-design.md`。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,7 +12,7 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-14
+lastReviewedAt: 2026-08-15
 lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,7 +13,7 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-14
+lastReviewedAt: 2026-08-15
 lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 
@@ -50,6 +50,16 @@ generic source pack for top-journal Policy initialization. It is immutable
 source material, not a user Policy or journal endorsement. The CLI copies a
 selected stack into the user-selected research workspace, where a human may
 customize and explicitly approve the exact resolved content.
+
+`tiangong-auto-research/references/scientific-design.md` defines the Skill-side
+native workflow for a closed project-specific design, three early independent
+scientific review gates, Policy-owned future freeze obligations for models,
+environment locks, and source-derived uncertainty states, authoritative
+recovery generations, and portable audit handoff. The Skill supplies
+instructions and conservative defaults only. The CLI owns schemas, hashing,
+stage admission, mechanical evaluation, lifecycle reservations, reviewer
+isolation, and audit verification; native Codex or Claude remains the
+scientific producer.
 
 ## Integration Points
 

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,7 +17,7 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-12
+lastReviewedAt: 2026-08-15
 lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
@@ -41,6 +41,14 @@ marketplace grouping metadata.
   visibly generic. They must not claim target-journal fit or acceptance; user
   customization, approval, expiry, and hash enforcement belong to the CLI and
   research workspace.
+- Scientific-design guidance and defaults must preserve the native-producer
+  boundary, distinguish observation from model comparison/scenario/accounting,
+  distinguish byte identity from model executability, bind pending model,
+  environment, and uncertainty objects to explicit future gates, require exact
+  joint-state mappings, never treat resampling as additional independent data,
+  and defer closed schemas, mechanical gates, reviewer-session enforcement,
+  lifecycle budgets, authoritative generations, and portable audit verification
+  to the CLI.
 
 ## Skill Surface
 

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,7 +17,7 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-12
+lastReviewedAt: 2026-08-15
 lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
 ---
 
@@ -62,8 +62,9 @@ scripts/test-clean-container.sh
 ```
 
 It builds from the digest-pinned Node 24 image, copies only the secret-filtered
-repository context, and runs the routing, resolver, agent
-wrapper, Research Policy pack, and evidence-wrapper suites as a non-root user
+repository context, and runs the routing, resolver, agent wrapper, Research
+Policy/scientific-design/native-execution contract, generated agent metadata,
+and evidence-wrapper suites as a non-root user
 with isolated HOME and runtime networking disabled. Do not mount host agent
 directories, CLIs, runtime caches, credentials, browser profiles, or source
 worktrees into the running container.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-14
+lastReviewedAt: 2026-08-15
 lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
 ---
 

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -53,6 +53,9 @@ detailed stop and recovery rules.
 - Read [references/publication-policy.md](references/publication-policy.md)
   before a top-journal project, Policy approval, final manuscript freeze,
   four-role publication review, or readiness closure.
+- Read [references/scientific-design.md](references/scientific-design.md) before
+  top-journal admission, any scope change, the three early scientific gates,
+  a target-specific recovery generation, or portable audit export.
 
 ## Choose the mode before spending budget
 
@@ -135,6 +138,15 @@ feasibility guidance, not journal endorsement. Follow
 [references/publication-policy.md](references/publication-policy.md); never
 invent a target-journal policy or bypass its status gate.
 
+Before top-journal preflight, the current native host must write the closed
+`scientific-design` contract. It must distinguish observation, validation,
+cross-model comparison, scenario, and accounting roles; freeze units,
+denominators, independent clusters, thresholds, baselines, evidence roles,
+closest-work requirements, known gaps, and handoff conditions. Pass the same
+exact file to preflight and init with the native producer's opaque session ID.
+Follow [references/scientific-design.md](references/scientific-design.md); never
+let the CLI invent a study design or describe resampling as new independent data.
+
 Prepare evidence requirements with `dimensions`, `sourceTypes`,
 `requiredCapabilityIds`, `requiredCompanionIds`, `requiredDiscoveryScopes`,
 `minSources`, `minFullTextSources`, `minDatedSources`, and nullable date bounds.
@@ -167,22 +179,30 @@ visible, but do not block unrelated research or weaken evidence coverage.
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   research project preflight \
   --workspace /absolute/path/to/workspace \
+  --goal top-journal --policy-project PROJECT \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
-  --input-plan /absolute/path/to/input-plan.json --json
+  --input-plan /absolute/path/to/input-plan.json \
+  --design /absolute/path/to/scientific-design.json --json
 
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   research project init PROJECT \
   --workspace /absolute/path/to/workspace \
+  --goal top-journal \
   --question "Research question" \
   --requirements /absolute/path/to/evidence-requirements.json \
   --input-plan /absolute/path/to/input-plan.json \
+  --design /absolute/path/to/scientific-design.json \
+  --design-producer-agent codex \
+  --design-producer-session OPAQUE_NATIVE_SESSION \
   --confirm-budget --json
 ```
 
 Stop when capability/input coverage is insufficient or the projected cost has
 not been accepted. Use the same requirements and input plan for preflight and
-initialization.
+initialization. For an explicitly selected evidence-report goal, omit the
+top-journal Policy/design options; do not silently downgrade a requested
+top-journal study to make admission pass.
 
 ## Validate, run, and recover
 
@@ -214,6 +234,13 @@ mechanical closure. Follow
 [references/native-execution.md](references/native-execution.md) for the exact
 commands and recovery rules.
 
+For a top-journal project, `research status` may require `research-design`,
+`evidence-construct`, or `pilot-methods` review before it exposes the next
+native stage. Produce the bounded assessment in this native host, then use a
+fresh configured reviewer session through the CLI. A real-record construct
+canary occurs before acquisition and an outcome-blind methods pilot occurs
+before analysis. Reviewer prose cannot override their mechanical failures.
+
 Proceed only when doctor reports ready. Discovery uses only locked broker
 capabilities; later stages are tool-free. Doctor, preflight, dependency,
 provider, and evidence-coverage failures must stop the workflow. Never silently
@@ -242,3 +269,6 @@ assessment, obtain fresh evidence, methods/reproducibility, domain/novelty, and
 journal-editor reviews, then mechanically close the publication generation.
 Any Policy or manuscript change invalidates downstream approval/review. Return
 only the CLI-computed bounded readiness language; never promise acceptance.
+Export and independently verify a portable project audit bundle before external
+handoff or archival; it must contain the formal evidence bytes and review
+objects, not merely receipts or local-path references.

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Run native research with policy-bound review"
-  default_prompt: "Use $tiangong-auto-research for this open-ended or multi-source research task. Resolve the exact CLI from the workspace runtime lock, verify required capabilities, budget, and any top-journal Research Policy, perform producer and manuscript work in this current native host, and use fresh independent reviewer sessions only through the controlled review workflow."
+  short_description: "Run native top-journal research with audited gates"
+  default_prompt: "Use $tiangong-auto-research to author this study's scientific design and execute it in the current native host, pass independent scientific and final publication reviews, and export a verified portable audit bundle."

--- a/tiangong-auto-research/assets/research-policy/defaults/article-types/computational-modeling.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/article-types/computational-modeling.md
@@ -18,6 +18,9 @@ constraints:
   requireRecallAudit: true
   requireCentralDimensionsCovered: true
   requireIndependentReproduction: true
+  requireScientificDesignContract: true
+  requireEarlyScientificReviews: true
+  requireRealRecordConstructCanary: true
 requiredReviewers:
   - evidence
   - methods-reproducibility
@@ -48,6 +51,12 @@ assumed, fitted, transferred, and independently measured values.
 Require baseline comparisons, identifiability or sensitivity analysis,
 uncertainty propagation, failure cases, and independent empirical validation
 where the paper makes real-world claims.
+Classify cross-model comparison, mechanism-model output, scenario output,
+accounting output, calibrated estimates, and independently observed validation
+as different result classes. Declare shared upstream data, independent
+data-generating processes, original units, independent clusters, effective
+units, and the cluster-preserving resampling unit. More bootstrap iterations do
+not create more independent observations.
 
 ## Reproducibility
 
@@ -59,6 +68,9 @@ complete table and figure generation path.
 - The main result follows algebraically from assumptions.
 - Calibration and validation use the same evidence without justification.
 - A scenario analysis is presented as a forecast or observed effect.
+- A model discrepancy is presented as field error without a declared observed
+  truth endpoint, or gross installed material is relabeled as a narrower or
+  network-wide quantity without a supported conversion.
 - Code or material parameters cannot be independently reconstructed.
 
 ## Required reviewer questions

--- a/tiangong-auto-research/assets/research-policy/defaults/baseline/top-journal.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/baseline/top-journal.md
@@ -16,6 +16,9 @@ constraints:
   requireRecallAudit: true
   requireCentralDimensionsCovered: true
   requireIndependentReproduction: true
+  requireScientificDesignContract: true
+  requireEarlyScientificReviews: true
+  requireRealRecordConstructCanary: true
 requiredReviewers:
   - evidence
   - methods-reproducibility
@@ -54,6 +57,10 @@ blocking for an original or systematic claim.
 Require a research design capable of answering the central question, explicit
 assumptions, tested alternative explanations, uncertainty analysis, and
 validation appropriate to the claimed scope. Disclosed fatal gaps remain fatal.
+Freeze endpoint truth roles, quantity/denominator scope, original and independent
+units, resampling units, threshold classes, and baseline fairness before result
+inspection. Require a real-record, outcome-blind construct canary before the
+main acquisition/analysis budget is spent.
 
 ## Reproducibility
 
@@ -69,6 +76,9 @@ as computational reproduction.
   or validated.
 - The contribution is incremental, outside scope, or unsupported by direct
   evidence.
+- Synthetic examples stand in for a feasible real-record join, repeated rows are
+  counted as independent units, or one model is called ground truth without an
+  independently observed endpoint.
 - The final manuscript was created or materially changed after review.
 
 ## Required reviewer questions

--- a/tiangong-auto-research/assets/research-policy/defaults/project/publication-brief.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/project/publication-brief.md
@@ -44,10 +44,29 @@ counterevidence, and applicability requirements for each central claim.
 Define data, methods, controls, baselines, alternatives, uncertainty,
 robustness, external validation, and computational reproduction.
 
+## Scientific identity, claims, and quantities
+
+Define the central study kind and every supporting component; the estimand;
+claim/evidence edges; endpoint truth roles and compatible comparisons; units,
+quantities, denominators, allowed terms, prohibited overclaims; and which result
+classes may appear in title, abstract, and conclusions.
+
+## Independence, thresholds, and early feasibility
+
+Define original units, independent clusters, effective independent units,
+shared upstream data, independent data-generating processes, resampling units,
+threshold classes, sensitivity analyses, and baseline decision-loss metrics.
+Specify an outcome-blind real-record construct canary and a pre-analysis methods
+pilot. Synthetic schema examples are not feasibility evidence.
+
 ## Novelty and recall plan
 
 Define databases, query families, closest known work, citation searches,
 counterevidence, and the stopping or saturation rule.
+
+Assign every central claim an evidence role, minimum independent sources, and
+minimum full texts. State how closest work is obtained and dispositioned before
+novelty language is frozen.
 
 ## Deliverables
 

--- a/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/methods-reproducibility.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/reviewer-rubrics/methods-reproducibility.md
@@ -34,6 +34,11 @@ applicable source or an explicit tested assumption.
 
 Challenge identification, controls, leakage, baselines, sensitivity, external
 validity, uncertainty, failure cases, and alternative explanations.
+Recompute original units, independent clusters, effective independent units,
+and resampling units. Verify endpoint truth roles, shared upstream data,
+quantity/denominator scope, threshold classes, and decision-loss metrics. A
+large resampling count cannot override four independent structures, a circular
+validation route, or an unobserved endpoint.
 
 ## Reproducibility
 
@@ -45,6 +50,8 @@ every material table and figure.
 - A central statistic or figure cannot be recomputed.
 - Results are identities or scenarios presented as observed effects.
 - Validation is absent, circular, or outside the claimed population.
+- A real-record construct canary is missing, inspected outcomes before freezing
+  the method, or failed a central evidence edge.
 
 ## Required reviewer questions
 

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -20,6 +20,31 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 producer stage. It is not an error and must not trigger a nested `codex exec` or
 `claude -p` call.
 
+For a top-journal project, `research status` can instead return a pending
+`research-design`, `evidence-construct`, or `pilot-methods` gate. Complete that
+gate before preparing a native stage. The current native host writes the
+schema-bound assessment; only the configured other agent family performs the
+fresh independent review. See [scientific-design.md](scientific-design.md).
+
+The ordering is deliberate:
+
+```text
+design review → discover → real-record construct review → acquire
+→ outcome-blind methods pilot review → analyze → synthesize
+```
+
+Do not replace the real-record canary with a synthetic schema example, inspect
+outcome values while proving construction, or use repeated cells/rows as
+independent resampling units. A later inherited package cannot bypass an earlier
+gate.
+
+Read `mechanicalAssessment.futureGateObligations` before continuing. Pending
+source-derived parameter values, executable model bytes, and exact environment
+locks are permitted only until their declared gate and only when an exact
+planned Policy rule owns them. They are not usable results. Freeze replacements
+through a new authoritative generation before the deadline; at the due gate the
+CLI must stop on the corresponding mechanical error.
+
 ## Prepare the exact stage
 
 Use the host agent selected by the immutable setup plan:
@@ -158,3 +183,8 @@ Use `research status` to follow the authoritative project. A recovery fork
 supersedes its source and is the only default-runnable descendant. Use
 `research status --all` for lineage audit, `research project archive` for
 complete/stale history, and `research project abandon` for unfinished history.
+
+Before an external handoff or archival milestone, export and verify the project
+audit bundle described in [scientific-design.md](scientific-design.md). A local
+manifest or receipt hash without the referenced evidence bytes is not a
+portable audit package.

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -42,6 +42,14 @@ and never treats them as exact-journal endorsement. See
 [publication-policy.md](publication-policy.md) for policy states, verdict
 ceilings, final manuscript freeze, and four-role review.
 
+Then have the current native host create the closed scientific-design contract
+and pass that same exact file to preflight and project init. Preflight evaluates
+observable estimands, claim/edge feasibility, endpoint truth roles, quantity and
+denominator scope, independent units, threshold types, evidence-role/full-text
+requirements, known gaps, context fit, and baseline fairness. It also reserves
+three early scientific reviews, four final publication reviews, and one bounded
+revision cycle. See [scientific-design.md](scientific-design.md).
+
 Use `research project preflight`; do not calculate a competing checklist in the
 skill. Production `project init` requires its evidence-requirements file and,
 when the configured threshold is crossed, explicit `--confirm-budget`.
@@ -79,8 +87,8 @@ The budget includes:
 - broker calls, response bytes, context items, and estimated context tokens;
 - the cost-confirmation threshold.
 
-New production workspaces use finite runaway ceilings of 20,000,000 total
-tokens and USD 2,000. Package ceilings are 12,000,000 for discovery, 2,000,000
+New production workspaces use finite runaway ceilings of 50,000,000 total
+tokens and USD 5,000. Package ceilings are 12,000,000 for discovery, 2,000,000
 for acquisition, 1,500,000 each for analysis and synthesis, and 2,500,000 for
 review. Primary output is bounded at 32,000 tokens and repair at 16,000. Input
 context is bounded at 128,000 tokens. These values are not a target spend:
@@ -88,6 +96,12 @@ coverage-driven working plans, early stop, three attempts per package, and
 explicit confirmation above USD 10 control ordinary execution. Smoke-test
 workspaces retain smaller low-cost defaults. Lower production ceilings only
 when preflight proves every complete reservation still fits.
+
+The lifecycle reserves up to 500,000 tokens for each early scientific review,
+750,000 for each final publication review, and 4,000,000 for one revision,
+with corresponding finite wall-time reserves. These are hard runaway ceilings,
+not expected consumption. Do not start a call when its reservation plus all
+remaining mandatory gates cannot fit the confirmed total.
 
 The CLI will not prepare or launch a package unless its full token and
 conservative price reservation fits. Native producer preparation reserves the
@@ -334,10 +348,21 @@ inherit only verified completed discovery/acquisition/analysis/synthesis
 artifacts; review and closure always run again. A closed-project evidence
 refresh uses `research project addendum`, not a fork or in-place mutation.
 
+For a top-journal source, initialize and approve Policy for `TARGET`, create a
+new target-specific design, and add `--design`, `--design-producer-agent`, and
+`--design-producer-session` to fork/addendum. Old scientific reviews never carry
+forward. The new generation re-enters the applicable early gates, even when it
+inherits completed outputs; an inherited later package cannot bypass them.
+
 The fork becomes authoritative immediately and its source becomes stale. The
 default status/run path excludes superseded, archived, and abandoned projects;
 `research status --all` is the audit view. Archive complete/stale history and
 abandon unfinished history with an explicit reason.
+
+At a milestone, use `research project audit export` followed by
+`research project audit verify`. The portable bundle includes exact formal
+evidence/artifact bytes and project review objects while excluding credentials,
+host-specific paths, active native state, capsules, and unrelated projects.
 
 When the next material step cannot be performed autonomously, use one of two
 durable states rather than another retry:

--- a/tiangong-auto-research/references/publication-policy.md
+++ b/tiangong-auto-research/references/publication-policy.md
@@ -59,6 +59,14 @@ Status is mechanical: `missing`, `default-unapproved`, `custom-draft`,
 `invalid`. Any content edit after approval yields `changed`; expiry yields
 `stale`. Both stop project stages and publication review until re-approved.
 
+Policy approval is necessary but not sufficient for project admission. The
+current native host must also create a project-specific scientific design, and
+fresh independent reviews must pass at research design, real-record evidence
+construction, and outcome-blind methods pilot boundaries. Read
+[scientific-design.md](scientific-design.md). These early gates are reverified
+before final manuscript freeze; a manually changed status field or missing
+review object cannot inherit publication approval.
+
 ## Verdict ceilings
 
 Defaults support feasibility and planning but are not journal endorsement. The
@@ -138,3 +146,8 @@ Closure re-verifies every hash and requires all four reviews. Report only the
 returned verdict, bounded statement, limitations, and pivots.
 `target-journal-submission-ready` means the frozen artifact passed its declared
 gates; it does not predict or guarantee editorial acceptance.
+
+After closure, export and verify the portable audit directory from
+[scientific-design.md](scientific-design.md). Handing off only the manuscript,
+receipt hashes, or a workspace-specific path is not sufficient for independent
+editorial or reproducibility audit.

--- a/tiangong-auto-research/references/scientific-design.md
+++ b/tiangong-auto-research/references/scientific-design.md
@@ -1,0 +1,226 @@
+# Scientific design contract and early review gates
+
+Load this reference before admitting a top-journal project, changing its scope,
+recovering into a new generation, or crossing the discover, acquire, or analyze
+boundaries. The current native Codex or Claude host performs the scientific
+reasoning. The CLI validates, freezes, hashes, routes, and audits it; the CLI
+does not create the study design or launch a nested producer.
+
+## Design before search
+
+Start with the approved Research Policy and inspect the closed schema:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show scientific-design --json
+```
+
+In the current native host, write one project-specific design JSON. It must
+make the following explicit before evidence search can consume the main budget:
+
+- article identity, central study kind, supporting components, bridge edges,
+  target journals, contribution statement, and allowed claim verbs;
+- estimand, claims, result classes, and a directed claim/evidence graph;
+- endpoints and their truth roles, comparable endpoint pairs, units, quantities,
+  denominators, permitted terms, and prohibited overclaims;
+- calibration/validation datasets, exposure identifiers, shared upstream data,
+  independent data-generating processes, original units, independent clusters,
+  effective independent units, and the resampling unit;
+- every model equation/coefficient set, safe object locator, raw-file SHA-256,
+  executable entrypoint, implementation status, exact environment-lock status,
+  baseline role, and the gate at which any pending object must be frozen;
+- empirical, regulatory, scenario, analytic, and decision thresholds, including
+  sensitivity plans for non-empirical thresholds;
+- factor levels, uncertainty application/composition rules, frozen or
+  source-pending parameter states, and an exact parameter-state binding for
+  every declared joint sensitivity state;
+- required evidence roles, closest-work full-text floors, counterevidence, known
+  gaps, baseline fairness, context construction, stop/handoff dispositions, and
+  one disposition for every resolved Research Policy rule.
+
+A model output is not field truth. A discrepancy between two engineering models
+is a cross-model result unless one endpoint is independently observed and
+declared as such. Resampling iterations reduce Monte Carlo error; they never
+increase the number of independent experimental or observational units. Gross
+installed mixture is not automatically binder, virgin material, network demand,
+or an observed effect. Encode those boundaries in quantities and claim verbs.
+
+## Executable model and uncertainty contracts
+
+A digest proves byte identity, not scientific executability. For every model,
+bind both the implementation and its environment lock with safe retrievable
+locators and declare `artifactHashBasis: raw-file-bytes`. A model marked
+`executable-frozen` and an environment marked `exact-frozen` must both use
+`research-design` as their freeze gate. Otherwise declare
+`pending-source-acquisition` or `pending-runtime-lock` and a later
+`evidence-construct` or `pilot-methods` deadline. Specification prose,
+unresolved coefficients, an unpinned runtime, or an empty dependency lock is
+not executable merely because its bytes are hash-bound.
+
+Every pending model deadline must be owned by a `planned` Policy disposition at
+the same gate through `modelStructureIds`. Every source-pending uncertainty
+parameter must likewise bind its `freezeBeforeGate` through
+`uncertaintyParameterIds`. A disposition cannot be `satisfied-by-design` while
+its required implementation, environment, or parameter states remain pending.
+
+For uncertainty groups, list every `jointStateId` and give one
+`jointStateBindings` entry that selects exactly one existing state from every
+grouped parameter. Keep factor levels and uncertainty multipliers distinct;
+declare their application point and composition rule and preserve factor-level
+identity. A large bootstrap count, a label-only joint state, or a full-factorial
+name without exact bindings is not an auditable state space.
+
+The directed bridge graph must be endpoint-continuous from every central model
+output through decision and accounting consequences. Each edge declares its
+operator, aggregation rule, scale reconciliation, join keys, spatial/temporal
+alignment, quantities, uncertainty inputs, and model identities. Do not bridge
+a model result to an overlay, scenario, or material claim only in prose.
+
+Run preflight and initialization with the same exact design:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project preflight \
+  --workspace /absolute/path/to/workspace \
+  --goal top-journal --policy-project PROJECT \
+  --question "Research question" \
+  --requirements /absolute/path/to/evidence-requirements.json \
+  --design /absolute/path/to/scientific-design.json --json
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project init PROJECT \
+  --workspace /absolute/path/to/workspace \
+  --goal top-journal --question "Research question" \
+  --requirements /absolute/path/to/evidence-requirements.json \
+  --design /absolute/path/to/scientific-design.json \
+  --design-producer-agent codex \
+  --design-producer-session OPAQUE_NATIVE_SESSION \
+  --confirm-budget --json
+```
+
+The session identifier is opaque input for reuse detection. Only its SHA-256 is
+persisted. Preflight reserves the base packages, three early scientific reviews,
+four final publication reviews, and one bounded revision cycle. Admission stops
+when the complete lifecycle does not fit the finite runaway ceiling.
+
+The design may pass admission with later-gate objects explicitly pending. This
+is not permission to compute from them. The research-design review packet lists
+each such item under `mechanicalAssessment.futureGateObligations`, including its
+error code, exact due gate, object IDs, and owning Policy rule IDs. At the due
+gate the same condition becomes a blocking mechanical error unless a new
+authoritative generation freezes replacement objects.
+
+## Three early scientific gates
+
+`research status` returns the next gate and a safe command. Do not prepare a
+native stage while an upstream gate is pending, under revision, stopped, or
+hash-invalid.
+
+1. `research-design` blocks discovery. It checks identity, observability,
+   claims/edges, truth roles, quantity ontology, validation semantics, known-gap
+   dispositions, and lifecycle feasibility.
+2. `evidence-construct` runs after discovery and blocks acquisition. The native
+   producer must construct the central joins/edges on real records without
+   inspecting result values, record the exact canary artifacts, demonstrate that
+   each required evidence role reaches its full-text and independent-source
+   floor, disposition closest work, and prove central evidence fits the bounded
+   context route.
+
+This real-record construct canary is a feasibility gate, not a result-producing
+analysis.
+3. `pilot-methods` runs after acquisition and blocks analysis. It checks
+   leakage/circularity, endpoint compatibility, baseline fairness, units and
+   denominators, threshold types, decision-loss metrics, validation-plan
+   coverage, and the original/cluster/effective/resampling-unit audit.
+
+For each gate, inspect its assessment schema, have the current native producer
+write a bounded assessment from the exact frozen inputs, and prepare a fresh
+independent reviewer packet:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show scientific-assessment-research-design --json
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project scientific review prepare PROJECT \
+  --role research-design \
+  --assessment /absolute/path/to/research-design-assessment.json \
+  --reviewer-agent claude \
+  --reviewer-session FRESH_OPAQUE_REVIEW_SESSION \
+  --workspace /absolute/path/to/workspace --json
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show scientific-review-research-design --json
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project scientific review submit PROJECT \
+  --role research-design --review /absolute/path/to/review.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Repeat with `evidence-construct` and `pilot-methods`. The reviewer must use the
+configured other agent family and a session unused by the producer or any prior
+review. The packet binds exact design, Policy, assessment, stage outputs, and
+reviewer identity hashes. Reviewer prose cannot override a failed mechanical
+canary, missing evidence role, inflated effective sample size, invalid
+resampling unit, unverified validation plan, or missing decision-loss metric.
+Revise the assessment/design/method and prepare a new packet with a new session.
+
+Review the exact promoted `stageInputs`. Their `sha256` values are digests of
+the raw file bytes at the portable `path`; `sourceLocator` records provenance,
+while `purpose` and `ownerId` bind the bytes to the scientific object under
+review. `packetSha256` is the packet's logical identity (excluding its own
+identity field); the portable audit manifest separately records the raw stored
+packet-file digest. Do not interchange those two hash meanings.
+
+## Scope change and authoritative generations
+
+Never edit a frozen design or old project in place. A top-journal fork or
+addendum requires an approved Policy and scientific design whose `projectId`
+matches the new target generation, plus a fresh native producer session:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project fork OLD --to NEW \
+  --design /absolute/path/to/new-scientific-design.json \
+  --design-producer-agent codex \
+  --design-producer-session FRESH_NATIVE_SESSION \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Inherited outputs remain evidence, not inherited scientific approval. The new
+generation starts at the applicable pending gates; a later ready package cannot
+bypass an earlier gate. The source becomes explicitly superseded, the default
+status shows only the authoritative descendant, and `--all` remains the history
+view.
+
+Freezing previously pending uncertainty values, executable model bytes, or an
+exact environment lock is a material design change. Create the successor before
+the declared due gate, rebind its Policy, design, raw objects, and native
+producer session, and obtain fresh early review. Never edit an old object or
+manually mark its obligation complete.
+
+## Portable audit handoff
+
+At a milestone or after publication closure, export an immutable directory and
+verify it independently:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project audit export PROJECT \
+  --output /absolute/path/to/new-audit-directory \
+  --workspace /absolute/path/to/workspace --json
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project audit verify \
+  --bundle /absolute/path/to/new-audit-directory --json
+```
+
+The bundle includes only the selected project, portable input copies, formal
+evidence/artifact bytes, Policy/design/review objects, outputs, environment
+fingerprints, and project journal proofs. It omits credentials, setup sources,
+browser profiles, active native state, ephemeral capsules, and unrelated files.
+Export refuses an existing/symlink destination, host-specific workspace paths,
+sensitive text, missing evidence bytes, or any hash drift. Verification rejects
+every extra, missing, or changed byte; it never scans a Downloads directory or
+substitutes a newer file.

--- a/tiangong-auto-research/scripts/test-research-policy-pack.mjs
+++ b/tiangong-auto-research/scripts/test-research-policy-pack.mjs
@@ -97,10 +97,20 @@ assert.equal(ids.size, Object.values(expected).flat().length);
 
 const skill = await readFile(join(skillRoot, "SKILL.md"), "utf8");
 const publicationReference = await readFile(join(skillRoot, "references", "publication-policy.md"), "utf8");
+const scientificDesignReference = await readFile(
+  join(skillRoot, "references", "scientific-design.md"),
+  "utf8",
+);
+const openAiMetadata = await readFile(join(skillRoot, "agents", "openai.yaml"), "utf8");
 assert.match(
   skill,
   /references\/publication-policy\.md/,
   "SKILL.md must route top-journal publication work to the detailed reference",
+);
+assert.match(
+  skill,
+  /references\/scientific-design\.md/,
+  "SKILL.md must route scientific design and early-gate work to the detailed reference",
 );
 assert.match(skill, /current native host/i, "final manuscript authoring must remain in the native host");
 for (const role of [
@@ -112,4 +122,21 @@ for (const role of [
   assert.match(publicationReference, new RegExp(`\\b${role}\\b`));
 }
 assert.match(publicationReference, /does not predict or guarantee editorial acceptance/i);
+for (const marker of [
+  "real-record construct canary",
+  "effective independent units",
+  "reviewer prose cannot override",
+  "project audit export",
+  "futureGateObligations",
+  "raw-file-bytes",
+  "executable-frozen",
+  "jointStateBindings",
+]) {
+  assert.match(scientificDesignReference, new RegExp(marker, "i"));
+}
+assert.match(scientificDesignReference, /current native Codex or Claude host/i);
+assert.match(scientificDesignReference, /does not create the study design or launch a nested producer/i);
+assert.match(openAiMetadata, /scientific design/i);
+assert.match(openAiMetadata, /independent scientific and final publication reviews/i);
+assert.match(openAiMetadata, /portable audit/i);
 process.stdout.write(`Research Policy default pack tests passed (${ids.size} templates)\n`);


### PR DESCRIPTION
Part of tiangong-ai/workspace#129

## Summary
- Route Auto Research through an explicit top-journal scientific-design lifecycle before inference.
- Extend the default policy pack, native execution guidance, and reviewer obligations with model, uncertainty, evidence-role, novelty, and environment freeze requirements.

## Key Decisions
- Keep the native Codex or Claude App as the research producer; the CLI remains a governance and independent-review boundary.
- Treat unresolved scientific inputs as future gate obligations instead of fabricating a completed result.
- Keep the Skill concise and place the detailed lifecycle in a first-level reference.

## Validation
- Root exact cold Docker gate passed, including the Skills clean-container suite.
- tiangong-auto-research policy-pack tests passed.
- skill-creator quick_validate passed using pinned PyYAML 6.0.3 offline.
- docpact 0.1.9 strict validation and explicit changed-file lint passed with no uncovered paths.
- git diff --check passed.

## Risks / Rollback
- Existing production workspaces will gain stricter pre-inference obligations when they install this orchestrator revision.
- Roll back by reverting this commit and retaining the previously pinned Skill commit; do not weaken a partially adopted policy pack.

## Follow-ups
- Update the CLI immutable first-party source pin and orchestrator tree hash after this PR merges.
- Publish the next CLI patch only after release-mode lineage and cold-container gates pass.

## Workspace Integration
- Required. The root release PR will pin the exact Skills merge commit and observed CLI release commit.