### PR TITLE
fix(auto-research): bind construct review to acquired evidence

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "a42a310422cdcf40136e6aeb39cb8e55b85b9a88"
+lastReviewedAt: "2026-08-18"
+lastReviewedCommit: "174a9c195ff2287bda59b15600b500365196fe86"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: a42a310422cdcf40136e6aeb39cb8e55b85b9a88
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: c26f4b17d8e50cd04267a1d86ff9d3ad9a07039a
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: a42a310422cdcf40136e6aeb39cb8e55b85b9a88
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -61,7 +61,8 @@ customize and explicitly approve the exact resolved content.
 
 `tiangong-auto-research/references/scientific-design.md` defines the Skill-side
 native workflow for a closed project-specific design, three early independent
-scientific review gates, Policy-owned future freeze obligations for models,
+scientific review gates, post-acquisition evidence-construct canary binding,
+Policy-owned future freeze obligations for models,
 environment locks, and source-derived uncertainty states, authoritative
 recovery generations, and portable audit handoff. The Skill supplies
 instructions and conservative defaults only. The CLI owns schemas, hashing,

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -45,7 +45,8 @@ marketplace grouping metadata.
   boundary, distinguish observation from model comparison/scenario/accounting,
   distinguish byte identity from model executability, bind pending model,
   environment, and uncertainty objects to explicit future gates, require exact
-  joint-state mappings, never treat resampling as additional independent data,
+  joint-state mappings, bind real-record construct artifacts only after a
+  frozen acquisition snapshot, never treat resampling as additional independent data,
   and defer closed schemas, mechanical gates, reviewer-session enforcement,
   lifecycle budgets, authoritative generations, and portable audit verification
   to the CLI.

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: a42a310422cdcf40136e6aeb39cb8e55b85b9a88
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: a42a310422cdcf40136e6aeb39cb8e55b85b9a88
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -264,8 +264,12 @@ For a top-journal project, `research status` may require `research-design`,
 `evidence-construct`, or `pilot-methods` review before it exposes the next
 native stage. Produce the bounded assessment in this native host, then use a
 fresh configured reviewer session through the CLI. A real-record construct
-canary occurs before acquisition and an outcome-blind methods pilot occurs
-before analysis. Reviewer prose cannot override their mechanical failures.
+canary occurs only after acquisition has frozen the evidence snapshot, and an
+outcome-blind methods pilot occurs after that canary and before analysis. The
+construct assessment may reference only source IDs and full-text/date states
+from the frozen snapshot. Pass its exact, external JSON canary files through
+`--canary-artifacts`; an unbound digest or invented source ID is a mechanical
+failure. Reviewer prose cannot override these failures.
 
 Proceed only when doctor reports ready. Discovery uses only locked broker
 capabilities; later stages are tool-free. Doctor, preflight, dependency,

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -170,8 +170,12 @@ Successful acquisition creates `outputs/evidence-snapshot.json` plus an
 immutable project-local copy under `evidence/snapshots/`. The semantic snapshot
 hash binds the question, evidence and acquisition records, ledger head,
 receipts, selected artifacts, coverage, limitations, and parent/delta lineage.
-Analysis and synthesis may use only this verified snapshot. They cannot fetch,
-register, or silently substitute new evidence.
+For top-journal work, the real-record evidence-construct canary and its exact
+content-addressed JSON artifacts are reviewed against this snapshot before the
+outcome-blind methods pilot. Only snapshot source IDs count; full-text and date
+states are re-derived mechanically. Analysis and synthesis may use only the
+verified snapshot after both gates pass. They cannot fetch, register, or
+silently substitute new evidence.
 
 The review packet binds the current snapshot chain, selected exact artifacts,
 permanent broker objects, bounded excerpts, analysis, and report. Claim and

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -29,14 +29,17 @@ fresh independent review. See [scientific-design.md](scientific-design.md).
 The ordering is deliberate:
 
 ```text
-design review → discover → real-record construct review → acquire
-→ outcome-blind methods pilot review → analyze → synthesize
+design review → discover → acquire and freeze evidence
+→ real-record construct review → outcome-blind methods pilot review
+→ analyze → synthesize
 ```
 
-Do not replace the real-record canary with a synthetic schema example, inspect
-outcome values while proving construction, or use repeated cells/rows as
-independent resampling units. A later inherited package cannot bypass an earlier
-gate.
+The post-acquisition order is a correctness boundary: discovery metadata cannot
+prove a full-text floor, and acquisition artifacts must be frozen before the
+construct canary cites them. Do not replace the real-record canary with a
+synthetic schema example, inspect outcome values while proving construction,
+or use repeated cells/rows as independent resampling units. A later inherited
+package cannot bypass an earlier gate.
 
 Read `mechanicalAssessment.futureGateObligations` before continuing. Pending
 source-derived parameter values, executable model bytes, and exact environment
@@ -44,6 +47,15 @@ locks are permitted only until their declared gate and only when an exact
 planned Policy rule owns them. They are not usable results. Freeze replacements
 through a new authoritative generation before the deadline; at the due gate the
 CLI must stop on the corresponding mechanical error.
