### PR TITLE
feat(auto-research): make setup options explicit

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a"
+lastReviewedCommit: "29598568e966c4d6ae019d1c7bd6946d3390b277"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
+lastReviewedCommit: 29598568e966c4d6ae019d1c7bd6946d3390b277
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -110,12 +110,16 @@ npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
 ```
 
 For repeatable non-interactive provisioning, run `research setup init` first.
-It creates a no-overwrite `.tiangong-research/setup.yaml` template plus
-`setup.env.example`. After the user reviews the current catalog, licenses,
-models, pricing, checks, and confirmations, bare `research setup` detects only
-that workspace-local YAML and bypasses the Wizard. The optional real
-`setup.env` must be owner-only and contains only values for variable names
-referenced by the YAML. Invalid declarations fail closed; they never trigger an
+It creates a no-overwrite schema-v2 `.tiangong-research/setup.yaml` template
+plus `setup.env.example`. The YAML explicitly lists every current catalog Skill,
+credential, and setting, including disabled optional entries; the env example
+lists every credential variable with an empty placeholder. After the user
+reviews the current catalog, enabled states, licenses, models, pricing, checks,
+and confirmations, bare `research setup` detects only that workspace-local YAML
+and bypasses the Wizard. The optional real `setup.env` must be owner-only;
+disabled credentials stay empty and a non-empty disabled value is rejected.
+The removed v1 declaration and all invalid or incomplete declarations fail
+closed; they never trigger an
 interactive fallback or parent-directory search. Setup returns success only
 after every selected dependency, provider live check, Policy compatibility
 check, and independent reviewer smoke reaches complete readiness. Use explicit

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,13 +107,15 @@ npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
 ```
 
 需要可重复、非交互式配置时，先运行 `research setup init`。它会以不覆盖已有
-文件的方式创建 `.tiangong-research/setup.yaml` 模板和
-`setup.env.example`。用户审阅当前 catalog、许可证、模型、价格、检查和确认项后，
-普通 `research setup` 只检测该 workspace 内的固定 YAML，并跳过 Wizard。可选的
-真实 `setup.env` 必须仅 owner 可读写，其中只能放 YAML 所引用变量名对应的值。
-无效声明会直接失败，不会回退到交互流程，也不会向父目录搜索。只有所有已选依赖、
-provider live check、Policy 兼容性检查和独立 reviewer smoke 都完全就绪，setup
-才返回成功。需要明确选择交互流程时使用 `research setup wizard`。详见
+文件的方式创建 schema v2 `.tiangong-research/setup.yaml` 模板和
+`setup.env.example`。YAML 会显式列出当前 catalog 中的全部 Skill、凭据和设置，
+包括处于关闭状态的可选项；env example 同样列出全部凭据变量及空占位。用户审阅
+启用状态、许可证、模型、价格、检查和确认项后，普通 `research setup` 只检测该
+workspace 内的固定 YAML，并跳过 Wizard。可选的真实 `setup.env` 必须仅 owner
+可读写；禁用凭据必须保持空值，非空的禁用凭据会直接报错。旧 v1、无效或不完整声明会失败，
+不会回退到交互流程，也不会向父目录搜索。只有所有已选依赖、provider live check、
+Policy 兼容性检查和独立 reviewer smoke 都完全就绪，setup 才返回成功。需要明确
+选择交互流程时使用 `research setup wizard`。详见
 `tiangong-auto-research/references/setup.md` 和
 `tiangong-auto-research/references/env.md`。
 

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
+lastReviewedCommit: 29598568e966c4d6ae019d1c7bd6946d3390b277
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -47,10 +47,11 @@ repository README when broadly useful.
 
 `tiangong-auto-research` documents both the interactive setup Wizard and the
 CLI-owned declarative path. Its references explain fixed workspace-local YAML
-discovery, owner-only env input, no interactive fallback after a declaration
-error, and complete-readiness gating. The Skill does not duplicate the closed
-YAML schema or parse configuration; the CLI-generated template and validator
-remain authoritative.
+discovery, complete explicit materialization of every current catalog Skill,
+credential, and setting, owner-only env input with empty disabled options, no
+interactive fallback after a declaration error, and complete-readiness gating.
+The Skill does not duplicate the closed YAML schema or parse configuration; the
+CLI-generated template and validator remain authoritative.
 
 `tiangong-auto-research/assets/research-policy/defaults/**` is the versioned,
 generic source pack for top-journal Policy initialization. It is immutable

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -18,7 +18,7 @@ checkPaths:
   - scripts/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
