### PR TITLE
Fix academic paper runtime argument forwarding

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "174a9c195ff2287bda59b15600b500365196fe86"
+lastReviewedCommit: "f95d0f8ecf6649e6f7512beb5c209936bdf24c28"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # Tiangong AI Skills Agent Contract
@@ -61,6 +61,9 @@ skill 内容、skill 规范、marketplace 元数据和本仓文档治理属于�
   `scripts/test-clean-container.sh` 创建的独立、无宿主 HOME/全局
   Skill/CLI/runtime cache 的容器中观察回归测试失败，再在另一个新容器中转绿；
   构建可复用输入未变化的 Docker layer，宿主测试不能替代。
+- 该容器必须运行 `academic-paper-download/scripts/tests` 的完整 unittest
+  discovery；测试镜像只安装 `requirements.lock` 中哈希锁定的核心依赖，绝不安装
+  可选 CloakBrowser 运行时或浏览器二进制。
 - 修改 `.dockerignore`、`Dockerfile.clean-test`、依赖输入，或准备 PR/发布时，
   必须额外运行 `scripts/test-clean-container.sh --cold-build` 验证冷构建路径。
 

--- a/Dockerfile.clean-test
+++ b/Dockerfile.clean-test
@@ -1,8 +1,17 @@
 FROM node:24.19.0-bookworm@sha256:934240a162082fd8b8a2f90cd5114446443f1eba1c5378f6687167ca405e6584
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates jq \
+    && apt-get install -y --no-install-recommends ca-certificates jq python3 python3-venv \
     && rm -rf /var/lib/apt/lists/*
+
+COPY academic-paper-download/requirements.lock /tmp/academic-paper-download.requirements.lock
+RUN python3 -m venv /opt/academic-paper-download-test \
+    && /opt/academic-paper-download-test/bin/pip install \
+        --disable-pip-version-check \
+        --no-input \
+        --no-compile \
+        --require-hashes \
+        -r /tmp/academic-paper-download.requirements.lock
 
 WORKDIR /skills
 RUN chown node:node /skills
@@ -11,5 +20,7 @@ COPY --chown=node:node . .
 
 ENV CI_CLEAN_CONTAINER=1
 ENV HOME=/home/node
+ENV PATH=/opt/academic-paper-download-test/bin:$PATH
+ENV PYTHONDONTWRITEBYTECODE=1
 
 CMD ["sh", "scripts/run-auto-research-tests.sh"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: a42a310422cdcf40136e6aeb39cb8e55b85b9a88
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-17
-lastReviewedCommit: a42a310422cdcf40136e6aeb39cb8e55b85b9a88
+lastReviewedAt: 2026-08-18
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # Skills Development Runbook
@@ -53,7 +53,8 @@ scripts/quick_validate.py <skill-path>
 
 Run representative script tests when a skill script changes.
 
-For `tiangong-auto-research` or its direct SCI/report/patent wrappers, use
+For `tiangong-auto-research` or any direct evidence wrapper, including
+`academic-paper-download`, use
 test-driven development exclusively through the mandatory clean-room entrypoint
 for the red and green cycles:
 
@@ -64,10 +65,16 @@ scripts/test-clean-container.sh
 It builds from the digest-pinned Node 24 image, copies only the secret-filtered
 repository context, and runs the routing, resolver, agent wrapper, Research
 Policy/scientific-design/native-execution contract, generated agent metadata,
-and evidence-wrapper suites as a non-root user
+SCI/report/patent wrapper suites, and the complete `academic-paper-download`
+unittest discovery as a non-root user
 with isolated HOME and runtime networking disabled. Do not mount host agent
 directories, CLIs, runtime caches, credentials, browser profiles, or source
 worktrees into the running container.
+
+The test image installs only `academic-paper-download/requirements.lock` with
+hash verification. It never installs the optional CloakBrowser requirements or
+downloads a browser binary; those remain explicit integration checks outside
+the network-disabled unit gate.
 
 The default entrypoint may reuse Docker layers whose declared inputs still
 match, while every test run uses a new container. Run the explicit cold mode

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-18
-lastReviewedCommit: 174a9c195ff2287bda59b15600b500365196fe86
+lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
 ---
 
 # Skills Documentation Standards

--- a/academic-paper-download/scripts/runtime.py
+++ b/academic-paper-download/scripts/runtime.py
@@ -354,16 +354,20 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = _parser().parse_args(argv)
-    as_json = bool(getattr(args, "json", False))
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    as_json = False
     try:
+        if arguments and arguments[0] in ENTRYPOINTS:
+            return run_entrypoint(arguments[0], arguments[1:])
+        args = _parser().parse_args(arguments)
+        as_json = bool(getattr(args, "json", False))
         if args.command == "bootstrap":
             return bootstrap(as_json=as_json)
         if args.command == "doctor":
             return doctor(as_json=as_json)
         if args.command == "smoke":
             return smoke(as_json=as_json)
-        return run_entrypoint(args.command, args.arguments)
+        raise RuntimeFailure("runtime_command_invalid", "Unknown runtime command")
     except RuntimeFailure as exc:
         _emit({"ok": False, "error": exc.payload()}, as_json=as_json)
         return 4 if exc.code == "dependency_install_failed" else 3

--- a/academic-paper-download/scripts/tests/test_runtime.py
+++ b/academic-paper-download/scripts/tests/test_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
@@ -8,6 +9,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SKILL_ROOT = Path(__file__).resolve().parents[2]
 RUNTIME = SKILL_ROOT / "scripts" / "runtime.py"
@@ -51,6 +53,50 @@ class RuntimeContractTests(unittest.TestCase):
         source = RUNTIME.read_text(encoding="utf-8")
         self.assertIn("Path(__file__).resolve()", source)
         self.assertNotRegex(source, re.compile(r"Path\([\"']requirements\.lock[\"']\)"))
+
+    def test_entrypoint_options_are_forwarded_without_double_dash(self) -> None:
+        spec = importlib.util.spec_from_file_location("academic_paper_runtime", RUNTIME)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        runtime = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(runtime)
+        completed = subprocess.CompletedProcess(args=[], returncode=0)
+
+        with (
+            mock.patch.object(runtime, "_verify_environment", return_value=Path("/locked/python")),
+            mock.patch.object(runtime.subprocess, "run", return_value=completed) as run,
+        ):
+            result = runtime.main(
+                [
+                    "notify-human",
+                    "--title",
+                    "Paper download needs your action",
+                    "--message",
+                    "Complete the security challenge normally.",
+                    "--button",
+                    "OK",
+                    "--timeout",
+                    "120",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        argv = run.call_args.args[0]
+        self.assertEqual(argv[0], "/locked/python")
+        self.assertEqual(Path(argv[1]).name, "notify_human.py")
+        self.assertEqual(
+            argv[2:],
+            [
+                "--title",
+                "Paper download needs your action",
+                "--message",
+                "Complete the security challenge normally.",
+                "--button",
+                "OK",
+                "--timeout",
+                "120",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/run-auto-research-tests.sh
+++ b/scripts/run-auto-research-tests.sh
@@ -18,6 +18,7 @@ node tiangong-auto-research/scripts/test-routing-contract.mjs
 node tiangong-auto-research/scripts/test-research-policy-pack.mjs
 node tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
 sh tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
+python3 -m unittest discover -s academic-paper-download/scripts/tests -v
 bash tiangong-kb-sci-search/scripts/test-sci-search.sh
 bash tiangong-kb-report-search/scripts/test-report-search.sh
 bash tiangong-kb-patent-search/scripts/test-patent-search.sh


### PR DESCRIPTION
Part of tiangong-ai/workspace#144.

The post-release 0.0.41 live canary reached a real Turnstile browser handoff and proved that the documented runtime.py notify-human --title ... invocation was rejected by the dispatcher before notify_human.py ran.

This change:
- forwards entrypoint options verbatim without requiring an undocumented separator;
- adds the regression to the complete academic-paper-download unittest suite;
- makes that suite part of the isolated clean-container gate using only the hash-locked core pypdf dependency;
- keeps optional CloakBrowser packages and browser binaries outside the unit image.

Validation:
- clean Docker red reproduced the argparse failure;
- separate clean Docker green passed 76 tests (1 explicit install-smoke skip);
- final cold clean-container gate passed;
- skill-creator quick validation passed;
- docpact lint passed with zero diagnostics;
- git diff --check passed.