### PR TITLE
feat: support WorkBuddy Auto Research bridge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -70,6 +70,7 @@
                 "./tiangong-kb-report-search",
                 "./tiangong-kb-patent-search",
                 "./tiangong-auto-research",
+                "./tiangong-auto-research-workbuddy",
                 "./fetch-meta-to-kb",
                 "./fetch-meta-from-kb",
                 "./fetch-abstract-to-kb",

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-19"
-lastReviewedCommit: "e05a056e422c178a1ba5de66b2e561c3574717a2"
+lastReviewedCommit: "f89d6b96641f47a6c246df8399c44b52043c1cc9"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
+lastReviewedCommit: f89d6b96641f47a6c246df8399c44b52043c1cc9
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: 1a8f768d3b489d8cf7583a2b4e9bea5913a03903
 ---
 
 # Tiangong AI Skills
@@ -42,6 +42,11 @@ npm i skills -g
 - Install specific skills:
   ```bash
   npx skills add https://github.com/tiangong-ai/skills --skill tiangong-auto-research --skill tiangong-kb-sci-search
+  ```
+- For a WorkBuddy/CodeBuddy producer, install the thin adapter beside the
+  canonical orchestrator:
+  ```bash
+  npx skills add https://github.com/tiangong-ai/skills --skill tiangong-auto-research --skill tiangong-auto-research-workbuddy
   ```
 
 ## Target agents and scope
@@ -142,6 +147,9 @@ The workspace can be any user-selected directory. Every entry is external,
 separately licensed, pinned, and explicitly confirmed/selected; nothing is
 bundled or installed by a research package. See
 `tiangong-auto-research/references/setup.md` and `external-skills.md`.
+`tiangong-auto-research-workbuddy` is only a sandboxed-IDE adapter. It routes
+back to the canonical orchestrator and its signed reviewer-bridge reference;
+it does not define a second research workflow.
 For PPT creation, prefer PPT Master; Anthropic PPTX remains compatible and may
 be selected alongside it when its workflow fits the task.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: 1a8f768d3b489d8cf7583a2b4e9bea5913a03903
 ---
 
 # 天工 AI Skills
@@ -42,6 +42,10 @@ npm i skills -g
 - 安装指定技能:
   ```bash
   npx skills add https://github.com/tiangong-ai/skills --skill tiangong-auto-research --skill tiangong-kb-sci-search
+  ```
+- WorkBuddy/CodeBuddy 作为 producer 时，在 canonical orchestrator 旁安装薄适配 Skill:
+  ```bash
+  npx skills add https://github.com/tiangong-ai/skills --skill tiangong-auto-research --skill tiangong-auto-research-workbuddy
   ```
 
 ## 目标 agent 与作用域
@@ -132,6 +136,8 @@ Anthropic 或 PPT Master 闭环后创作 Skills。workspace 可以是用户指�
 所有条目都是外生、独立授权、精确锁定且经用户明确确认或选择；研究 package
 不会捆绑或安装它们。完整流程见
 `tiangong-auto-research/references/setup.md` 和 `external-skills.md`。
+`tiangong-auto-research-workbuddy` 只负责沙箱 IDE 路由，会回到 canonical
+orchestrator 及其签名 reviewer bridge 流程，不维护第二套研究协议。
 创建 PPT 时首选 PPT Master；Anthropic PPTX 仍是兼容的按场景选项，需要时可在
 同一显式计划中一起选择。
 
@@ -143,7 +149,7 @@ Policy Wizard 会把所选 Markdown 复制到研究 workspace 供人类审阅；
 上限。这套门禁只能产出可复核的投稿候选稿，不能承诺编辑接受。详见
 `tiangong-auto-research/references/publication-policy.md`。
 
-在 discovery 之前，当前原生 Codex 或 Claude host 还必须给出封闭、目标特定的科学
+在 discovery 之前，当前原生 Codex、Claude、WorkBuddy 或 CodeBuddy host 还必须给出封闭、目标特定的科学
 设计。CLI 只负责验证和冻结设计，并依次在 discovery、acquisition、analysis 前强制
 独立的 `research-design`、真实记录 `evidence-construct`、`pilot-methods` 审查。
 acquisition 后还必须完成逐文件拆解、精确 evidence atom、typed-content snapshot、

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
+lastReviewedCommit: f89d6b96641f47a6c246df8399c44b52043c1cc9
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: 1a8f768d3b489d8cf7583a2b4e9bea5913a03903
 ---
 
 # Skills Repository Architecture
@@ -69,8 +69,14 @@ source-derived uncertainty states, authoritative recovery generations, and
 portable audit handoff. The Skill supplies instructions and conservative
 defaults only. The CLI owns schemas, hashing, stage admission, mechanical
 evaluation, lifecycle reservations, other-family reviewer isolation, and
