### PR TITLE
Require a frozen evidence-to-submission chain

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-18"
-lastReviewedCommit: "f95d0f8ecf6649e6f7512beb5c209936bdf24c28"
+lastReviewedAt: "2026-08-19"
+lastReviewedCommit: "e05a056e422c178a1ba5de66b2e561c3574717a2"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -159,10 +159,17 @@ Before discovery, the current native Codex or Claude host must also provide a
 closed, target-specific scientific design. The CLI validates and freezes the
 design, then enforces independent `research-design`, real-record
 `evidence-construct`, and `pilot-methods` reviews before discovery, acquisition,
-and analysis respectively. It reserves the complete early/final-review and
-revision lifecycle, requires reapproval for every authoritative recovery
-generation, and exports a portable audit directory containing exact formal
-evidence rather than host-local pointers. The CLI remains the deterministic
-control plane; it never launches a nested producer to invent the science. See
+and analysis respectively. After acquisition it also requires exact
+decomposition records, evidence atoms, a typed-content snapshot, a passing
+inference snapshot, a reproduced analysis, and a mechanically generated
+Claim-Evidence Graph. Publication freeze requires the complete manuscript
+sections and explicit cover/title/checklist/availability/source-data files;
+four fresh reviews must use the configured agent family that differs from the
+native producer. It reserves the complete early/final-review and revision
+lifecycle, requires reapproval for every authoritative recovery generation,
+and exports a semantic-chain-verified portable audit directory containing exact
+formal evidence rather than host-local pointers. The CLI remains the
+deterministic control plane; it never launches a nested producer to invent the
+science. See
 `tiangong-auto-research/references/publication-policy.md` and
 `tiangong-auto-research/references/scientific-design.md`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -145,8 +145,12 @@ Policy Wizard 会把所选 Markdown 复制到研究 workspace 供人类审阅；
 
 在 discovery 之前，当前原生 Codex 或 Claude host 还必须给出封闭、目标特定的科学
 设计。CLI 只负责验证和冻结设计，并依次在 discovery、acquisition、analysis 前强制
-独立的 `research-design`、真实记录 `evidence-construct`、`pilot-methods` 审查；它
-会为全部早期审查、终稿审查和一次修订预留预算，每个权威恢复世代都必须重新审批，
-并可导出包含正式证据原文而不是宿主本地路径的可移植审计目录。CLI 仍是确定性控制
-平面，不会启动嵌套 producer 来替用户发明科学设计。详见
+独立的 `research-design`、真实记录 `evidence-construct`、`pilot-methods` 审查。
+acquisition 后还必须完成逐文件拆解、精确 evidence atom、typed-content snapshot、
+passing inference snapshot、可复现分析和机械生成的 Claim-Evidence Graph。投稿冻结
+要求完整论文章节及显式的 cover/title/checklist/data/code/source-data 文件；四个终稿
+审阅必须使用与原生 producer 不同的已配置 agent family 和全新 session。CLI 会为
+全部早期审查、终稿审查和一次修订预留预算，每个权威恢复世代都必须重新审批，并只
+在语义复核完整冻结链后导出包含正式证据原文而不是宿主本地路径的可移植审计目录。
+CLI 仍是确定性控制平面，不会启动嵌套 producer 来替用户发明科学设计。详见
 `tiangong-auto-research/references/scientific-design.md`。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -61,14 +61,16 @@ customize and explicitly approve the exact resolved content.
 
 `tiangong-auto-research/references/scientific-design.md` defines the Skill-side
 native workflow for a closed project-specific design, three early independent
-scientific review gates, post-acquisition evidence-construct canary binding,
-Policy-owned future freeze obligations for models,
-environment locks, and source-derived uncertainty states, authoritative
-recovery generations, and portable audit handoff. The Skill supplies
-instructions and conservative defaults only. The CLI owns schemas, hashing,
-stage admission, mechanical evaluation, lifecycle reservations, reviewer
-isolation, and audit verification; native Codex or Claude remains the
-scientific producer.
+scientific review gates, post-acquisition decomposition/evidence-atom/content
+freeze, evidence-construct canary binding, inference snapshot, reproducible
+analysis and Claim-Evidence Graph, role-complete submission packaging,
+Policy-owned future freeze obligations for models, environment locks, and
+source-derived uncertainty states, authoritative recovery generations, and
+portable audit handoff. The Skill supplies instructions and conservative
+defaults only. The CLI owns schemas, hashing, stage admission, mechanical
+evaluation, lifecycle reservations, other-family reviewer isolation, and
+semantic audit verification; native Codex or Claude remains the scientific
+producer.
 
 ## Integration Points
 

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -45,11 +45,14 @@ marketplace grouping metadata.
   boundary, distinguish observation from model comparison/scenario/accounting,
   distinguish byte identity from model executability, bind pending model,
   environment, and uncertainty objects to explicit future gates, require exact