+
+For `evidence-construct`, write one or more bounded JSON canary artifacts outside
+`.tiangong-research`. Put their exact SHA-256 values in the assessment and pass
+an owner-reviewed JSON array of their absolute canonical paths with
+`--canary-artifacts`. The CLI rejects symlinks, duplicates, oversized or
+credential-like content, promotes exact bytes into content-addressed project
+storage, and binds them into the review packet. Coverage IDs must exist in the
+post-acquisition frozen snapshot; claimed full-text and publication-date states
+are re-derived from that snapshot rather than trusted from producer JSON.
 
 ## Prepare the exact stage
 

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -50,6 +50,13 @@ requirements, known gaps, context fit, and baseline fairness. It also reserves
 three early scientific reviews, four final publication reviews, and one bounded
 revision cycle. See [scientific-design.md](scientific-design.md).
 
+The scientific gate order is design review, discovery, acquisition and evidence
+freeze, evidence-construct review, outcome-blind methods pilot, then inference.
+This prevents discovery metadata from being misreported as acquired full text.
+The evidence-construct packet binds owner-supplied canary JSON artifacts and
+revalidates every referenced source ID, full-text state, and publication date
+against the frozen snapshot.
+
 Use `research project preflight`; do not calculate a competing checklist in the
 skill. Production `project init` requires its evidence-requirements file and,
 when the configured threshold is crossed, explicit `--confirm-budget`.

--- a/tiangong-auto-research/references/scientific-design.md
+++ b/tiangong-auto-research/references/scientific-design.md
@@ -119,16 +119,21 @@ hash-invalid.
 1. `research-design` blocks discovery. It checks identity, observability,
    claims/edges, truth roles, quantity ontology, validation semantics, known-gap
    dispositions, and lifecycle feasibility.
-2. `evidence-construct` runs after discovery and blocks acquisition. The native
-   producer must construct the central joins/edges on real records without
-   inspecting result values, record the exact canary artifacts, demonstrate that
-   each required evidence role reaches its full-text and independent-source
-   floor, disposition closest work, and prove central evidence fits the bounded
-   context route.
+2. `evidence-construct` runs after acquisition has frozen
+   `evidence-snapshot.json` and blocks analysis. The native producer must
+   construct the central joins/edges on real records without inspecting result
+   values, record the exact canary artifacts, demonstrate that each required
+   evidence role reaches its full-text and independent-source floor, disposition
+   closest work, and prove central evidence fits the bounded context route.
 
 This real-record construct canary is a feasibility gate, not a result-producing
-analysis.
-3. `pilot-methods` runs after acquisition and blocks analysis. It checks
+analysis. Discovery metadata alone cannot satisfy it. Every coverage ID must
+exist in the frozen snapshot, and full-text/date claims are checked against that
+snapshot. Put canary artifact SHA-256 values in the assessment and supply their
+absolute canonical paths in a separate owner-reviewed JSON array through
+`--canary-artifacts`; the CLI promotes the exact non-symlink JSON bytes and
+binds them into the packet without persisting the host source paths.
+3. `pilot-methods` runs after the evidence-construct review and blocks analysis. It checks
    leakage/circularity, endpoint compatibility, baseline fairness, units and
    denominators, threshold types, decision-loss metrics, validation-plan
    coverage, and the original/cluster/effective/resampling-unit audit.
@@ -158,7 +163,9 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   --workspace /absolute/path/to/workspace --json
 ```
 
-Repeat with `evidence-construct` and `pilot-methods`. The reviewer must use the
+Repeat with `evidence-construct`, adding
+`--canary-artifacts /absolute/path/to/canary-paths.json`, and then with
+`pilot-methods`. The reviewer must use the
 configured other agent family and a session unused by the producer or any prior
 review. The packet binds exact design, Policy, assessment, stage outputs, and
 reviewer identity hashes. Reviewer prose cannot override a failed mechanical


### PR DESCRIPTION
Part of tiangong-ai/workspace#144

## Summary
- Move the top-journal `evidence-construct` canary after acquisition freezes the evidence snapshot.
- Require snapshot-backed source/full-text/date claims and exact `--canary-artifacts` binding in Auto Research guidance.
- Align native execution, evidence pipeline, production workflow, architecture, and repository governance docs.

## Key Decisions
- Discovery metadata cannot satisfy a full-text floor.
- Evidence construction runs before inference, but only after exact acquisition artifacts and the immutable snapshot exist.
- Canary source paths remain external; the CLI stores content-addressed bytes and never host paths.

## Validation
- `scripts/test-clean-container.sh`
- `scripts/test-clean-container.sh --cold-build` through the root combined gate
- skill-creator `quick_validate.py tiangong-auto-research`
- docpact 0.1.9 validate/lint: `ok`, zero diagnostics
- `git diff --check`

## Risks / Rollback
- Requires the matching CLI release; using these instructions with an older CLI will expose the old gate order. Roll back by reverting this commit together with the matching CLI/root integration.

## Follow-ups
- CLI 0.0.41 will pin the merged Skills commit and implement the mechanical contract.
- Run a fresh post-release native production canary.

## Workspace Integration
- Required; root workspace issue tiangong-ai/workspace#144 remains `Workspace Integration = Pending` until Skills, CLI distribution, and root gitlinks are complete.
