### PR TITLE
docs(auto-research): document declarative setup

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-16"
-lastReviewedCommit: "cc090cd161bff05cd41e15b74b7ef281165ae6d3"
+lastReviewedAt: "2026-08-17"
+lastReviewedCommit: "c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # Tiangong AI Skills
@@ -108,6 +108,20 @@ npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
   tiangong-ai research setup \
   --workspace /absolute/path/to/workspace
 ```
+
+For repeatable non-interactive provisioning, run `research setup init` first.
+It creates a no-overwrite `.tiangong-research/setup.yaml` template plus
+`setup.env.example`. After the user reviews the current catalog, licenses,
+models, pricing, checks, and confirmations, bare `research setup` detects only
+that workspace-local YAML and bypasses the Wizard. The optional real
+`setup.env` must be owner-only and contains only values for variable names
+referenced by the YAML. Invalid declarations fail closed; they never trigger an
+interactive fallback or parent-directory search. Setup returns success only
+after every selected dependency, provider live check, Policy compatibility
+check, and independent reviewer smoke reaches complete readiness. Use explicit
+`research setup wizard` to choose the interactive path. See
+`tiangong-auto-research/references/setup.md` and
+`tiangong-auto-research/references/env.md`.
 
 The bootstrap version is an explicit new-workspace choice, never `latest`, a
 tag, or a range. After apply creates `runtime-lock.json`, the installed

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # 天工 AI Skills
@@ -105,6 +105,17 @@ npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
   tiangong-ai research setup \
   --workspace /absolute/path/to/workspace
 ```
+
+需要可重复、非交互式配置时，先运行 `research setup init`。它会以不覆盖已有
+文件的方式创建 `.tiangong-research/setup.yaml` 模板和
+`setup.env.example`。用户审阅当前 catalog、许可证、模型、价格、检查和确认项后，
+普通 `research setup` 只检测该 workspace 内的固定 YAML，并跳过 Wizard。可选的
+真实 `setup.env` 必须仅 owner 可读写，其中只能放 YAML 所引用变量名对应的值。
+无效声明会直接失败，不会回退到交互流程，也不会向父目录搜索。只有所有已选依赖、
+provider live check、Policy 兼容性检查和独立 reviewer smoke 都完全就绪，setup
+才返回成功。需要明确选择交互流程时使用 `research setup wizard`。详见
+`tiangong-auto-research/references/setup.md` 和
+`tiangong-auto-research/references/env.md`。
 
 bootstrap 版本是新 workspace 的显式选择，不得使用 `latest`、tag 或 range。
 apply 创建 `runtime-lock.json` 后，已安装 orchestrator 的内置 resolver 会让

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # Skills Repository Architecture
@@ -44,6 +44,13 @@ Skills are consumed by external agent runtimes through the `skills` CLI or by
 copy/symlink installation. Some skills require environment variables for
 external APIs; those requirements belong in the relevant skill docs and the
 repository README when broadly useful.
+
+`tiangong-auto-research` documents both the interactive setup Wizard and the
+CLI-owned declarative path. Its references explain fixed workspace-local YAML
+discovery, owner-only env input, no interactive fallback after a declaration
+error, and complete-readiness gating. The Skill does not duplicate the closed
+YAML schema or parse configuration; the CLI-generated template and validator
+remain authoritative.
 
 `tiangong-auto-research/assets/research-policy/defaults/**` is the versioned,
 generic source pack for top-journal Policy initialization. It is immutable

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-16
-lastReviewedCommit: cc090cd161bff05cd41e15b74b7ef281165ae6d3
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -22,6 +22,15 @@ reviewed exact bootstrap CLI version. Never substitute `latest`, a range, a
 tag, a path, or a command fragment. After setup creates the runtime lock, use
 the resolver above.
 
+If that clean directory contains the fixed workspace-local
+`.tiangong-research/setup.yaml`, bare `research setup` must use its declarative
+path without a TTY. It never scans parent directories and must not fall back to
+the Wizard after a declaration error. Use `research setup init` to generate the
+no-overwrite YAML and env examples, or explicit `research setup wizard` when the
+user chooses the interactive path. Follow [references/setup.md](references/setup.md)
+and [references/env.md](references/env.md); the generated CLI template is the
+only authoritative declaration schema.
+
 The CLI is the deterministic control plane: it owns setup, locks, brokered
 evidence, schemas, coverage, budgets, admission, the independent review process,
 the journal, and closure. The current interactive Codex or Claude Code session
