### PR TITLE
feat(auto-research): stop on proven evidence exhaustion

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-15"
-lastReviewedCommit: "126b3e177739064f5b4b29eb240930c9020bb2ef"
+lastReviewedAt: "2026-08-16"
+lastReviewedCommit: "cc090cd161bff05cd41e15b74b7ef281165ae6d3"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 126b3e177739064f5b4b29eb240930c9020bb2ef
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: 3d5d85f41bac03b7b31208e89d6c5e56da320baf
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-15
-lastReviewedCommit: d4854e6688055ea67ddc6c8a0ec2cec053712e16
+lastReviewedAt: 2026-08-16
+lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
 ---
 
 # Skills Documentation Standards

--- a/scripts/run-auto-research-tests.sh
+++ b/scripts/run-auto-research-tests.sh
@@ -16,6 +16,7 @@ sh scripts/test-clean-container-entrypoint.sh
 node tiangong-auto-research/scripts/test-research-cli.mjs
 node tiangong-auto-research/scripts/test-routing-contract.mjs
 node tiangong-auto-research/scripts/test-research-policy-pack.mjs
+node tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
 sh tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
 bash tiangong-kb-sci-search/scripts/test-sci-search.sh
 bash tiangong-kb-report-search/scripts/test-report-search.sh

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -48,6 +48,9 @@ detailed stop and recovery rules.
   before production preflight, execution, recovery, or closure.
 - Read [references/evidence-pipeline.md](references/evidence-pipeline.md) before
   discovery, acquisition, evidence refresh, or an addendum.
+- Read [references/evidence-exhaustion.md](references/evidence-exhaustion.md)
+  before declaring a material evidence gap exhausted, requesting paid or
+  authorized access, waiting for an external response, or narrowing scope.
 - Read [references/native-execution.md](references/native-execution.md) before
   preparing or submitting discover, acquire, analyze, or synthesize stages.
 - Read [references/publication-policy.md](references/publication-policy.md)
@@ -144,6 +147,9 @@ cross-model comparison, scenario, and accounting roles; freeze units,
 denominators, independent clusters, thresholds, baselines, evidence roles,
 closest-work requirements, known gaps, and handoff conditions. Pass the same
 exact file to preflight and init with the native producer's opaque session ID.
+The design must map every required evidence role to its lawful acquisition
+routes. All plan-bound lawful agent routes must have immutable terminal events
+before an evidence-exhausted handoff is valid.
 Follow [references/scientific-design.md](references/scientific-design.md); never
 let the CLI invent a study design or describe resampling as new independent data.
 

--- a/tiangong-auto-research/assets/research-policy/defaults/project/publication-brief.md
+++ b/tiangong-auto-research/assets/research-policy/defaults/project/publication-brief.md
@@ -62,7 +62,9 @@ pilot. Synthetic schema examples are not feasibility evidence.
 ## Novelty and recall plan
 
 Define databases, query families, closest known work, citation searches,
-counterevidence, and the stopping or saturation rule.
+counterevidence, lawful acquisition routes, and the stopping or saturation
+rule. Map all agent-executable routes to immutable attempt evidence before an
+evidence-exhausted disposition.
 
 Assign every central claim an evidence role, minimum independent sources, and
 minimum full texts. State how closest work is obtained and dispositioned before
@@ -76,4 +78,6 @@ and journal-specific submission materials.
 ## Stop, handoff, and pivot conditions
 
 Define conditions for additional autonomous work, user authorization, external
-response, research redesign, article-type change, or journal change.
+response, research redesign, article-type change, or journal change. State the
+required evidence role, alternatives tried, and exact resume criteria for every
+purchase, subscription, authorization, or external response.