-semantic audit verification; native Codex or Claude remains the scientific
-producer.
+semantic audit verification; the configured native Codex, Claude, WorkBuddy,
+or CodeBuddy host remains the scientific producer.
+
+`tiangong-auto-research-workbuddy` is a thin sandboxed-IDE adapter. It routes
+WorkBuddy/CodeBuddy native producer tasks back to the canonical orchestrator and
+its `sandboxed-ide.md` reference. It owns no duplicate research schema or
+control-plane behavior. Independent review remains a CLI-owned Codex/Claude
+route through either the native platform capsule or the signed sidecar bridge.
 
 ## Integration Points
 

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-18
-lastReviewedCommit: f95d0f8ecf6649e6f7512beb5c209936bdf24c28
+lastReviewedAt: 2026-08-19
+lastReviewedCommit: 1a8f768d3b489d8cf7583a2b4e9bea5913a03903
 ---
 
 # Skills Repository Contract
@@ -53,6 +53,11 @@ marketplace grouping metadata.
   mechanical gates, reviewer-family/session enforcement, lifecycle budgets,
   authoritative generations, and semantic portable-audit verification to the
   CLI.
+- Sandboxed-IDE adapters must remain thin routers to the canonical
+  `tiangong-auto-research` Skill. They must preserve Default Permission, record
+  WorkBuddy/CodeBuddy honestly as the native producer, require an explicit
+  reviewer transport, and forbid Full Access, nested-sandbox bypass, arbitrary
+  sidecar commands, or silent transport fallback.
 
 ## Skill Surface
 

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
+lastReviewedCommit: 1a8f768d3b489d8cf7583a2b4e9bea5913a03903
 ---
 
 # Skills Development Runbook
@@ -87,6 +87,11 @@ scripts/test-clean-container.sh --cold-build
 
 Cold mode adds `--no-cache`; neither mode uses `--pull`, so the base image can
 change only through a reviewed digest update.
+
+When changing sandboxed-IDE routing, keep its deterministic markers in
+`tiangong-auto-research/scripts/test-routing-contract.mjs` and require the thin
+adapter, canonical reference, exact structured bridge errors, and no-bypass
+language to pass in the clean container.
 
 ## README And Marketplace Updates
 

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: e05a056e422c178a1ba5de66b2e561c3574717a2
+lastReviewedCommit: f89d6b96641f47a6c246df8399c44b52043c1cc9
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research-workbuddy/SKILL.md
+++ b/tiangong-auto-research-workbuddy/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: tiangong-auto-research-workbuddy
+description: Adapt a managed Tiangong Auto Research workflow to a native WorkBuddy or CodeBuddy producer running in Default Permission mode, especially when independent review needs the explicit sandbox-bridge transport. Use only as a thin router to the project-installed tiangong-auto-research Skill; do not use for unrelated WorkBuddy tasks or standalone searches.
+---
+
+# Tiangong Auto Research for WorkBuddy
+
+Use this adapter only inside a user-selected managed Auto Research workspace.
+Inspect the exact workspace context first. If setup is absent, use the canonical
+Skill's setup reference; do not copy control files or invent a workspace.
+
+Load the sibling project-installed `tiangong-auto-research/SKILL.md`, then read
+its `references/sandboxed-ide.md` and the other reference selected by the
+current stage. That canonical Skill owns the research workflow, schemas,
+budgets, evidence rules, and recovery behavior; this adapter does not duplicate
+them.
+
+Keep WorkBuddy in Default Permission mode. Never choose Full Access, an
+unsandboxed-command escape hatch, `dangerouslyDisableSandbox`,
+`dangerously-skip-permissions`, `excludedCommands`, or silent transport
+fallback.
+
+The workspace must identify the actual native producer as `workbuddy` or
+`codebuddy`. Use that same value for the packet's `--host-agent`; never
+impersonate Codex or Claude. The CLI must not launch the producer as a child.
+
+For `sandbox-bridge`, require the owner to start the exact-version reviewer
+sidecar from a separate native terminal and a private state directory outside
+the workspace. From the IDE, verify `research reviewer status`, then run the
+explicitly cost-confirmed reviewer doctor. Stop on any structured bridge,
+signature, nonce, model, version, result-binding, or sandbox-policy failure.
+
+After readiness passes, perform native producer stages in this current task and
+return every result through the canonical CLI packet. Independent review and
+mechanical closure remain CLI-controlled.

--- a/tiangong-auto-research-workbuddy/SKILL.md
+++ b/tiangong-auto-research-workbuddy/SKILL.md
@@ -15,6 +15,12 @@ current stage. That canonical Skill owns the research workflow, schemas,
 budgets, evidence rules, and recovery behavior; this adapter does not duplicate
 them.
 