@@ -97,6 +106,13 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   research setup \
   --workspace /absolute/path/to/workspace --json
 ```
+
+When the user asks for repeatable non-interactive configuration, first create
+the safe template with `research setup init --workspace
+/absolute/path/to/workspace --json`, then let the user review and complete it.
+Never pre-accept licenses, downloads, global writes, quota, or agent-smoke cost.
+Setup is complete only when the resulting `overallReadiness` is `READY`; a
+planned, skipped-check, partially ready, or blocked result is not success.
 
 The user must explicitly confirm the recommended project-local
 `tiangong-auto-research` orchestrator and every external source, then accept its

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -32,6 +32,33 @@ must contain exactly one line per logical ID listed with
 `--credential-stdin <id[,id...]>`. Neither path writes a value to the command
 line, setup plan, stdout, stderr, journal, report, or shell history.
 
+### Declarative credential input
+
+`research setup init` creates
+`.tiangong-research/setup.env.example` beside the non-secret
+`.tiangong-research/setup.yaml`. If file-based input is needed, copy it to the
+fixed `.tiangong-research/setup.env` path and restrict it before setup:
+
+```bash
+cp .tiangong-research/setup.env.example .tiangong-research/setup.env
+chmod 600 .tiangong-research/setup.env
+```
+
+The real file must be regular, non-symlink, no larger than 64 KiB, and
+owner-only on POSIX. It accepts one literal `NAME=value` line per variable
+referenced by `credentialEnvironment` in `setup.yaml`. It does not execute
+`export`, interpolation, command substitution, or other shell syntax. Extra and
+duplicate names are rejected. If the same name also exists in the owner shell,
+the two values must not differ; the CLI never chooses one silently.
+
+The control-directory `.gitignore` excludes `setup.env`. Values are held only
+in memory during declarative apply, sanitized as configured secrets, and then
+written to the same owner-only logical stores used by interactive setup. They
+never enter YAML, immutable plans, declaration bindings, output, reports, or
+journals. After setup reaches full readiness, the source env file is no longer
+required because subsequent checks can use the owner-only logical stores; the
+owner may securely remove it unless repeatable provisioning still needs it.
+
 Environment-variable mode remains available for developers and CI. Recommended
 default names are:
 

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -26,7 +26,72 @@ confirmation and exact targets are frozen into the plan. Setup never installs
 system packages or Python packages, never runs `pip install`, never follows a
 Skill destination symlink, and never performs a floating update.
 
-## Clean-directory Wizard
+## Declarative clean-directory setup
+
+Use the declarative path for reviewed, repeatable provisioning without a TTY.
+The workspace may still be any user-selected absolute directory; the CLI never
+derives a product default from a sample or repository path.
+
+Generate no-overwrite examples with the exact reviewed bootstrap CLI:
+
+```bash
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup init \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+This creates `.tiangong-research/setup.yaml`,
+`.tiangong-research/setup.env.example`, and a control-directory `.gitignore`
+that excludes `setup.env`. The YAML contains only non-secret selections,
+settings, environment variable names, agent routes, checks, and confirmations.
+The generated template deliberately does not accept licenses, network writes,
+global mutation, or paid smoke cost for the user. Review the current catalog,
+complete those fields explicitly, and treat the generated CLI template—not
+this reference—as the authoritative closed schema.
+
+When file-based credentials are useful, copy the env example locally, fill only
+the variable names referenced by `credentialEnvironment`, and make it
+owner-only:
+
+```bash
+cp .tiangong-research/setup.env.example .tiangong-research/setup.env
+chmod 600 .tiangong-research/setup.env
+```
+
+Then run ordinary setup. Bare setup detects only the fixed workspace-local
+`.tiangong-research/setup.yaml`; it never scans a parent directory. Absolute
+`--config` and `--env-file` are explicit alternatives. If a declaration exists,
+the command is non-interactive and does not fall back to the Wizard after a
+YAML, schema, permission, credential, install, provider, reviewer, or readiness
+failure. Use `research setup wizard` only when the user explicitly chooses the
+interactive path.
+
+```bash
+npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
+  tiangong-ai research setup \
+  --workspace /absolute/path/to/research-workspace --json
+```
+
+Declarative setup requires live provider checks and the independent reviewer
+CLI agent smoke with explicit cost authorization. It runs them through the
+same apply/doctor pipeline as the Wizard and succeeds only when
+`overallReadiness=READY`. Missing dependencies, skipped checks, provider
+failure, reviewer failure, and warnings from any selected component remain a
+non-zero incomplete result. The current native producer is never launched as a
+child process.
+
+The CLI binds the semantic YAML hash to the immutable plan. An unchanged file
+reuses the same plan and reruns verification. A changed declaration stops; only
+after reviewing the complete change may the owner set
+`replaceExistingPlan: true`. The CLI then archives the prior immutable plan and
+declaration binding before creating the replacement. Never edit a plan or
+binding file directly.
+
+Read [env.md](env.md) before creating `setup.env`. Secret values are imported
+into the existing owner-only stores before downloads and are excluded from the
+YAML, plan, binding, stdout, stderr, report, and journal.
+
+## Interactive clean-directory Wizard
 
 The workspace may be any ordinary user-selected directory. Example paths below
 are placeholders, not defaults or repository requirements.