-  joint-state mappings, bind real-record construct artifacts only after a
-  frozen acquisition snapshot, never treat resampling as additional independent data,
-  and defer closed schemas, mechanical gates, reviewer-session enforcement,
-  lifecycle budgets, authoritative generations, and portable audit verification
-  to the CLI.
+  joint-state mappings, bind real-record construct artifacts only after frozen
+  acquisition and typed-content snapshots, require exact decomposition lineage
+  and evidence atoms before inference, never treat resampling as additional
+  independent data, require a reproduced analysis/Claim-Evidence Graph/
+  submission-package chain for publication, and defer closed schemas,
+  mechanical gates, reviewer-family/session enforcement, lifecycle budgets,
+  authoritative generations, and semantic portable-audit verification to the
+  CLI.
 
 ## Skill Surface
 

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -254,7 +254,11 @@ packet's broker command. Record discovery assessments incrementally instead of
 returning all source metadata in the final stage output. Record native
 Web/Browser activity, formalize useful leads through the broker, and bind every
 network download to its exact download event before artifact registration.
-Repeat for discover, acquire, analyze, and synthesize. Only then may
+After acquire, disposition every acquired content artifact, register exact
+line-range/JSON-Pointer evidence atoms, and freeze typed content. A stopped
+acquisition/content gate still preserves these frozen results but prohibits
+inference. Only then proceed through inference, analyze, the mechanically
+generated Claim-Evidence Graph, and synthesize. Only after that may
 `research run` launch the configured independent reviewer and perform
 mechanical closure. Follow
 [references/native-execution.md](references/native-execution.md) for the exact
@@ -264,10 +268,10 @@ For a top-journal project, `research status` may require `research-design`,
 `evidence-construct`, or `pilot-methods` review before it exposes the next
 native stage. Produce the bounded assessment in this native host, then use a
 fresh configured reviewer session through the CLI. A real-record construct
-canary occurs only after acquisition has frozen the evidence snapshot, and an
-outcome-blind methods pilot occurs after that canary and before analysis. The
-construct assessment may reference only source IDs and full-text/date states
-from the frozen snapshot. Pass its exact, external JSON canary files through
+canary occurs only after acquisition and typed-content snapshots are frozen,
+and an outcome-blind methods pilot occurs after that canary and before analysis.
+The construct assessment may reference only source IDs, exact atoms, and
+full-text/date states from the frozen chain. Pass its exact, external JSON canary files through
 `--canary-artifacts`; an unbound digest or invented source ID is a mechanical
 failure. Reviewer prose cannot override these failures.
 
@@ -294,10 +298,13 @@ project has a passing independent review, `outputs/report.md`, and
 binding, usage/cost, decision, and material limitations.
 
 For a top-journal goal, that base closure is not publication closure. Author the
-final paper in this current native host, freeze its exact manuscript and
-assessment, obtain fresh evidence, methods/reproducibility, domain/novelty, and
+final paper and role-complete submission files in this current native host,
+freeze their exact manifest with the assessment, inference chain,
+Claim-Evidence Graph, and reproducibility record, obtain fresh configured
+other-family evidence, methods/reproducibility, domain/novelty, and
 journal-editor reviews, then mechanically close the publication generation.
-Any Policy or manuscript change invalidates downstream approval/review. Return
+Any Policy, manuscript, or submission-file change invalidates downstream
+approval/review. Return
 only the CLI-computed bounded readiness language; never promise acceptance.
 Export and independently verify a portable project audit bundle before external
 handoff or archival; it must contain the formal evidence bytes and review

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -162,26 +162,91 @@ Keep these distinctions exact:
 
 An accepted source may remain metadata/abstract-only when the requirements
 allow it, but the audit must state that limitation. Unresolved blocking gaps