+Run canonical CLI operations through this adapter's
+`scripts/workbuddy_research_cli.sh`. It selects only an explicit Node.js 24
+runtime and then delegates to the sibling canonical resolver. Do not call
+WorkBuddy's ambient Node 22/npx after an `EBADENGINE` warning and do not suppress
+the engine requirement.
+
 Keep WorkBuddy in Default Permission mode. Never choose Full Access, an
 unsandboxed-command escape hatch, `dangerouslyDisableSandbox`,
 `dangerously-skip-permissions`, `excludedCommands`, or silent transport

--- a/tiangong-auto-research-workbuddy/agents/openai.yaml
+++ b/tiangong-auto-research-workbuddy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tiangong Auto Research for WorkBuddy"
+  short_description: "Run native research through the secure reviewer bridge"
+  default_prompt: "Use $tiangong-auto-research-workbuddy to continue this managed research in WorkBuddy Default Permission mode with an explicit, verified reviewer transport."

--- a/tiangong-auto-research-workbuddy/scripts/workbuddy_research_cli.sh
+++ b/tiangong-auto-research-workbuddy/scripts/workbuddy_research_cli.sh
@@ -12,8 +12,16 @@ fi
 
 ambient_node=$(command -v node 2>/dev/null || true)
 configured_node=${AUTO_RESEARCH_NODE:-}
+owner_home=${HOME:-}
 