--- a/tiangong-auto-research/references/evidence-exhaustion.md
+++ b/tiangong-auto-research/references/evidence-exhaustion.md
@@ -1,0 +1,72 @@
+# Evidence exhaustion and access handoff
+
+Use this protocol only when a required evidence role remains materially
+unsatisfied after broad discovery and strict admission. It separates work the
+current native host can still perform from work that requires a purchase or
+subscription, user authorization, or an external response.
+
+## Plan acquisition routes before search
+
+The frozen scientific design maps each required evidence role to explicit
+lawful routes. An agent route selects one auditable mechanism: a locked broker
+capability, a named native activity channel, an OA download backend, or an
+authorized browser backend. A non-agent route identifies licensed material,
+owner-provided material, an external data request, or field collection.
+
+Do not add a route after results are known merely to justify stopping. A
+material route change requires a new authoritative scientific-design
+generation and fresh applicable review.
+
+## Distinguish immediate challenges from true exhaustion
+
+An `interactive-challenge` handoff pauses immediately for login, SSO/MFA,
+CAPTCHA, Turnstile, a security warning, VPN, entitlement, or a visible paywall.
+It does not claim that other evidence routes are exhausted and it must never
+trigger automatic bypass.
+
+An `evidence-exhausted` handoff is valid only when all required,
+agent-executable routes mapped to every cited missing required evidence role
+have a verified terminal event hash. A completed search with insufficient
+admissible evidence or a deterministic access block may be terminal. A timeout,
+429, retryable server failure, cancelled download, or an unrecorded assertion is
+not exhaustion.
+
+Inspect the CLI evidence access status before requesting this handoff. If it
+lists an untried required agent route, continue that route or revise the
+reviewed design; do not continue substitute searching outside the plan.
+
+## Make every access request actionable
+
+For each remaining non-agent route, record:
+
+- the exact required evidence role and material gap;
+- the resource type and non-sensitive resource name;
+- an official HTTPS locator for a database subscription, article purchase,
+  institutional-access page, or licensed dataset when one exists;
+- the lawful access mode and whether cost is unknown or requires a provider
+  quote;
+- the alternatives tried, identified by reviewed route IDs and terminal event
+  hashes;
+- the minimum user or external action;
+- exact resume criteria, such as an authorized browser session, a registered
+  owner input, or a hash-bound downloaded artifact.
+
+Do not fabricate a price, subscription entitlement, database coverage, license,
+response, full text, or evidence value. Never place credentials, cookies,
+session data, authorization headers, sensitive URL parameters, or profile
+paths in the record. The CLI sanitization and URL checks remain authoritative.
+
+## Stop and resume
+
+Use `user-action-required` for purchase, subscription, institutional login,
+authorization, VPN, or owner-supplied material. Use
+`external-response-required` when a government, institution, data owner, or
+collaborator must respond. Once either state is durable, stop model work and do
+not continue substitute searching.
+
+Resolve only after the requested condition is true. Resolution reopens the
+same reviewed route; it does not mark the missing evidence role satisfied.
+Evidence must still enter through the ordinary broker, input, download,
+artifact, snapshot, scientific-review, and publication gates. If the resource
+cannot be obtained, create a new reviewed scope or article-generation decision
+instead of implying that unavailable evidence was observed.

--- a/tiangong-auto-research/references/evidence-exhaustion.md
+++ b/tiangong-auto-research/references/evidence-exhaustion.md
@@ -12,6 +12,15 @@ lawful routes. An agent route selects one auditable mechanism: a locked broker
 capability, a named native activity channel, an OA download backend, or an
 authorized browser backend. A non-agent route identifies licensed material,
 owner-provided material, an external data request, or field collection.
+Every declared agent route that maps a required evidence role must itself be
+required. Every `requiredCapabilityId` must map to a required broker route whose
+capability exists in the current verified lock; preflight rejects optional,
+unmapped, or unavailable routes.
+
+Bind every broker request with the exact design route in
+`acquisition_route_id`. Bind native activity and download events with the exact
+route in `acquisitionRouteId`. A missing, mismatched, or after-the-fact route ID
+is rejected and cannot prove exhaustion.
 
 Do not add a route after results are known merely to justify stopping. A
 material route change requires a new authoritative scientific-design
@@ -27,13 +36,26 @@ trigger automatic bypass.
 An `evidence-exhausted` handoff is valid only when all required,
 agent-executable routes mapped to every cited missing required evidence role
 have a verified terminal event hash. A completed search with insufficient
-admissible evidence or a deterministic access block may be terminal. A timeout,
-429, retryable server failure, cancelled download, or an unrecorded assertion is
+admissible evidence, an explicit broker authentication/entitlement block, or a
+validated deterministic no-OA/unavailable download result may be terminal. A
+malformed request, configuration mismatch, HTTP 422, timeout, 429, 5xx,
+cancelled download, blocked interactive challenge, or unrecorded assertion is
 not exhaustion.
 