-stop snapshot creation.
+do not erase successfully acquired evidence: acquisition freezes the complete
+source/artifact/gap audit and marks its separate `inferenceGate=stop`.
+Continue only far enough to decompose everything already acquired and freeze
+the typed-content record; then request the exact access/scope handoff. Never
+report the stopped snapshot as inference-ready.
 
 ## 5. Freeze, then infer
 
 Successful acquisition creates `outputs/evidence-snapshot.json` plus an
 immutable project-local copy under `evidence/snapshots/`. The semantic snapshot
 hash binds the question, evidence and acquisition records, ledger head,
-receipts, selected artifacts, coverage, limitations, and parent/delta lineage.
-For top-journal work, the real-record evidence-construct canary and its exact
-content-addressed JSON artifacts are reviewed against this snapshot before the
-outcome-blind methods pilot. Only snapshot source IDs count; full-text and date
-states are re-derived mechanically. Analysis and synthesis may use only the
-verified snapshot after both gates pass. They cannot fetch, register, or
-silently substitute new evidence.
+receipts, selected artifacts, coverage, explicit gaps, the inference decision,
+and parent/delta lineage. File existence is not readiness; inspect the semantic
+hash and gate through `research status --json`.
 
-The review packet binds the current snapshot chain, selected exact artifacts,
-permanent broker objects, bounded excerpts, analysis, and report. Claim and
-review bindings are appended to the ledger. Mechanical closure re-verifies all
-hashes and refuses a missing, changed, or stale snapshot, packet, context,
-receipt, artifact, or source.
+Before any evidence-construct assessment or analysis, disposition every
+acquired full-text/data artifact. Use the installed document/PDF/spreadsheet
+tools to create legitimate producer-readable derivatives, register each exact
+derived artifact with its parent, and record one decomposition object per
+source artifact:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence decomposition record PROJECT \
+  --record /absolute/path/to/decomposition.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+A complete decomposition names the parser/version, exact parent and output
+artifact IDs, content classes, and limitations. A limited or failed
+decomposition is an explicit disposition, not permission to omit the file.
+Never claim that a PDF, workbook, archive, or HTML challenge page was read
+merely because it was downloaded.
+
+Register claim-usable evidence as exact atoms from a producer-readable
+UTF-8/JSON/CSV/Markdown artifact. Each atom binds the admitted source and
+candidate, exact artifact hash, a one-based line range or JSON Pointer, the
+control-plane-extracted excerpt and excerpt hash, evidence role/dimension,
+support/counterevidence/method/limitation function, scope, and limitations:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence atom register PROJECT \
+  --record /absolute/path/to/evidence-atom.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Do not paste an invented excerpt or cite only a source-level ID when an exact
+atom is required. Freeze the typed universe only after all acquired artifacts
+have dispositions and all material claims have atoms:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence content freeze PROJECT \
+  --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research status --project PROJECT \
+  --workspace /absolute/path/to/workspace --json
+```
+
+The `evidencePipeline` status reports acquisition gaps/gate, decomposition and
+atom counts, typed role gaps, inference identity, and Claim-Evidence Graph
+identity. A stopped acquisition or content gate prohibits inference. It does
+not justify further low-yield substitute search after lawful routes are
+exhausted.
+
+For top-journal work, the real-record evidence-construct canary and its exact
+content-addressed JSON artifacts are reviewed against both frozen acquisition
+and typed-content snapshots before the outcome-blind methods pilot. Only
+snapshot source IDs and exact atoms count; full-text and date states are
+re-derived mechanically. After those gates pass, preparing `analyze` freezes an
+immutable `inference-snapshot.json` containing the exact sources, atoms, design
+claims/edges, policy/review bindings, input artifacts, implementations, and
+environment locks. Analyze schema v2 must bind that snapshot, one reproduced
+analysis run, and for every finding the admitted source IDs, exact atom IDs,
+design claim IDs, uncertainty, and applicability. Successful submit generates
+`claim-evidence-graph.json` mechanically; do not hand-author it. Synthesis and
+review may use only this verified chain and cannot fetch, register, or silently
+substitute new evidence.
+
+The review packet binds the current acquisition/content/inference/graph chain,
+selected exact artifacts, permanent broker objects, bounded excerpts, analysis,
+and report. Claim and review bindings are appended to the ledger. Mechanical
+closure re-verifies all hashes and refuses a missing, changed, or stale
+snapshot, graph, packet, context, receipt, artifact, or source.
 
 ## 6. Refresh through an addendum
 
@@ -205,5 +270,6 @@ Use `research project archive` for complete/stale history and
 `research project abandon` for unfinished history; never infer the latest
 project from its name or version suffix.
 
-Use the status response's `discovery`, `snapshot`, `nativeStage`, `lineage`, and
-`recommendedAction` fields instead of inspecting control files manually.
+Use the status response's `discovery`, `snapshot`, `evidencePipeline`,
+`nativeStage`, `lineage`, and `recommendedAction` fields instead of inspecting
+control files manually.

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -30,8 +30,9 @@ The ordering is deliberate:
 
 ```text
 design review → discover → acquire and freeze evidence