-for candidate in "$configured_node" /usr/local/bin/node /opt/homebrew/bin/node "$ambient_node"; do
+for candidate in \
+    "$configured_node" \
+    "$owner_home"/.nvm/versions/node/v24*/bin/node \
+    "$owner_home"/.local/share/fnm/node-versions/v24*/installation/bin/node \
+    "$owner_home"/.volta/bin/node \
+    /usr/local/bin/node \
+    /opt/homebrew/bin/node \
+    "$ambient_node"; do
     [ -n "$candidate" ] || continue
     case "$candidate" in
         /*) ;;

--- a/tiangong-auto-research-workbuddy/scripts/workbuddy_research_cli.sh
+++ b/tiangong-auto-research-workbuddy/scripts/workbuddy_research_cli.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+resolver="$script_dir/../../tiangong-auto-research/scripts/research_cli.mjs"
+
+if [ ! -f "$resolver" ] || [ -L "$resolver" ]; then
+    printf '%s\n' '{"error":{"code":"AUTO_RESEARCH_CANONICAL_SKILL_REQUIRED","message":"The project-installed canonical Auto Research resolver is missing or invalid.","details":{"minimumAction":"Install the pinned tiangong-auto-research Skill beside this WorkBuddy adapter."}}}' >&2
+    exit 2
+fi
+
+ambient_node=$(command -v node 2>/dev/null || true)
+configured_node=${AUTO_RESEARCH_NODE:-}
+
+for candidate in "$configured_node" /usr/local/bin/node /opt/homebrew/bin/node "$ambient_node"; do
+    [ -n "$candidate" ] || continue
+    case "$candidate" in
+        /*) ;;
+        *) continue ;;
+    esac
+    [ -x "$candidate" ] || continue
+    major=$(
+        "$candidate" -p 'Number(process.versions.node.split(".")[0])' 2>/dev/null || true
+    )
+    [ "$major" = 24 ] || continue
+    resolved=$(
+        "$candidate" -p 'process.execPath' 2>/dev/null || true
+    )
+    case "$resolved" in
+        /*) exec "$resolved" "$resolver" "$@" ;;
+    esac
+done
+
+printf '%s\n' '{"error":{"code":"AUTO_RESEARCH_NODE_VERSION_INVALID","message":"No explicit Node.js 24 executable is available to the WorkBuddy adapter.","details":{"minimumAction":"Install Node.js 24 or set AUTO_RESEARCH_NODE to its absolute executable path; do not use WorkBuddy ambient Node 22."}}}' >&2
+exit 2

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tiangong-auto-research
-description: Orchestrate open-ended, multi-source, evidence-backed research in the current native Codex or Claude Code host, especially when an ancestor directory contains `.tiangong-research` or the user asks to research, investigate, build on prior outputs, compare evidence, form a conclusion, or produce a reviewed research artifact. Also use for setup, preflight, native producer execution, recovery, independent review, and closure. In an Auto Research workspace this Skill takes precedence over individual web, news, SCI, report, patent, download, or document Skills unless the user explicitly requests one isolated standalone operation outside the research workflow. Covers Chinese requests such as “研究一下”, “朝这个方向做一做”, “结合已有成果继续研究”, “查资料并形成结论”, and “系统梳理证据”.
+description: Orchestrate open-ended, multi-source, evidence-backed research in the current native Codex, Claude Code, WorkBuddy, or CodeBuddy host, especially when an ancestor directory contains `.tiangong-research` or the user asks to research, investigate, build on prior outputs, compare evidence, form a conclusion, or produce a reviewed research artifact. Also use for setup, preflight, native producer execution, recovery, independent review, and closure. In an Auto Research workspace this Skill takes precedence over individual web, news, SCI, report, patent, download, or document Skills unless the user explicitly requests one isolated standalone operation outside the research workflow. Covers Chinese requests such as “研究一下”, “朝这个方向做一做”, “结合已有成果继续研究”, “查资料并形成结论”, and “系统梳理证据”.
 ---
 
 # Tiangong Auto Research
@@ -37,8 +37,9 @@ authoritative declaration schema.
 
 The CLI is the deterministic control plane: it owns setup, locks, brokered
 evidence, schemas, coverage, budgets, admission, the independent review process,
-the journal, and closure. The current interactive Codex or Claude Code session
-owns producer reasoning. The CLI must never launch a nested producer process.
+the journal, and closure. The current interactive Codex, Claude Code,
+WorkBuddy, or CodeBuddy session owns producer reasoning. The CLI must never
+launch a nested producer process.
 Do not reproduce control-plane contracts or edit control files by hand.
 
 During an accepted apply, the CLI may temporarily create the project Skill
@@ -66,6 +67,9 @@ detailed stop and recovery rules.
   authorized access, waiting for an external response, or narrowing scope.
 - Read [references/native-execution.md](references/native-execution.md) before
   preparing or submitting discover, acquire, analyze, or synthesize stages.
+- Read [references/sandboxed-ide.md](references/sandboxed-ide.md) when the
+  producer runs inside WorkBuddy, CodeBuddy, or another outer sandbox, or when
+  native reviewer isolation returns a nested-sandbox error.
 - Read [references/publication-policy.md](references/publication-policy.md)
   before a top-journal project, Policy approval, final manuscript freeze,
   four-role publication review, or readiness closure.

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -6,9 +6,13 @@
   workspace runtime lock and the setup-pinned `skills@1.5.22` package. A clean
   directory needs one user-reviewed exact bootstrap CLI version before that
   lock exists; never infer `latest` for an existing workspace.
-- A current interactive Codex or Claude Code producer host plus an authenticated
-  executable for the other-family independent reviewer route.
-- macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`).
+- A current interactive Codex, Claude Code, WorkBuddy, or CodeBuddy producer
+  host plus an authenticated Codex or Claude executable for the independent
+  reviewer route.
+- macOS `/usr/bin/sandbox-exec` or Linux Bubblewrap (`bwrap`) on the process
+  that actually runs the reviewer capsule. For an outer-sandboxed IDE this is
+  the owner-started sidecar, not the IDE process; see
+  [sandboxed-ide.md](sandboxed-ide.md).
 - Python 3.10+ only for selected Python-based companions. Setup reports missing
   Python dependencies but never installs them.
 

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -1,8 +1,8 @@
 # Native producer execution
 
 Discover, acquire, analyze, and synthesize are performed by the current
-interactive Codex app/session or Claude Code session. The CLI is not a
-producer-agent launcher. It prepares a hash-bound packet, brokers authorized
+interactive Codex, Claude Code, WorkBuddy, or CodeBuddy session. The CLI is not
+a producer-agent launcher. It prepares a hash-bound packet, brokers authorized
 evidence, registers exact acquired artifacts, admits the result, launches the
 other agent family only for independent review, and closes mechanically.
 
@@ -60,12 +60,14 @@ are re-derived from that snapshot rather than trusted from producer JSON.
 
 ## Prepare the exact stage
 
-Use the host agent selected by the immutable setup plan:
+Use the exact native host selected by the immutable setup plan. Valid host
+identities are `codex`, `claude`, `workbuddy`, and `codebuddy`; never label one
+host as another merely to pass admission:
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   research project stage prepare PROJECT \
-  --stage discover --host-agent codex \
+  --stage discover --host-agent workbuddy \
   --workspace /absolute/path/to/workspace --json
 ```
 

--- a/tiangong-auto-research/references/sandboxed-ide.md
+++ b/tiangong-auto-research/references/sandboxed-ide.md
@@ -96,7 +96,9 @@ WORKBUDDY_AUTO_RESEARCH=/absolute/path/to/workspace/.agents/skills/tiangong-auto
 
 The adapter rejects WorkBuddy's ambient Node 22 instead of continuing after
 `EBADENGINE`. It selects an explicit Node.js 24 executable and the adjacent
-`npx`, then the canonical resolver enforces the workspace's exact CLI version.
+`npx`, including a fixed NVM/FNM/Volta Node 24 location when the IDE hides
+system `/usr/local` paths, then the canonical resolver enforces the workspace's
+exact CLI version. `AUTO_RESEARCH_NODE` remains the explicit absolute override.
 
 Status is zero-model-cost and verifies the signed workspace/version/key binding
 plus negative probes. Doctor runs the real tool-free reviewer smoke and may use

--- a/tiangong-auto-research/references/sandboxed-ide.md
+++ b/tiangong-auto-research/references/sandboxed-ide.md
@@ -1,0 +1,138 @@
+# Sandboxed IDE producer and reviewer bridge
+
+Use this reference when the native producer runs in WorkBuddy, CodeBuddy, or
+another IDE sandbox, or when `native-direct` reports
+`RESEARCH_NESTED_SANDBOX_UNSUPPORTED`.
+
+## Keep the boundaries separate
+
+The IDE is the native producer host. It may prepare and submit producer stages,
+but the CLI never launches it as a child process. The independent reviewer is
+still an authenticated Codex or Claude CLI running inside the existing
+macOS `sandbox-exec` or Linux Bubblewrap capsule.
+
+Choose one reviewer transport explicitly during setup:
+
+- `native-direct`: the current process creates the platform capsule. Use it on
+  an ordinary native host.
+- `sandbox-bridge`: the IDE client sends one hash-bound reviewer request to an
+  owner-started sidecar outside the IDE sandbox. The sidecar creates the same
+  platform capsule and returns a signed, result-bound attestation.
+
+There is no fallback between these transports. Do not enable WorkBuddy Full
+Access, `dangerouslyDisableSandbox`, `dangerously-skip-permissions`,
+`excludedCommands`, unsandboxed-command escape hatches, or any equivalent
+bypass. Keep WorkBuddy in Default Permission mode.
+
+## Configure the producer and transport
+
+In the generated `setup.yaml`, keep the generated closed schema and set only
+the reviewed values. A WorkBuddy example uses:
+
+```yaml
+agentRoutes:
+  producerAgent: workbuddy
+  reviewerAgent: claude
+  producerModel: <actual-workbuddy-model-id>
+  reviewerModel: <actual-claude-model-id>
+  producerPricing: <reviewed-price-object>
+  reviewerPricing: <reviewed-price-object>
+reviewerExecution:
+  transport: sandbox-bridge
+  isolationProvider: platform-capsule
+```
+
+For CodeBuddy use `producerAgent: codebuddy`. The reviewer must remain `codex`
+or `claude`; never label WorkBuddy/CodeBuddy output as Codex or Claude. Use the
+exact model that the native host actually reports.
+
+Apply setup normally. A bridge workspace remains blocked until its sidecar is
+running and status/doctor succeeds. This is intentional; setup does not start a
+privileged background process from inside the IDE.
+
+## Start the owner-controlled sidecar
+
+From a separate native terminal outside the IDE sandbox, resolve the exact CLI
+through the installed canonical Skill and choose an explicit private state
+directory outside the research workspace:
+
+```bash
+AUTO_RESEARCH_CLI=/absolute/path/to/workspace/.agents/skills/tiangong-auto-research/scripts/research_cli.mjs
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research reviewer serve \
+  --workspace /absolute/path/to/workspace \
+  --state-dir /absolute/private/sidecar-state --json
+```
+
+The state directory must be a regular non-symlink directory. It holds the
+owner-only Ed25519 private key and atomic nonce claims and must not be placed in
+the workspace, synchronized evidence tree, Skill directory, or version control.
+The workspace receives only an owner-only ephemeral client binding. Neither
+path, token, nor private key is printed or journaled.
+
+The sidecar refuses READY until real negative probes prove that its capsule
+cannot read the workspace credential store or an unapproved file and cannot
+write outside the private capsule to the host. Its protocol exposes only
+`execute`, `fingerprint`, and `status`; it has no arbitrary-command action. The
+reviewer invocation disables shell, browser, web, undeclared MCP, Skills, and
+other tools. Provider network remains available only because the authenticated
+reviewer CLI must reach its configured model service.
+
+## Verify from the IDE
+
+Inside WorkBuddy/CodeBuddy, keep Default Permission and run:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research reviewer status --workspace /absolute/path/to/workspace --json
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research reviewer doctor --confirm-agent-smoke-cost \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Status is zero-model-cost and verifies the signed workspace/version/key binding
+plus negative probes. Doctor runs the real tool-free reviewer smoke and may use
+provider quota. Production remains blocked until the normal setup/workspace
+doctor attestation is current.
+
+Every bridge review binds the exact CLI version, runtime lock, workspace
+configuration, capsule tree, request, result, reviewer model/runtime, platform
+sandbox policy, tool policy, nonce, and signing-key fingerprint. Version,
+model, policy, packet, result, signature, or session drift fails closed.
+
+## Run native stages honestly
+
+When the CLI reports `native-stage-required`, WorkBuddy uses
+`--host-agent workbuddy`; CodeBuddy uses `--host-agent codebuddy`. Follow the
+returned packet exactly and then submit through the canonical Skill resolver.
+Do not invoke a nested reasoning CLI for producer work.
+
+If a bridge error occurs, stop on its structured code. Restart the exact-version
+sidecar for `UNAVAILABLE`; repair the reviewed configuration for version/model
+drift; create a fresh request for replay; and treat attestation, result, or
+sandbox-policy failures as security blockers. Never switch to `native-direct`
+silently after a bridge failure or switch to the bridge silently after a native
+failure.
+
+The actionable fail-closed codes are:
+
+- `RESEARCH_NESTED_SANDBOX_UNSUPPORTED`: the explicitly selected
+  `native-direct` capsule cannot start inside the current outer sandbox.
+- `RESEARCH_REVIEW_BRIDGE_UNAVAILABLE`: start or restore the exact-version
+  owner-controlled sidecar, then rerun status.
+- `RESEARCH_REVIEW_BRIDGE_VERSION_MISMATCH`: align the active CLI, runtime lock,
+  client binding, and sidecar exact version.
+- `RESEARCH_REVIEW_BRIDGE_ATTESTATION_INVALID`: stop; the workspace, request,
+  signer, hash, or signature binding is invalid.
+- `RESEARCH_REVIEW_BRIDGE_SANDBOX_POLICY_INVALID`: stop; the platform capsule,
+  negative probes, tool-free policy, or network policy is not the reviewed one.
+- `RESEARCH_REVIEW_BRIDGE_MODEL_MISMATCH`: stop; use the exact configured
+  reviewer family/model and rerun doctor.
+- `RESEARCH_REVIEW_BRIDGE_NONCE_REPLAY`: create one fresh request; never retry
+  or copy the rejected protocol bytes.
+- `RESEARCH_REVIEW_BRIDGE_RESULT_BINDING_INVALID`: stop; the capsule, response,
+  or exact result no longer matches the signed request.
+
+Do not hide any of these codes behind a generic retry loop.

--- a/tiangong-auto-research/references/sandboxed-ide.md
+++ b/tiangong-auto-research/references/sandboxed-ide.md
@@ -84,13 +84,19 @@ reviewer CLI must reach its configured model service.
 Inside WorkBuddy/CodeBuddy, keep Default Permission and run:
 
 ```bash
-node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+WORKBUDDY_AUTO_RESEARCH=/absolute/path/to/workspace/.agents/skills/tiangong-auto-research-workbuddy/scripts/workbuddy_research_cli.sh
+
+"$WORKBUDDY_AUTO_RESEARCH" --workspace /absolute/path/to/workspace -- \
   research reviewer status --workspace /absolute/path/to/workspace --json
 
-node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+"$WORKBUDDY_AUTO_RESEARCH" --workspace /absolute/path/to/workspace -- \
   research reviewer doctor --confirm-agent-smoke-cost \
   --workspace /absolute/path/to/workspace --json
 ```
+
+The adapter rejects WorkBuddy's ambient Node 22 instead of continuing after
+`EBADENGINE`. It selects an explicit Node.js 24 executable and the adjacent
+`npx`, then the canonical resolver enforces the workspace's exact CLI version.
 
 Status is zero-model-cost and verifies the signed workspace/version/key binding
 plus negative probes. Doctor runs the real tool-free reviewer smoke and may use

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -52,6 +52,10 @@ omission is not a state. The generated template deliberately does not accept
 licenses, network writes, global mutation, or paid smoke cost for the user.
 Review the current catalog, complete those fields explicitly, and treat the
 generated CLI template—not this reference—as the authoritative closed schema.
+The same template makes `reviewerExecution.transport` explicit. Use
+`native-direct` when the current host can create the platform capsule, or
+`sandbox-bridge` for an outer-sandboxed IDE with an owner-started sidecar. Read
+[sandboxed-ide.md](sandboxed-ide.md) before selecting the bridge.
 The removed v1 declaration is rejected; regenerate the v2 template instead of
 hand-migrating an old file.
 

--- a/tiangong-auto-research/scripts/research_cli.mjs
+++ b/tiangong-auto-research/scripts/research_cli.mjs
@@ -3,7 +3,7 @@
 import { constants as fsConstants } from "node:fs";
 import { access, lstat, readFile, realpath } from "node:fs/promises";
 import { spawn } from "node:child_process";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const MAX_RUNTIME_LOCK_BYTES = 64 * 1024;
@@ -244,6 +244,8 @@ async function run() {
   const parsed = parseArguments(process.argv.slice(2));
   const runtime = await resolveWorkspaceRuntime(parsed.workspace);
   const executable = await resolveNpxExecutable();
+  const runtimeBin = dirname(process.execPath);
+  const inheritedPath = process.env.PATH ?? "";
   const args = [
     "--yes",
     "--package",
@@ -255,7 +257,11 @@ async function run() {
 
   const exitCode = await new Promise((resolveExit, rejectExit) => {
     const child = spawn(executable, args, {
-      env: { ...process.env, DO_NOT_TRACK: "1" },
+      env: {
+        ...process.env,
+        PATH: inheritedPath.length > 0 ? `${runtimeBin}${delimiter}${inheritedPath}` : runtimeBin,
+        DO_NOT_TRACK: "1",
+      },
       shell: false,
       stdio: "inherit",
     });

--- a/tiangong-auto-research/scripts/research_cli.mjs
+++ b/tiangong-auto-research/scripts/research_cli.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-import { lstat, readFile, realpath } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { access, lstat, readFile, realpath } from "node:fs/promises";
 import { spawn } from "node:child_process";
-import { isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const MAX_RUNTIME_LOCK_BYTES = 64 * 1024;
@@ -20,6 +21,39 @@ class ResolverError extends Error {
 
 function resolverError(code, message, minimumAction) {
   return new ResolverError(code, message, minimumAction);
+}
+
+function requireNode24() {
+  if (Number(process.versions.node.split(".")[0]) === 24) return;
+  throw resolverError(
+    "AUTO_RESEARCH_NODE_VERSION_INVALID",
+    `Auto Research requires Node.js 24; the current process is Node ${process.versions.node}.`,
+    "Run this resolver with an explicit Node.js 24 executable. In WorkBuddy/CodeBuddy use the installed workbuddy_research_cli.sh adapter instead of ambient node/npx.",
+  );
+}
+
+async function resolveNpxExecutable() {
+  const configured = process.env.AUTO_RESEARCH_NPX;
+  const candidate = configured ?? join(dirname(process.execPath), process.platform === "win32" ? "npx.cmd" : "npx");
+  if (!isAbsolute(candidate) || candidate.includes("\0")) {
+    throw resolverError(
+      "AUTO_RESEARCH_NPX_INVALID",
+      "The locked Auto Research resolver requires an absolute npx executable beside Node.js 24.",
+      "Install npx beside the selected Node.js 24 runtime or set AUTO_RESEARCH_NPX to one reviewed absolute executable path.",
+    );
+  }
+  try {
+    const info = await lstat(candidate);
+    if (!info.isFile() && !info.isSymbolicLink()) throw new Error("not-file");
+    await access(candidate, fsConstants.X_OK);
+  } catch {
+    throw resolverError(
+      "AUTO_RESEARCH_NPX_INVALID",
+      "The locked Auto Research resolver could not use the npx executable beside Node.js 24.",
+      "Install npx beside the selected Node.js 24 runtime or set AUTO_RESEARCH_NPX to one reviewed absolute executable path.",
+    );
+  }
+  return candidate;
 }
 
 export async function resolveWorkspaceRuntime(workspaceInput) {
@@ -206,9 +240,10 @@ function writeStructuredError(error) {
 }
 
 async function run() {
+  requireNode24();
   const parsed = parseArguments(process.argv.slice(2));
   const runtime = await resolveWorkspaceRuntime(parsed.workspace);
-  const executable = process.platform === "win32" ? "npx.cmd" : "npx";
+  const executable = await resolveNpxExecutable();
   const args = [
     "--yes",
     "--package",

--- a/tiangong-auto-research/scripts/test-research-cli.mjs
+++ b/tiangong-auto-research/scripts/test-research-cli.mjs
@@ -65,7 +65,10 @@ function invoke(workspace, extraEnv = {}) {
         ...extraEnv,
         AUTO_RESEARCH_NPX: fakeNpx,
         FAKE_NPX_AUDIT: auditPath,
-        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        // Model an outer IDE whose PATH has no usable Node.js. The resolver is
+        // responsible for keeping its selected Node 24 runtime authoritative
+        // when npx and the installed CLI bin follow /usr/bin/env node shebangs.
+        PATH: `${fakeBin}:/usr/bin:/bin`,
       },
     },
   );

--- a/tiangong-auto-research/scripts/test-research-cli.mjs
+++ b/tiangong-auto-research/scripts/test-research-cli.mjs
@@ -8,6 +8,27 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const script = join(dirname(fileURLToPath(import.meta.url)), "research_cli.mjs");
+const resolverSource = await readFile(script, "utf8");
+assert.match(resolverSource, /AUTO_RESEARCH_NODE_VERSION_INVALID/);
+assert.match(resolverSource, /dirname\(process\.execPath\).*npx/s);
+const workBuddyLauncher = join(
+  dirname(script),
+  "..",
+  "..",
+  "tiangong-auto-research-workbuddy",
+  "scripts",
+  "workbuddy_research_cli.sh",
+);
+const workBuddyLauncherSource = await readFile(workBuddyLauncher, "utf8");
+for (const marker of [
+  "/usr/local/bin/node",
+  "/opt/homebrew/bin/node",
+  "AUTO_RESEARCH_NODE",
+  "process.versions.node",
+  "research_cli.mjs",
+]) {
+  assert.ok(workBuddyLauncherSource.includes(marker), `WorkBuddy launcher must include ${marker}`);
+}
 const root = await mkdtemp(join(tmpdir(), "tiangong-auto-research-resolver-"));
 const fakeBin = join(root, "bin");
 const auditPath = join(root, "npx-args.json");
@@ -41,6 +62,7 @@ function invoke(workspace, extraEnv = {}) {
       env: {
         ...process.env,
         ...extraEnv,
+        AUTO_RESEARCH_NPX: fakeNpx,
         FAKE_NPX_AUDIT: auditPath,
         PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
       },

--- a/tiangong-auto-research/scripts/test-research-cli.mjs
+++ b/tiangong-auto-research/scripts/test-research-cli.mjs
@@ -23,6 +23,7 @@ const workBuddyLauncherSource = await readFile(workBuddyLauncher, "utf8");
 for (const marker of [
   "/usr/local/bin/node",
   "/opt/homebrew/bin/node",
+  ".nvm/versions/node/v24",
   "AUTO_RESEARCH_NODE",
   "process.versions.node",
   "research_cli.mjs",

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const skillsRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const skillNames = [
   "tiangong-auto-research",
+  "tiangong-auto-research-workbuddy",
   "tiangong-kb-sci-search",
   "tiangong-kb-report-search",
   "tiangong-kb-patent-search",
@@ -44,6 +45,10 @@ const publicationReference = await readFile(
   join(skillsRoot, "tiangong-auto-research", "references", "publication-policy.md"),
   "utf8",
 );
+const sandboxedIdeReference = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "references", "sandboxed-ide.md"),
+  "utf8",
+);
 
 for (const marker of [
   ".tiangong-research/setup.yaml",
@@ -52,6 +57,30 @@ for (const marker of [
   "overallReadiness",
 ]) {
   assert.ok(autoResearchSkill.includes(marker), `Auto Research entry must explain ${marker}`);
+}
+
+for (const marker of [
+  "native-direct",
+  "sandbox-bridge",
+  "Default Permission",
+  "research reviewer serve",
+  "research reviewer status",
+  "research reviewer doctor",
+  "--host-agent workbuddy",
+  "no arbitrary-command action",
+  "Never switch",
+  "RESEARCH_REVIEW_BRIDGE_UNAVAILABLE",
+  "RESEARCH_REVIEW_BRIDGE_VERSION_MISMATCH",
+  "RESEARCH_REVIEW_BRIDGE_ATTESTATION_INVALID",
+  "RESEARCH_REVIEW_BRIDGE_SANDBOX_POLICY_INVALID",
+  "RESEARCH_REVIEW_BRIDGE_MODEL_MISMATCH",
+  "RESEARCH_REVIEW_BRIDGE_NONCE_REPLAY",
+  "RESEARCH_REVIEW_BRIDGE_RESULT_BINDING_INVALID",
+]) {
+  assert.ok(
+    sandboxedIdeReference.includes(marker),
+    `Sandboxed IDE reference must explain ${marker}`,
+  );
 }
 
 for (const marker of [
@@ -67,6 +96,20 @@ for (const marker of [
   "overallReadiness=READY",
 ]) {
   assert.ok(setupReference.includes(marker), `Setup reference must explain ${marker}`);
+}
+
+
+for (const marker of [
+  "workbuddy",
+  "codebuddy",
+  "default permission",
+  "sandbox-bridge",
+  "thin router",
+]) {
+  assert.ok(
+    descriptions["tiangong-auto-research-workbuddy"].includes(marker),
+    `WorkBuddy adapter routing description must include ${marker}`,
+  );
 }
 
 for (const marker of [


### PR DESCRIPTION
Closes the Skills portion of tiangong-ai/workspace#150.

What changed:
- adds a thin WorkBuddy/CodeBuddy adapter that routes to the canonical Auto Research Skill
- documents explicit native-direct versus sandbox-bridge selection and Default Permission safety boundaries
- adds a Node 24 launcher that rejects ambient WorkBuddy Node 22
- preserves the selected Node 24 runtime through npx and CLI shebang execution
- updates routing, marketplace, setup, and governance documentation

Validation:
- clean Docker red then green for nested IDE Node PATH behavior
- final cached clean-container suite green
- prior cold clean-container suite green; final cold gate will run before merge
- skill-creator validation passed for canonical and adapter Skills
- docpact 0.1.9 enforce lint green
- real WorkBuddy 5.3.14 Default Permission canary exercised the adapter and bridge workflow