-Inspect the CLI evidence access status before requesting this handoff. If it
-lists an untried required agent route, continue that route or revise the
-reviewed design; do not continue substitute searching outside the plan.
+Inspect the exact status before requesting this handoff:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project access status PROJECT \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Use only the returned route IDs, terminal event hashes, classifications, and
+recommended action. If it lists an untried required agent route, continue that
+route or revise the reviewed design; do not continue substitute searching
+outside the plan. When all agent routes are terminal, first assess the required
+evidence-role coverage. Follow `ifEvidenceStillInsufficient` only when a cited
+required role genuinely remains below its reviewed floor.
 
 ## Make every access request actionable
 
@@ -63,6 +85,12 @@ authorization, VPN, or owner-supplied material. Use
 `external-response-required` when a government, institution, data owner, or
 collaborator must respond. Once either state is durable, stop model work and do
 not continue substitute searching.
+
+If every required agent route is proven terminal and no lawful user or
+external-party route remains, request the reviewed scope-pivot disposition with
+empty remaining routes and access requests. The user must narrow or abandon
+the unsupported scope or claim; absence of obtainable evidence is never a
+positive result.
 
 Resolve only after the requested condition is true. Resolution reopens the
 same reviewed route; it does not mark the missing evidence role satisfied.

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -22,6 +22,12 @@ context, reservation, and expected-cost gaps.
 Production requires an independent public-internet capability. Add every
 owner-whitelisted database whose contents matter to the question as an exact
 required capability; a general web result cannot silently substitute for it.
+For top-journal work, the frozen scientific design must also enumerate every
+lawful, relevant route available in the configured environment: broker
+capabilities, native Web/Browser channels, OA/download adapters, explicitly
+authorized browsers, licensed or owner-provided material, external requests,
+and field collection. Omitting an applicable route is a design/review defect,
+not permission to stop early.
 
 ## 2. Search broadly in bounded batches
 
@@ -62,6 +68,8 @@ use, reviewer binding, and supersession.
 The current native Codex or Claude app may use its own Web/Browser experience
 to find additional leads. Record every material search, navigation, download,
 or file-inspection occurrence through the packet's `recordActivity` command.
+For a top-journal project, pass the exact frozen route as
+`acquisitionRouteId`; the control plane rejects unbound or mismatched activity.
 The control plane persists only a sanitized input hash, channel, counts, status,
 challenge class, and candidate IDs. Then register safe, non-secret candidate
 metadata through `registerCandidate`. Such a lead remains
@@ -104,6 +112,9 @@ object or equivalent transport completion, save it to a unique planned staging
 path, and first bind that event through `bindDownload`. A failed or cancelled
 event creates no successful binding and cannot register an artifact. Never scan
 a directory for the newest file and never infer success from file existence.
+For a top-journal project, the binding record must carry the exact
+`acquisitionRouteId`. Broker fetches use the corresponding snake-case
+`acquisition_route_id` argument.
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -147,13 +147,16 @@ It does not silently retry research or invoke another model.
 
 Login, MFA, CAPTCHA, Turnstile, paywall, security-warning, or authorization
 activity cannot be submitted as ordinary completion. Record it as `blocked`
-through `recordActivity`, create a `user-action-required` record with the
-packet's `requestHandoff` argv, and stop. When the missing material requires an
-institution or another third party to respond, request
-`external-response-required` instead of searching indefinite substitutes. Both
-states are durable and do not burn the prepared attempt. Resume only after an
-operator explicitly runs `research project handoff resolve` with a non-secret
-resolution note.
+through `recordActivity`, create an `interactive-challenge`
+`user-action-required` record with the packet's `requestHandoff` argv, and stop.
+This immediate safety pause is not an evidence-exhausted claim. When all
+plan-bound lawful routes have terminal evidence but a required role still needs
+licensed or owner material, follow
+[evidence-exhaustion.md](evidence-exhaustion.md) and request an
+`evidence-exhausted` handoff. Use `external-response-required` when an
+institution or another third party must respond. Both states are durable and do
+not burn the prepared attempt. Resume only after an operator explicitly runs
+`research project handoff resolve` with a non-secret resolution note.
 
 ## Continue, review, or abort
 

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -149,7 +149,9 @@ Login, MFA, CAPTCHA, Turnstile, paywall, security-warning, or authorization
 activity cannot be submitted as ordinary completion. Record it as `blocked`
 through `recordActivity`, create an `interactive-challenge`
 `user-action-required` record with the packet's `requestHandoff` argv, and stop.