+lastReviewedCommit: 29598568e966c4d6ae019d1c7bd6946d3390b277
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
+lastReviewedCommit: 29598568e966c4d6ae019d1c7bd6946d3390b277
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
+lastReviewedCommit: 29598568e966c4d6ae019d1c7bd6946d3390b277
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -26,10 +26,14 @@ If that clean directory contains the fixed workspace-local
 `.tiangong-research/setup.yaml`, bare `research setup` must use its declarative
 path without a TTY. It never scans parent directories and must not fall back to
 the Wizard after a declaration error. Use `research setup init` to generate the
-no-overwrite YAML and env examples, or explicit `research setup wizard` when the
-user chooses the interactive path. Follow [references/setup.md](references/setup.md)
-and [references/env.md](references/env.md); the generated CLI template is the
-only authoritative declaration schema.
+no-overwrite YAML and env examples. The YAML and env example explicitly expose
+all current catalog Skills, credentials, and settings, including disabled
+optional entries. Only declaration schema v2 is accepted; omission is invalid
+and a disabled credential must remain empty. Use explicit
+`research setup wizard` when the user chooses the
+interactive path. Follow [references/setup.md](references/setup.md) and
+[references/env.md](references/env.md); the generated CLI template is the only
+authoritative declaration schema.
 
 The CLI is the deterministic control plane: it owns setup, locks, brokered
 evidence, schemas, coverage, budgets, admission, the independent review process,

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -45,11 +45,24 @@ chmod 600 .tiangong-research/setup.env
 ```
 
 The real file must be regular, non-symlink, no larger than 64 KiB, and
-owner-only on POSIX. It accepts one literal `NAME=value` line per variable
-referenced by `credentialEnvironment` in `setup.yaml`. It does not execute
-`export`, interpolation, command substitution, or other shell syntax. Extra and
-duplicate names are rejected. If the same name also exists in the owner shell,
-the two values must not differ; the CLI never chooses one silently.
+owner-only on POSIX. It exposes all catalog credentials with one literal `NAME=value`
+line per variable declared under `credentials` in `setup.yaml`.
+Leave every disabled credential empty. A non-empty disabled credential is
+rejected rather than selected implicitly; enable it explicitly in YAML or
+remove the value. The parser does not execute `export`, interpolation, command
+substitution, or other shell syntax. Extra and duplicate names are rejected. If
+the same name also exists in the owner shell, the two values must not differ;
+the CLI never chooses one silently.
+
+The YAML is the choice authority. `requirement` is derived from the catalog and
+the current Skill selection, `appliesTo` is catalog metadata, and `enabled`
+records the owner decision. A required credential must be enabled whenever its
+applicable required Skill is enabled; the same credential is conditional while
+none of those Skills is selected. An optional credential may remain
+`enabled: false` even when its
+Skill is selected; changing it to true makes that credential explicitly
+selected and therefore required from `setup.env`, the same named owner
+environment variable, or an already persisted logical store.
 
 The control-directory `.gitignore` excludes `setup.env`. Values are held only
 in memory during declarative apply, sanitized as configured secrets, and then
@@ -66,11 +79,14 @@ default names are:
 | --- | --- | --- |
 | `BRAVE_API_KEY` | `brave.search.api-key` | Required for a selected Brave public-internet profile. |
 | `TIANGONG_SCI_APIKEY` | `tiangong.sci.api-key` | Required only when the owner-authorized Tiangong SCI capability is selected. |
+| `TIANGONG_REPORT_APIKEY` | `tiangong.report.api-key` | Required only when the owner-authorized Tiangong report capability is selected. |
+| `TIANGONG_PATENT_APIKEY` | `tiangong.patent.api-key` | Required only when the owner-authorized Tiangong patent capability is selected. |
 | `UNSTRUCTURED_AUTH_TOKEN` | `tiangong.unstructure.auth-token` | Required only when document preprocessing is selected. |
 | `SEMANTIC_SCHOLAR_API_KEY` | `semantic-scholar.api-key` | Optional for academic paper acquisition. |
 
-The variable name can differ, but it must be explicitly bound in the immutable
-plan. Values must be non-trivial. After a successful apply, later
+The variable name can differ, but it must appear in the explicit credential
+entry and is then bound in the immutable plan only when that entry is enabled.
+Enabled values must be non-trivial. After a successful apply, later
 status/doctor/run commands use the owner-only logical stores and do not require
 those source shell variables to remain exported. Do not put values in setup
 JSON files, CLI arguments, shell history, Skill files, capability declarations,

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -40,18 +40,33 @@ npx --yes --package "@tiangong-ai/cli@$REVIEWED_BOOTSTRAP_CLI_VERSION" -- \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
-This creates `.tiangong-research/setup.yaml`,
+This creates a closed `schemaVersion: 2` `.tiangong-research/setup.yaml`,
 `.tiangong-research/setup.env.example`, and a control-directory `.gitignore`
-that excludes `setup.env`. The YAML contains only non-secret selections,
-settings, environment variable names, agent routes, checks, and confirmations.
-The generated template deliberately does not accept licenses, network writes,
-global mutation, or paid smoke cost for the user. Review the current catalog,
-complete those fields explicitly, and treat the generated CLI template—not
-this reference—as the authoritative closed schema.
+that excludes `setup.env`. The YAML contains only non-secret choices and
+materializes all current catalog Skills under `selection.skills`, all
+credentials, and all settings. Every Skill includes an explicit `enabled`
+state and its catalog license ID. Every credential and setting includes its
+catalog- and current-selection-derived `requirement`, catalog `appliesTo`, and
+explicit enabled state; optional
+omission is not a state. The generated template deliberately does not accept
+licenses, network writes, global mutation, or paid smoke cost for the user.
+Review the current catalog, complete those fields explicitly, and treat the
+generated CLI template—not this reference—as the authoritative closed schema.
+The removed v1 declaration is rejected; regenerate the v2 template instead of
+hand-migrating an old file.
 
-When file-based credentials are useful, copy the env example locally, fill only
-the variable names referenced by `credentialEnvironment`, and make it
-owner-only:
+The closed schema requires exactly all current catalog entries. Missing or
+extra entries, changed license/requirement/applicability metadata, an incomplete
+Brave profile combination, a disabled currently required entry, or an
+enabled setting without a value fails before network access. Optional entries
+remain visible with `enabled: false`; set one to true only after intentionally
+selecting its applicable Skill and reviewing the corresponding license,
+dependency, provider, and cost.
+
+When file-based credentials are useful, copy the env example locally. It lists
+all catalog credentials, including disabled optional entries. Fill only values
+whose `credentials.<id>.enabled` choice is true, leave the rest empty, and make
+the file owner-only:
 
 ```bash
 cp .tiangong-research/setup.env.example .tiangong-research/setup.env

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -48,7 +48,12 @@ for (const marker of [
 
 for (const marker of [
   "## Declarative clean-directory setup",
+  "schemaVersion: 2",
   ".tiangong-research/setup.env.example",
+  "selection.skills",
+  "all current catalog Skills",
+  "requirement",
+  "enabled: false",
   "replaceExistingPlan: true",
   "does not fall back to the Wizard",
   "overallReadiness=READY",
@@ -60,6 +65,8 @@ for (const marker of [
   ".tiangong-research/setup.env",
   "chmod 600",
   "literal `NAME=value`",
+  "all catalog credentials",
+  "disabled credential",
   "must not differ",
   "owner-only logical stores",
 ]) {


### PR DESCRIPTION
## Tracking

Part of tiangong-ai/workspace#140.

## Summary

- document the closed declaration schema v2
- require every catalog Skill, credential, and setting to remain explicit
- describe disabled credential and complete setup.env.example behavior
- add routing-contract assertions for the new setup contract

## Key decisions

- declaration v1 is intentionally unsupported
- optional entries remain visible with enabled: false
- the generated CLI template remains authoritative; the Skill stays concise and routes details to references

## Validation

- scripts/test-clean-container.sh --cold-build
- Auto Research routing contract
- 25 Research Policy templates
- Skill quick_validate.py
- docpact validate-config and worktree lint
- git diff --check

## Risks / rollback

Risk is limited to documentation/routing contract drift. Revert this commit together with the corresponding CLI change before publication if the schema contract changes.

## Follow-ups

The CLI implementation, npm 0.0.40 publication, and root integration remain in workspace#140.

## Workspace integration

Required and pending. The root workspace must pin the merged Skills commit before CLI publication and final integration.