+→ decompose acquired content → register atoms → freeze typed content
 → real-record construct review → outcome-blind methods pilot review
-→ analyze → synthesize
+→ freeze inference → analyze → freeze Claim-Evidence Graph → synthesize
 ```
 
 The post-acquisition order is a correctness boundary: discovery metadata cannot
@@ -132,6 +133,16 @@ alone does not claim producer-readable full text. Register a separately derived
 UTF-8 text/JSON/CSV/Markdown artifact when one was legitimately produced
 and should be embedded within the bounded producer context.
 
+Acquisition submit freezes the complete result even when it contains honest
+blocking gaps. Before preparing `evidence-construct` or `analyze`, follow
+[evidence-pipeline.md](evidence-pipeline.md): record a complete/limited/failed
+decomposition for every acquired full-text or data artifact, register exact
+line-range or JSON-Pointer evidence atoms, and run `research project evidence
+content freeze`. Do not leave acquired PDFs, spreadsheets, archives, or
+structured files as unexamined binary attachments. `research status` must show
+the typed content as verified; a stopped content/acquisition gate requires a
+scope/access handoff rather than analysis.
+
 ## Submit producer output
 
 Save only the schema-conforming JSON object to a new regular non-symlink file.
@@ -175,9 +186,12 @@ not burn the prepared attempt. Resume only after an operator explicitly runs
 ## Continue, review, or abort
 
 After each successful submit, call `research run` again. Prepare/submit the
-next native producer stage through discover, acquire, analyze, and synthesize.
-The same run command may then launch only the configured independent reviewer
-CLI and, after a passing review, perform mechanical closure.
+next native producer stage through discover, acquire, analyze, and synthesize,
+performing the typed-content steps between acquire and analyze. Analyze prepare
+freezes the exact inference snapshot; analyze submit mechanically freezes the
+Claim-Evidence Graph. The same run command may then launch only the configured
+independent reviewer CLI and, after a passing review, perform mechanical
+closure.
 
 For a top-journal project, this is the base research closure, not the final
 publication verdict. Continue in the same current native host to author and

--- a/tiangong-auto-research/references/production-research.md
+++ b/tiangong-auto-research/references/production-research.md
@@ -289,13 +289,16 @@ body. GET remains the default method inside an explicit HTTP endpoint policy.
 ## Coverage, retry, and recovery
 
 Discovery output is promoted for diagnosis, then acquisition audits every
-provisionally admitted source. The CLI freezes only accepted/limited sources
-and their explicitly selected artifacts, then derives producer-readable
-full-text availability, source types, source counts, dated counts, date range,
-per-dimension source IDs, and the pass/insufficient decision from that snapshot.
-`partial` is usable but incomplete; `missing`, an acquisition gap, or any unmet
-source/full-text/date minimum blocks analysis. Model-provided qualitative gaps
-remain visible but cannot override those derived fields. See
+provisionally admitted source. The CLI freezes accepted/limited sources, their
+explicitly selected artifacts, and honest unresolved gaps in one immutable
+snapshot; the separate inference gate records whether the chain may continue.
+It derives producer-readable full-text availability, source types, source
+counts, dated counts, date range, per-dimension source IDs, and the
+pass/insufficient decision mechanically. `partial` is usable but incomplete;
+`missing`, an acquisition gap, or any unmet source/full-text/date minimum stops
+inference after all acquired material has been decomposed and typed. Model-
+provided qualitative gaps remain visible but cannot override those derived
+fields. See
 [evidence-pipeline.md](evidence-pipeline.md) for exact full-file versus
 producer-readable semantics and addendum lineage.
 
@@ -311,9 +314,12 @@ the packet's `research project evidence fetch` argv for admitted network
 evidence; standalone web/search/database tools cannot replace required broker
 receipts. Broker results include the exact bounded view inline with the receipt.
 Acquire receives the provisional evidence record and exact artifact registry
-command, then produces a complete audit. Analyze receives the frozen evidence
-snapshot; synthesize receives the snapshot and analysis. Neither later stage
-may gather new evidence. Review is tool-free and embeds
+command, then produces a complete audit. Between acquire and analyze, the
+native host records exact decomposition lineage and evidence atoms and freezes
+the typed-content snapshot. Analyze receives only a passing immutable inference
+snapshot and emits schema v2 with a reproduced analysis run; submit generates
+the Claim-Evidence Graph. Synthesize receives that chain and analysis. Neither
+later stage may gather new evidence. Review is tool-free and embeds
 generated artifacts plus deterministic excerpts from bounded local/broker
 evidence views within the reviewer's route-specific structured-output turn cap.
 Preflight and runtime reserve the same
@@ -422,16 +428,20 @@ Confirm the owning CLI release passed deterministic mock coverage for:
 - explicit owner-database import, required-discovery receipt enforcement, and
   local-only production rejection;
 - routing and smoke/production mode boundaries;
-- discover → acquire → freeze → analyze → synthesize → review → close;
-- top-journal Policy approval, publication assessment, frozen final manuscript,
-  four fresh role-bound reviews, revision invalidation, and publication closure;
+- discover → acquire → decompose/atomize → content freeze → inference freeze →
+  analyze → Claim-Evidence Graph → synthesize → review → close;
+- top-journal Policy approval, publication assessment, required manuscript
+  sections, complete submission roles, content/inference/graph/reproducibility
+  binding, four fresh configured other-family role-bound reviews, revision
+  invalidation, and publication closure;
 - public `research run` never launching a producer subprocess, with native
   prepare/fetch/register/submit advancing the four producer stages;
 - native-only leads remaining supplemental until an immutable broker
   occurrence formalizes the same candidate;
 - exact artifact registration, binary-only full-text semantics, immutable
   snapshot/delta lineage, and addendum supersession;
-- permanent evidence and review-packet hash verification;
+- permanent evidence and review-packet hash verification plus semantic
+  pre-export validation of the named portable audit research chain;
 - persistent bounded review-context verification and packet/context tamper
   rejection before closure;
 - malformed JSON repair and a second-failure stop;

--- a/tiangong-auto-research/references/publication-policy.md
+++ b/tiangong-auto-research/references/publication-policy.md
@@ -84,10 +84,43 @@ recall, missing direct evidence, or unreproduced result.
 
 ## Author in the current native host
 
-After the base `discover → acquire → analyze → synthesize → review → close`
-project is complete, write the final manuscript and assessment in the current
-Codex app/session or interactive Claude Code session. The CLI remains a control
-plane and must not launch a nested producer. Inspect the schema, then freeze:
+After the base research chain is complete, write the final manuscript,
+assessment, and submission files in the current Codex app/session or
+interactive Claude Code session. The CLI remains a control plane and must not
+launch a nested producer. The Markdown/plain-text manuscript must contain
+Abstract, Introduction, Methods (or Materials and Methods), Results,
+Discussion, Data availability, Code availability, and References/Bibliography.
+
+Create an owner-reviewed submission manifest outside `.tiangong-research`. It
+uses `schemaVersion: 1` and distinct absolute canonical paths. Required roles
+are `cover-letter`, `title-page`, `reporting-checklist`, `data-availability`,
+`code-availability`, and `source-data`; optional roles are
+`figure-table-index`, `extended-data`, and `supplementary-methods`:
+
+```json
+{
+  "schemaVersion": 1,
+  "files": [
+    { "role": "cover-letter", "path": "/absolute/path/cover-letter.md" },
+    { "role": "title-page", "path": "/absolute/path/title-page.md" },
+    {
+      "role": "reporting-checklist",
+      "path": "/absolute/path/reporting-checklist.md"
+    },
+    {
+      "role": "data-availability",
+      "path": "/absolute/path/data-availability.md"
+    },
+    {
+      "role": "code-availability",
+      "path": "/absolute/path/code-availability.md"
+    },
+    { "role": "source-data", "path": "/absolute/path/source-data.csv" }
+  ]
+}
+```
+
+Inspect the assessment schema, then freeze:
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
@@ -96,14 +129,20 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   research publication freeze PROJECT \
   --manuscript /absolute/path/to/final-manuscript.md \
   --assessment /absolute/path/to/publication-assessment.json \
+  --submission /absolute/path/to/submission-package.json \
   --producer-agent codex --producer-session OPAQUE_NATIVE_SESSION \
   --workspace /absolute/path/to/workspace --json
 ```
 
