### PR TITLE
fix(auto-research): document scientific object intake

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-19"
-lastReviewedCommit: "b6654fa5fd942c48f2aa1ed99a92373a7304a3d2"
+lastReviewedCommit: "8f04a2559a51fad8f7061ecc1d0ad853e01ddea0"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: b6654fa5fd942c48f2aa1ed99a92373a7304a3d2
+lastReviewedCommit: 8f04a2559a51fad8f7061ecc1d0ad853e01ddea0
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ acceptance.
 
 Before discovery, the current native Codex or Claude host must also provide a
 closed, target-specific scientific design. The CLI validates and freezes the
-design, then enforces independent `research-design`, real-record
+design. Frozen model implementations and environment locks must first enter the
+workspace through `research scientific object register`; the Skill never asks
+the user to hand-copy them into `.tiangong-research`. The CLI then enforces independent `research-design`, real-record
 `evidence-construct`, and `pilot-methods` reviews before discovery, acquisition,
 and analysis respectively. After acquisition it also requires exact
 decomposition records, evidence atoms, a typed-content snapshot, a passing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,7 +154,8 @@ Policy Wizard 会把所选 Markdown 复制到研究 workspace 供人类审阅；
 `tiangong-auto-research/references/publication-policy.md`。
 
 在 discovery 之前，当前原生 Codex、Claude、WorkBuddy 或 CodeBuddy host 还必须给出封闭、目标特定的科学
-设计。CLI 只负责验证和冻结设计，并依次在 discovery、acquisition、analysis 前强制
+设计。冻结的模型实现和环境锁必须先通过 `research scientific object register`
+进入 workspace；Skill 不会要求用户手工把文件写入 `.tiangong-research`。CLI 只负责验证和冻结设计，并依次在 discovery、acquisition、analysis 前强制
 独立的 `research-design`、真实记录 `evidence-construct`、`pilot-methods` 审查。
 acquisition 后还必须完成逐文件拆解、精确 evidence atom、typed-content snapshot、
 passing inference snapshot、可复现分析和机械生成的 Claim-Evidence Graph。投稿冻结

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: b6654fa5fd942c48f2aa1ed99a92373a7304a3d2
+lastReviewedCommit: 8f04a2559a51fad8f7061ecc1d0ad853e01ddea0
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -60,7 +60,9 @@ selected stack into the user-selected research workspace, where a human may
 customize and explicitly approve the exact resolved content.
 
 `tiangong-auto-research/references/scientific-design.md` defines the Skill-side
-native workflow for a closed project-specific design, three early independent
+native workflow for a closed project-specific design, explicit public
+pre-admission registration of raw model/environment objects, frozen-versus-
+pending null semantics, exact portable review-blob promotion, three early independent
 scientific review gates, post-acquisition decomposition/evidence-atom/content
 freeze, evidence-construct canary binding, inference snapshot, reproducible
 analysis and Claim-Evidence Graph, role-complete submission packaging,

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -44,7 +44,10 @@ marketplace grouping metadata.
 - Scientific-design guidance and defaults must preserve the native-producer
   boundary, distinguish observation from model comparison/scenario/accounting,
   distinguish byte identity from model executability, bind pending model,
-  environment, and uncertainty objects to explicit future gates, require exact
+  environment, and uncertainty objects to explicit future gates, require the
+  public content-addressed intake for frozen raw model/environment bytes rather
+  than manual control-store writes, use null bindings for genuinely pending
+  objects, require exact
   joint-state mappings, bind real-record construct artifacts only after frozen
   acquisition and typed-content snapshots, require exact decomposition lineage
   and evidence atoms before inference, never treat resampling as additional

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: b6654fa5fd942c48f2aa1ed99a92373a7304a3d2
+lastReviewedCommit: 8f04a2559a51fad8f7061ecc1d0ad853e01ddea0
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-19
-lastReviewedCommit: b6654fa5fd942c48f2aa1ed99a92373a7304a3d2
+lastReviewedCommit: 8f04a2559a51fad8f7061ecc1d0ad853e01ddea0
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -171,6 +171,9 @@ cross-model comparison, scenario, and accounting roles; freeze units,
 denominators, independent clusters, thresholds, baselines, evidence roles,
 closest-work requirements, known gaps, and handoff conditions. Pass the same
 exact file to preflight and init with the native producer's opaque session ID.