@@ -47,7 +112,7 @@ REVIEWED_BOOTSTRAP_CLI_VERSION=X.Y.Z
 npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
   tiangong-ai --version
 npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
-  tiangong-ai research setup \
+  tiangong-ai research setup wizard \
   --workspace /absolute/path/to/research-workspace
 ```
 
@@ -196,7 +261,9 @@ requires `--agent-smoke --confirm-agent-smoke-cost`. Doctor does not launch the
 native producer. It probes a required capability only once and skips the paid
 reviewer smoke when an earlier blocking prerequisite fails.
 
-Read `researchReadiness` for admission. `preprocessingReadiness`,
+Setup commands return success only when `overallReadiness` is `READY`; this is
+the complete selected-configuration result. Read `researchReadiness` for later
+research-core admission. `preprocessingReadiness`,
 `acquisitionReadiness`, and `authoringReadiness` describe optional domains;
 `overallReadiness` may be `PARTIALLY_READY` while unrelated research remains
 ready. An optional component becomes blocking only when the current project or

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -24,6 +24,48 @@ const descriptions = Object.fromEntries(
   await Promise.all(skillNames.map(async (name) => [name, await description(name)])),
 );
 
+const autoResearchSkill = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "SKILL.md"),
+  "utf8",
+);
+const setupReference = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "references", "setup.md"),
+  "utf8",
+);
+const environmentReference = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "references", "env.md"),
+  "utf8",
+);
+
+for (const marker of [
+  ".tiangong-research/setup.yaml",
+  "research setup init",
+  "never scans parent directories",
+  "overallReadiness",
+]) {
+  assert.ok(autoResearchSkill.includes(marker), `Auto Research entry must explain ${marker}`);
+}
+
+for (const marker of [
+  "## Declarative clean-directory setup",
+  ".tiangong-research/setup.env.example",
+  "replaceExistingPlan: true",
+  "does not fall back to the Wizard",
+  "overallReadiness=READY",
+]) {
+  assert.ok(setupReference.includes(marker), `Setup reference must explain ${marker}`);
+}
+
+for (const marker of [
+  ".tiangong-research/setup.env",
+  "chmod 600",
+  "literal `NAME=value`",
+  "must not differ",
+  "owner-only logical stores",
+]) {
+  assert.ok(environmentReference.includes(marker), `Environment reference must explain ${marker}`);
+}
+
 for (const marker of [
   "open-ended",
   "multi-source",


### PR DESCRIPTION
Refs tiangong-ai/workspace#137

## Summary
- document workspace-local declarative Auto Research setup and owner-only credential input
- require complete setup readiness and retain the explicit interactive Wizard path
- add routing-contract regression coverage for the new setup behavior

## Key Decisions
- the CLI-generated closed template remains the authoritative declaration schema
- invalid declarations fail closed without parent-directory discovery or Wizard fallback
- no license, network, global-write, quota, or agent-smoke consent is pre-accepted

## Validation
- `scripts/test-clean-container.sh --cold-build`
- `node tiangong-auto-research/scripts/test-routing-contract.mjs`
- skill-creator `quick_validate.py tiangong-auto-research`
- `../scripts/docpact lint --root . --worktree --format json --output .docpact/runs/latest.json`
- `git diff --check`

## Risks / Rollback
- documentation and contract-test change only; rollback by reverting this PR

## Follow-ups
- merge the dependent CLI implementation and publish `@tiangong-ai/cli@0.0.39`

## Workspace Integration
- required after the Skills and CLI release commits are verified; root Issue tiangong-ai/workspace#137 remains active