-Freeze content-addresses the manuscript, assessment, supplements, approved
-Policy, final evidence snapshot, and base outputs. It evaluates central claims,
-outcomes, result classes, evidence composition, owner-input trust, recall,
-novelty, reproduction, and pivots. File existence alone is never success.
+Freeze requires the configured native producer family and content-addresses the
+manuscript, assessment, supplements, submission files, approved Policy, final
+acquisition/content/inference snapshots, reproduced analysis, Claim-Evidence
+Graph, reproducibility manifest, and base outputs. It validates every finding's
+exact graph topology to atoms, sources, design claims, and the analysis run; a
+graph with the right edge names but disconnected endpoints fails even if its
+own hash was recomputed. It evaluates central claims, outcomes, result classes,
+evidence composition, owner-input trust, recall, novelty, reproduction, and
+pivots. File existence alone is never success.
 
 ## Four fresh independent final reviews
 
@@ -123,15 +162,19 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   --workspace /absolute/path/to/workspace --json
 ```
 
-Repeat with fresh sessions. A reviewer may use the configured headless Codex or
-Claude CLI, but must not be the producer session or any prior project reviewer
-session. The append-only journal stores only its SHA-256 for reuse detection;
-deleting a mutable cache does not permit reuse.
+Repeat with fresh sessions. A reviewer uses the configured headless Codex or
+Claude CLI family, which must differ from the native producer family. Merely
+changing the session while keeping the producer family is not independent. It
+must also differ from every prior project reviewer session. The append-only
+journal stores only the session SHA-256 for reuse detection; deleting a mutable
+cache does not permit reuse.
 
-Each packet binds the exact Policy, evidence snapshot, base closure, manuscript,
-assessment, supplements, mechanical result, role, reviewer, and schema. Review
-cannot add evidence. A manuscript revision creates a new generation and
-invalidates every old review; a Policy change or expiry blocks publication.
+Each packet binds the exact Policy, evidence/content/inference snapshots,
+Claim-Evidence Graph, reproducibility manifest, base closure, manuscript,
+assessment, submission files, supplements, mechanical result, role, reviewer,
+and schema. Review cannot add evidence. A manuscript or submission-file
+revision creates a new generation and invalidates every old review; a Policy
+change or expiry blocks publication.
 
 ## Close and report bounded language
 
@@ -147,7 +190,10 @@ returned verdict, bounded statement, limitations, and pivots.
 `target-journal-submission-ready` means the frozen artifact passed its declared
 gates; it does not predict or guarantee editorial acceptance.
 
-After closure, export and verify the portable audit directory from
+`publication status` exposes `submissionPackageSha256`, `submissionRoles`,
+`contentSnapshotSha256`, `inferenceSnapshotSha256`, and
+`claimEvidenceGraphSha256`; inspect these before launching a paid review. After
+closure, export and verify the portable audit directory from
 [scientific-design.md](scientific-design.md). Handing off only the manuscript,
 receipt hashes, or a workspace-specific path is not sufficient for independent
 editorial or reproducibility audit.

--- a/tiangong-auto-research/references/scientific-design.md
+++ b/tiangong-auto-research/references/scientific-design.md
@@ -119,17 +119,21 @@ hash-invalid.
 1. `research-design` blocks discovery. It checks identity, observability,
    claims/edges, truth roles, quantity ontology, validation semantics, known-gap
    dispositions, and lifecycle feasibility.
-2. `evidence-construct` runs after acquisition has frozen
-   `evidence-snapshot.json` and blocks analysis. The native producer must
+2. `evidence-construct` runs only after acquisition has frozen
+   `evidence-snapshot.json` and the producer has dispositioned every acquired
+   artifact, registered exact evidence atoms, and frozen
+   `content-snapshot.json`. It blocks analysis. The native producer must
    construct the central joins/edges on real records without inspecting result
    values, record the exact canary artifacts, demonstrate that each required
-   evidence role reaches its full-text and independent-source floor, disposition
-   closest work, and prove central evidence fits the bounded context route.
+   evidence role reaches its full-text, atom, and independent-source floor,
+   disposition closest work, and prove central evidence fits the bounded
+   context route.
 
 This real-record construct canary is a feasibility gate, not a result-producing
-analysis. Discovery metadata alone cannot satisfy it. Every coverage ID must
-exist in the frozen snapshot, and full-text/date claims are checked against that
-snapshot. Put canary artifact SHA-256 values in the assessment and supply their
+analysis. Discovery metadata or a binary file alone cannot satisfy it. Every
+coverage ID must exist in the frozen acquisition/content chain, claim-usable
+support must bind exact atoms, and full-text/date claims are checked against the
+snapshots. Put canary artifact SHA-256 values in the assessment and supply their
 absolute canonical paths in a separate owner-reviewed JSON array through
 `--canary-artifacts`; the CLI promotes the exact non-symlink JSON bytes and
 binds them into the packet without persisting the host source paths.
@@ -223,11 +227,16 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   --bundle /absolute/path/to/new-audit-directory --json
 ```
 