+Before referencing a frozen model implementation or environment lock, use
+`research scientific object register` and copy its returned raw-byte hash and
+safe locator into the design; never hand-copy objects into the control store.
 The design must map every required evidence role to its lawful acquisition
 routes. All plan-bound lawful agent routes must have immutable terminal events
 before an evidence-exhausted handoff is valid.

--- a/tiangong-auto-research/references/scientific-design.md
+++ b/tiangong-auto-research/references/scientific-design.md
@@ -45,6 +45,47 @@ increase the number of independent experimental or observational units. Gross
 installed mixture is not automatically binder, virgin material, network demand,
 or an observed effect. Encode those boundaries in quantities and claim verbs.
 
+## Register frozen scientific objects
+
+Before writing a design that marks an implementation `executable-frozen` or an
+environment `exact-frozen`, register the external raw files through the public
+workspace-scoped intake. This happens before project initialization, so it does
+not take a project ID:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research scientific object register \
+  --kind model-implementation \
+  --path /absolute/path/to/model.py \
+  --media-type text/x-python \
+  --workspace /absolute/path/to/workspace --json
+
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research scientific object register \
+  --kind environment-lock \
+  --path /absolute/path/to/requirements.lock \
+  --media-type text/plain \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Copy each returned `sha256` and `objectLocator` exactly into the matching design
+field. The locator has the form `lineage/objects/<sha256>/blob`. The CLI accepts
+only bounded regular non-symlink files outside `.tiangong-research`, validates
+reviewable UTF-8 media, hashes raw bytes, writes the blob atomically, and creates
+a deterministic record without the host source path. Registration is
+idempotent. Use `research scientific object inspect --kind KIND --locator
+LOCATOR` to revalidate an existing record and blob. Do not hand-copy files into
+the control directory, reuse an object under the wrong kind, or put an external
+absolute path in the design.
+
+The research-design review promotes registered Python, R, JavaScript, text,
+JSON, TOML, or YAML bytes as exact project-local portable blobs. It records
+their media type, object kind, safe source locator, registration-record hash,
+size, and raw-byte SHA-256 in `stageInputs`; it does not parse code or lock files
+as JSON. Preflight and project admission revalidate every frozen binding and
+report the exact model/artifact/reason when an object is missing, unsafe,
+kind-mismatched, metadata-invalid, or hash-drifted.
+
 ## Executable model and uncertainty contracts
 
 A digest proves byte identity, not scientific executability. For every model,
@@ -56,6 +97,13 @@ locators and declare `artifactHashBasis: raw-file-bytes`. A model marked
 `evidence-construct` or `pilot-methods` deadline. Specification prose,
 unresolved coefficients, an unpinned runtime, or an empty dependency lock is
 not executable merely because its bytes are hash-bound.
+
+A pending implementation must set `implementationArtifactSha256`,
+`implementationArtifactLocator`, and `implementationEntrypoint` to `null`. A
+pending environment must set `environmentLockSha256` and
+`environmentLockLocator` to `null`. The early review does not try to promote
+those absent objects; their Policy-owned future obligation remains explicit and
+becomes blocking at its declared due gate.
 
 Every pending model deadline must be owned by a `planned` Policy disposition at
 the same gate through `modelStructureIds`. Every source-pending uncertainty
@@ -136,11 +184,10 @@ support must bind exact atoms, and full-text/date claims are checked against the
 snapshots. Put canary artifact SHA-256 values in the assessment and supply their
 absolute canonical paths in a separate owner-reviewed JSON array through
 `--canary-artifacts`; the CLI promotes the exact non-symlink JSON bytes and