-This immediate safety pause is not an evidence-exhausted claim. When all
+This immediate safety pause is not an evidence-exhausted claim, does not create
+a terminal acquisition-route event, and must be resolved by the user before
+that route can continue. When all
 plan-bound lawful routes have terminal evidence but a required role still needs
 licensed or owner material, follow
 [evidence-exhaustion.md](evidence-exhaustion.md) and request an

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -377,7 +377,8 @@ remaining evidence gaps. `research run` returns `handoff-required` and does not
 schedule more work. Resolve it explicitly only after the action or response has
 been registered; never treat continued substitute searching as resolution.
 
-For a material evidence ceiling, inspect the project evidence access status
+For a material evidence ceiling, run the evidence access status command,
+`research project access status PROJECT --workspace /absolute/path --json`
 before requesting the handoff. An `evidence-exhausted` record must cite every
 terminal event hash for all required plan-bound agent routes and must bind each
 remaining purchase, subscription, authorization, or external request to a

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -377,6 +377,14 @@ remaining evidence gaps. `research run` returns `handoff-required` and does not
 schedule more work. Resolve it explicitly only after the action or response has
 been registered; never treat continued substitute searching as resolution.
 
+For a material evidence ceiling, inspect the project evidence access status
+before requesting the handoff. An `evidence-exhausted` record must cite every
+terminal event hash for all required plan-bound agent routes and must bind each
+remaining purchase, subscription, authorization, or external request to a
+required evidence role and exact resume criteria. Follow
+[evidence-exhaustion.md](evidence-exhaustion.md). An interactive challenge is a
+separate immediate pause and never asserts route exhaustion.
+
 Run one recovered or canary project with an explicit scope:
 
 ```bash

--- a/tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
+++ b/tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const skillRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const skill = await readFile(join(skillRoot, "SKILL.md"), "utf8");
+const production = await readFile(join(skillRoot, "references", "production-research.md"), "utf8");
+const nativeExecution = await readFile(join(skillRoot, "references", "native-execution.md"), "utf8");
+const exhaustion = await readFile(
+  join(skillRoot, "references", "evidence-exhaustion.md"),
+  "utf8",
+);
+const policyBrief = await readFile(
+  join(skillRoot, "assets", "research-policy", "defaults", "project", "publication-brief.md"),
+  "utf8",
+);
+
+assert.match(skill, /references\/evidence-exhaustion\.md/);
+assert.match(skill, /all plan-bound lawful agent routes/i);
+assert.match(production, /evidence access status/i);
+assert.match(nativeExecution, /interactive-challenge/i);
+assert.match(nativeExecution, /evidence-exhausted/i);
+
+for (const phrase of [
+  /required evidence role/i,
+  /terminal event hash/i,
+  /purchase\s+or\s+subscription/i,
+  /official HTTPS locator/i,
+  /alternatives tried/i,
+  /resume criteria/i,
+  /do not fabricate/i,
+  /do not continue substitute searching/i,
+]) {
+  assert.match(exhaustion, phrase);
+}
+
+assert.match(policyBrief, /lawful acquisition routes/i);
+assert.match(policyBrief, /purchase, subscription, authorization, or external response/i);
+assert.match(policyBrief, /all agent-executable routes/i);
+
+process.stdout.write("evidence exhaustion contract tests passed\n");

--- a/tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
+++ b/tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
@@ -31,6 +31,11 @@ for (const phrase of [
   /resume criteria/i,
   /do not fabricate/i,
   /do not continue substitute searching/i,
+  /research project access status/i,
+  /acquisition_route_id/,
+  /acquisitionRouteId/,
+  /422/,
+  /narrow or abandon/i,
 ]) {
   assert.match(exhaustion, phrase);
 }


### PR DESCRIPTION
## Outcome

Defines a fail-closed evidence exhaustion protocol for top-journal Auto Research. Research must execute every required lawful, configured acquisition route before declaring exhaustion, preserve exact terminal evidence, and stop with an actionable access or scope handoff when required evidence remains unavailable.

## Changes

- require route-bound acquisition planning before inference
- distinguish retryable failures and human challenges from terminal exhaustion
- define purchase, subscription, institutional-access, external-response, owner-input, field-collection, and scope-pivot handoffs
- prohibit unsupported substitution and premature purchase recommendations
- add deterministic Skill contract tests and operator documentation
- record docpact governance review evidence

## Validation

- clean Docker iterative TDD suite
- clean Docker cold Skills suite
- root combined clean Docker cold integration suite
- skill-creator quick validation
- docpact 0.1.9 enforce lint: zero diagnostics
- git diff --check

Tracks tiangong-ai/workspace#132.