-The bundle includes only the selected project, portable input copies, formal
-evidence/artifact bytes, Policy/design/review objects, outputs, environment
-fingerprints, and project journal proofs. It omits credentials, setup sources,
-browser profiles, active native state, ephemeral capsules, and unrelated files.
-Export refuses an existing/symlink destination, host-specific workspace paths,
-sensitive text, missing evidence bytes, or any hash drift. Verification rejects
-every extra, missing, or changed byte; it never scans a Downloads directory or
-substitutes a newer file.
+Before copying, export semantically reloads every present acquisition,
+typed-content, inference, Claim-Evidence Graph, and publication object; a stale
+or internally rehashed-but-disconnected chain is not exportable. The manifest's
+`researchChain` records their intrinsic IDs/hashes and the publication
+generation/package binding. The bundle includes only the selected project,
+portable input copies, formal evidence/artifact bytes, Policy/design/review
+objects, outputs, environment fingerprints, and safe journal derivatives that
+retain source event/payload hashes without operational session values. It omits
+credentials, setup sources, browser profiles, active native state, ephemeral
+capsules, and unrelated files. Export refuses an existing/symlink destination,
+host-specific workspace paths, sensitive text, missing evidence bytes, semantic
+drift, or any hash drift. Verification rejects every extra, missing, or changed
+byte; it never scans a Downloads directory or substitutes a newer file.

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -36,6 +36,14 @@ const environmentReference = await readFile(
   join(skillsRoot, "tiangong-auto-research", "references", "env.md"),
   "utf8",
 );