-binds them into the packet without persisting the host source paths.
-3. `pilot-methods` runs after the evidence-construct review and blocks analysis. It checks
-   leakage/circularity, endpoint compatibility, baseline fairness, units and
-   denominators, threshold types, decision-loss metrics, validation-plan
-   coverage, and the original/cluster/effective/resampling-unit audit.
+binds them into the packet without persisting the host source paths. 3. `pilot-methods` runs after the evidence-construct review and blocks analysis. It checks
+leakage/circularity, endpoint compatibility, baseline fairness, units and
+denominators, threshold types, decision-loss metrics, validation-plan
+coverage, and the original/cluster/effective/resampling-unit audit.
 
 For each gate, inspect its assessment schema, have the current native producer
 write a bounded assessment from the exact frozen inputs, and prepare a fresh
@@ -179,8 +226,10 @@ Revise the assessment/design/method and prepare a new packet with a new session.
 
 Review the exact promoted `stageInputs`. Their `sha256` values are digests of
 the raw file bytes at the portable `path`; `sourceLocator` records provenance,
-while `purpose` and `ownerId` bind the bytes to the scientific object under
-review. `packetSha256` is the packet's logical identity (excluding its own
+while `purpose`, `ownerId`, `mediaType`, `objectKind`, and
+`registrationRecordSha256` bind the bytes to the scientific object under
+review. Model implementations and environment locks use an exact portable
+`blob`, not a newest-file scan or JSON reinterpretation. `packetSha256` is the packet's logical identity (excluding its own
 identity field); the portable audit manifest separately records the raw stored
 packet-file digest. Do not interchange those two hash meanings.
 

--- a/tiangong-auto-research/scripts/test-research-policy-pack.mjs
+++ b/tiangong-auto-research/scripts/test-research-policy-pack.mjs
@@ -48,14 +48,25 @@ for (const [category, files] of Object.entries(expected)) {
   for (const file of files) {
     const path = join(policyRoot, category, file);
     const text = await readFile(path, "utf8");
-    assert.match(text, /^---\n[\s\S]+?\n---\n/, `${path} must have frontmatter`);
+    assert.match(
+      text,
+      /^---\n[\s\S]+?\n---\n/,
+      `${path} must have frontmatter`,
+    );
     const id = text.match(/^id:\s*([a-z0-9.-]+)$/m)?.[1];
     assert.ok(id, `${path} must declare a stable id`);
     assert.equal(ids.has(id), false, `duplicate policy id ${id}`);
     ids.add(id);
-    assert.match(text, /^schemaVersion:\s*1$/m, `${path} must use policy schema v1`);
+    assert.match(
+      text,
+      /^schemaVersion:\s*1$/m,
+      `${path} must use policy schema v1`,
+    );
     assert.match(text, /^kind:\s*[a-z-]+$/m, `${path} must declare kind`);
-    assert.match(text, /^templateClass:\s*(bundled-default|exact-journal-template|project-template)$/m);
+    assert.match(
+      text,
+      /^templateClass:\s*(bundled-default|exact-journal-template|project-template)$/m,
+    );
     assert.match(text, /^#\s+\S/m, `${path} must have a title`);
   }
 }
@@ -76,7 +87,11 @@ for (const relative of [
     "Required reviewer questions",
     "Permitted pivots",
   ]) {
-    assert.match(text, new RegExp(`^## ${heading}$`, "m"), `${relative.join("/")} lacks ${heading}`);
+    assert.match(
+      text,
+      new RegExp(`^## ${heading}$`, "m"),
+      `${relative.join("/")} lacks ${heading}`,
+    );
   }
 }
 
@@ -85,7 +100,11 @@ for (const relative of [
   ...expected["article-types"].map((file) => ["article-types", file]),
 ]) {
   const text = await readFile(join(policyRoot, ...relative), "utf8");
-  assert.match(text, /^constraints:$/m, `${relative.join("/")} lacks mechanical constraints`);
+  assert.match(
+    text,
+    /^constraints:$/m,
+    `${relative.join("/")} lacks mechanical constraints`,
+  );
   assert.match(
     text,
     /^  minDirectPeerReviewedFullText:\s*[1-9][0-9]*$/m,
@@ -96,12 +115,18 @@ for (const relative of [
 assert.equal(ids.size, Object.values(expected).flat().length);
 
 const skill = await readFile(join(skillRoot, "SKILL.md"), "utf8");
-const publicationReference = await readFile(join(skillRoot, "references", "publication-policy.md"), "utf8");
+const publicationReference = await readFile(
+  join(skillRoot, "references", "publication-policy.md"),
+  "utf8",
+);
 const scientificDesignReference = await readFile(
   join(skillRoot, "references", "scientific-design.md"),
   "utf8",
 );
-const openAiMetadata = await readFile(join(skillRoot, "agents", "openai.yaml"), "utf8");
+const openAiMetadata = await readFile(
+  join(skillRoot, "agents", "openai.yaml"),
+  "utf8",
+);
 assert.match(
   skill,
   /references\/publication-policy\.md/,
@@ -112,7 +137,11 @@ assert.match(
   /references\/scientific-design\.md/,
   "SKILL.md must route scientific design and early-gate work to the detailed reference",
 );
-assert.match(skill, /current native host/i, "final manuscript authoring must remain in the native host");
+assert.match(
+  skill,
+  /current native host/i,
+  "final manuscript authoring must remain in the native host",
+);
 for (const role of [
   "evidence",
   "methods-reproducibility",
@@ -121,7 +150,10 @@ for (const role of [
 ]) {
   assert.match(publicationReference, new RegExp(`\\b${role}\\b`));
 }
-assert.match(publicationReference, /does not predict or guarantee editorial acceptance/i);
+assert.match(
+  publicationReference,
+  /does not predict or guarantee editorial acceptance/i,
+);
 for (const marker of [
   "real-record construct canary",
   "effective independent units",
@@ -131,12 +163,30 @@ for (const marker of [
   "raw-file-bytes",
   "executable-frozen",
   "jointStateBindings",
+  "research scientific object register",
+  "model-implementation",
+  "environment-lock",
+  "lineage/objects/<sha256>/blob",
+  "Do not hand-copy",
 ]) {
   assert.match(scientificDesignReference, new RegExp(marker, "i"));
 }
+assert.match(
+  skill,
+  /research scientific object register/i,
+  "SKILL.md must require public scientific-object intake before a frozen design",
+);
 assert.match(scientificDesignReference, /current native Codex or Claude host/i);
-assert.match(scientificDesignReference, /does not create the study design or launch a nested producer/i);
+assert.match(
+  scientificDesignReference,
+  /does not create the study design or launch a nested producer/i,
+);
 assert.match(openAiMetadata, /scientific design/i);
-assert.match(openAiMetadata, /independent scientific and final publication reviews/i);
+assert.match(
+  openAiMetadata,
+  /independent scientific and final publication reviews/i,
+);
 assert.match(openAiMetadata, /portable audit/i);
-process.stdout.write(`Research Policy default pack tests passed (${ids.size} templates)\n`);
+process.stdout.write(
+  `Research Policy default pack tests passed (${ids.size} templates)\n`,
+);


### PR DESCRIPTION
## Summary
- require public pre-admission registration for frozen model and environment bytes
- document deterministic path-free object records, exact portable review blobs, and precise binding failures
- align pending model fields with null bindings and future-gate obligations
- add clean-container contract markers

## Validation
- clean-container red observed before documentation changes
- `scripts/test-clean-container.sh`
- `scripts/test-clean-container.sh --cold-build`
- skill-creator `quick_validate.py tiangong-auto-research`
- docpact validate/lint
- `git diff --check`

Part of tiangong-ai/workspace#155.