+const evidencePipelineReference = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "references", "evidence-pipeline.md"),
+  "utf8",
+);
+const publicationReference = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "references", "publication-policy.md"),
+  "utf8",
+);
 
 for (const marker of [
   ".tiangong-research/setup.yaml",
@@ -71,6 +79,33 @@ for (const marker of [
   "owner-only logical stores",
 ]) {
   assert.ok(environmentReference.includes(marker), `Environment reference must explain ${marker}`);
+}
+
+for (const marker of [
+  "evidence decomposition record",
+  "evidence atom register",
+  "evidence content freeze",
+  "inference-snapshot.json",
+  "claim-evidence-graph.json",
+  "evidencePipeline",
+]) {
+  assert.ok(
+    evidencePipelineReference.includes(marker),
+    `Evidence pipeline reference must explain ${marker}`,
+  );
+}
+
+for (const marker of [
+  "--submission",
+  "reporting-checklist",
+  "source-data",
+  "Claim-Evidence Graph",
+  "submissionPackageSha256",
+]) {
+  assert.ok(
+    publicationReference.includes(marker),
+    `Publication reference must explain ${marker}`,
+  );
 }
 
 for (const marker of [


### PR DESCRIPTION
## What changed

- document acquisition snapshots that preserve honest gaps separately from inference readiness
- require typed decomposition, exact evidence atoms, inference snapshots, Claim-Evidence Graphs, and complete submission packages
- require final publication reviewers to use the configured agent family distinct from the native producer
- add routing-contract coverage for the new commands and status fields

## Why

The global data-centre water live case showed that acquired full text, later content analysis, inference state, and publication files could otherwise remain separate or implicit. This makes the full frozen chain discoverable and auditable while preserving a scientifically correct access/scope handoff when evidence is insufficient.

## Validation

- `scripts/test-clean-container.sh` (fresh offline container, green)
- `skill-creator` quick validation (green)
- `docpact validate-config --root . --strict`
- `docpact lint --root . --worktree`
- `git diff --check`

Workspace tracking: tiangong-ai/workspace#147