### PR TITLE
chore(kb-ingest): pin CLI 0.0.48

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-19"
-lastReviewedCommit: "d7978275855c67158e08cc21e49dc6e2b43878d5"
+lastReviewedAt: "2026-08-20"
+lastReviewedCommit: "eddfc711e8c86270412e161cc489fde6d2015fb4"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 8f04a2559a51fad8f7061ecc1d0ad853e01ddea0
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: d7978275855c67158e08cc21e49dc6e2b43878d5
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # Tiangong AI Skills
@@ -46,6 +46,10 @@ npm i skills -g
 - Install the Tsinghua graduate thesis LaTeX workflow:
   ```bash
   npx skills add https://github.com/tiangong-ai/skills --skill tsinghua-graduate-thesis
+  ```
+- Install the Tiangong KB ingest workflow:
+  ```bash
+  npx skills add https://github.com/tiangong-ai/skills --skill tiangong-kb-ingest
   ```
 - For a WorkBuddy/CodeBuddy producer, install the thin adapter beside the
   canonical orchestrator:
@@ -100,6 +104,20 @@ an external service, read that skill's `references/env.md` when present.
 `npx skills add` installs or links skill files; it does not provision language
 runtimes or execute post-install hooks. When a skill provides a locked runtime
 bootstrap and smoke command, run those explicit steps from its own instructions.
+
+## Tiangong KB Ingest Compatibility
+
+`tiangong-kb-ingest` uses the exact reviewed CLI 0.0.48 distribution. After
+installing or updating the Skill, run the credential-free compatibility smoke:
+
+```bash
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai --version
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb --help
+```
+
+The version command must print `0.0.48`; KB help must list the bulk scan,
+metadata dry-run, collection list/schema, ingest, and status surfaces. These
+checks do not call or mutate the KB backend.
 
 ## Auto Research External Skill Setup
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: d7978275855c67158e08cc21e49dc6e2b43878d5
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # 天工 AI Skills
@@ -46,6 +46,10 @@ npm i skills -g
 - 安装清华研究生学位论文 LaTeX 工作流:
   ```bash
   npx skills add https://github.com/tiangong-ai/skills --skill tsinghua-graduate-thesis
+  ```
+- 安装天工 KB 导入工作流:
+  ```bash
+  npx skills add https://github.com/tiangong-ai/skills --skill tiangong-kb-ingest
   ```
 - WorkBuddy/CodeBuddy 作为 producer 时，在 canonical orchestrator 旁安装薄适配 Skill:
   ```bash
@@ -98,6 +102,19 @@ skill 的 `references/env.md`（如存在）。
 `npx skills add` 只安装或链接 Skill 文件，不会配置语言运行时或执行安装后 hook。
 如果 Skill 提供锁定运行时的 bootstrap 与 smoke 命令，应按该 Skill 的说明显式
 执行这些步骤。
+
+## 天工 KB 导入兼容性
+
+`tiangong-kb-ingest` 使用经过验证的精确 CLI 0.0.48 发行版。安装或更新 Skill
+后，运行不需要凭据的兼容性冒烟：
+
+```bash
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai --version
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb --help
+```
+
+版本命令必须输出 `0.0.48`；KB 帮助必须列出 bulk scan、metadata dry-run、
+collection list/schema、ingest 和 status 命令。上述检查不会调用或修改 KB 后端。
 
 ## Auto Research 外部 Skill 配置
 

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: d7978275855c67158e08cc21e49dc6e2b43878d5
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: b6654fa5fd942c48f2aa1ed99a92373a7304a3d2
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # Skills Repository Architecture
@@ -44,6 +44,12 @@ Skills are consumed by external agent runtimes through the `skills` CLI or by
 copy/symlink installation. Some skills require environment variables for
 external APIs; those requirements belong in the relevant skill docs and the
 repository README when broadly useful.
+
+`tiangong-kb-ingest` is a thin orchestration Skill over an exact published
+Tiangong CLI. Its offline contract rejects stale or inconsistent CLI literals;
+its explicit networked install smoke exercises both copy and symlink installs,
+then verifies the exact CLI version, KB help surface, and a credential-free
+local bulk scan without contacting the backend.
 
 `tiangong-auto-research` documents both the interactive setup Wizard and the
 CLI-owned declarative path. Its references explain fixed workspace-local YAML

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: b6654fa5fd942c48f2aa1ed99a92373a7304a3d2
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # Skills Repository Contract
@@ -81,6 +81,8 @@ assets, generated `agents/**` files, or marketplace metadata require review of:
 - For skill changes, run the applicable `skill-creator` validation workflow,
   including `scripts/quick_validate.py <skill-path>` from the `skill-creator`
   skill when available.
+- When a Skill changes an exact external CLI pin, add or update an offline
+  stale-pin contract and run its clean temporary install/command-surface smoke.
 - For `tsinghua-graduate-thesis` PDF renderer changes, preserve the privacy-safe
   embedded Adobe-GB1 binary fixture, observe the behavior regression in its
   targeted clean container, and turn it green in a separate container. The

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: 8f04a2559a51fad8f7061ecc1d0ad853e01ddea0
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # Skills Development Runbook
@@ -50,6 +50,20 @@ For skill changes, run the validator required by `AGENTS.md` from the
 ```bash
 scripts/quick_validate.py <skill-path>
 ```
+
+For a `tiangong-kb-ingest` exact CLI pin change, run the offline stale-pin
+contract and then the explicit networked copy/symlink install smoke:
+
+```bash
+python3 -m unittest discover -s tiangong-kb-ingest/scripts/tests -v
+TIANGONG_KB_INGEST_RUN_INSTALL_SMOKE=1 \
+  python3 -m unittest discover -s tiangong-kb-ingest/scripts/tests -v
+```
+
+The install smoke uses a temporary project and HOME, runs the repository-
+standard exact `skills` installer, verifies the installed Skill files, and
+invokes only CLI version/help plus a local bulk scan. It must not receive KB
+credentials or contact the backend.
 
 For `tsinghua-graduate-thesis` PDF renderer or visual-QA behavior, write the
 real-PDF regression first and run each phase through the targeted entrypoint:

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-19
-lastReviewedCommit: d7978275855c67158e08cc21e49dc6e2b43878d5
+lastReviewedAt: 2026-08-20
+lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
 ---
 
 # Skills Documentation Standards

--- a/scripts/run-auto-research-tests.sh
+++ b/scripts/run-auto-research-tests.sh
@@ -20,6 +20,7 @@ node tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
 sh tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
 node --test tsinghua-graduate-thesis/scripts/tests/*.test.mjs
 python3 -m unittest discover -s academic-paper-download/scripts/tests -v
+python3 -m unittest discover -s tiangong-kb-ingest/scripts/tests -v
 bash tiangong-kb-sci-search/scripts/test-sci-search.sh
 bash tiangong-kb-report-search/scripts/test-report-search.sh
 bash tiangong-kb-patent-search/scripts/test-patent-search.sh

--- a/tiangong-kb-ingest/SKILL.md
+++ b/tiangong-kb-ingest/SKILL.md
@@ -7,7 +7,7 @@ description: Upload local files or folders into Tiangong KB through the Tiangong
 
 ## Boundary
 
-Use the Tiangong AI CLI for execution through `npx @tiangong-ai/cli@0.0.19` by default, so users do not need a preinstalled CLI. The agent may orchestrate CLI schema, scan, metadata dry-run, and bulk commands, but it must not call backend databases or storage systems directly.
+Use the Tiangong AI CLI through the exact reviewed entrypoint `npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai` by default, so users do not need a preinstalled CLI. The agent may orchestrate CLI schema, scan, metadata dry-run, and bulk commands, but it must not call backend databases or storage systems directly.
 
 CLI-owned behavior:
 
@@ -42,15 +42,15 @@ Skill-owned behavior:
    - for a folder, read `.env` from that folder
    - loaded dotenv values fill only unset environment variables; explicit user
      inputs passed as CLI flags take precedence
-4. For a first check, run `npx @tiangong-ai/cli@0.0.19 kb collections list --json`.
+4. For a first check, run `npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb collections list --json`.
 5. For bulk/upload runs without `--metadata-map`, generate `metadata-map.yaml`:
    - call CLI collection schema through the Tiangong KB ingest API
    - call CLI bulk scan for folder structure
    - write a layered metadata map with base filesystem fields plus conservative domain/detector rules
    - run CLI metadata dry-run against the generated map
-6. Ingest with `npx @tiangong-ai/cli@0.0.19 kb ingest bulk <path> --json`; pass `--metadata-map metadata-map.yaml` unless a metadata map is already provided or the user explicitly asks to skip metadata-map generation.
+6. Ingest with `npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest bulk <path> --json`; pass `--metadata-map metadata-map.yaml` unless a metadata map is already provided or the user explicitly asks to skip metadata-map generation.
 7. For long runs, tune `--window-size`, `--top-up-max`, `--upload-concurrency`, `--retries`, and `--state`; do not add `--max-polls` unless the user explicitly wants a bounded monitoring run.
-8. If the user asks to verify later state, use `npx @tiangong-ai/cli@0.0.19 kb ingest status <document-id-or-job-id> --json`.
+8. If the user asks to verify later state, use `npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest status <document-id-or-job-id> --json`.
 9. Report only current CLI output and backend response fields. Do not infer success from direct database queries.
 
 ## Metadata Map Minimum
@@ -95,9 +95,9 @@ value, `0` for numbers, `false` for booleans, `1970-01-01` for dates, and
 Validate before upload:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb ingest bulk scan /path/to/folder --json
-npx @tiangong-ai/cli@0.0.19 kb collections schema --collection-key course/thu_humanities --json
-npx @tiangong-ai/cli@0.0.19 kb ingest metadata dry-run /path/to/folder --metadata-map metadata-map.yaml --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest bulk scan /path/to/folder --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb collections schema --collection-key course/thu_humanities --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest metadata dry-run /path/to/folder --metadata-map metadata-map.yaml --json
 ```
 
 For offline validation with a captured schema, pass
@@ -108,43 +108,43 @@ For offline validation with a captured schema, pass
 Upload one file:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/document.pdf --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest bulk /path/to/document.pdf --json
 ```
 
 Upload a folder:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/folder --upload-concurrency 3 --retries 3 --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest bulk /path/to/folder --upload-concurrency 3 --retries 3 --json
 ```
 
 Use an existing metadata map:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/folder --metadata-map metadata-map.yaml --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest bulk /path/to/folder --metadata-map metadata-map.yaml --json
 ```
 
 Use a metadata map saved at a specific path:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb ingest bulk /path/to/folder --metadata-map course-map.yaml --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest bulk /path/to/folder --metadata-map course-map.yaml --json
 ```
 
 List uploadable collections:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb collections list --capability upload --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb collections list --capability upload --json
 ```
 
 Read a collection schema through the API:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb collections schema --collection-key course/thu_humanities --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb collections schema --collection-key course/thu_humanities --json
 ```
 
 Check document status:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 kb ingest status <document-id> --json
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb ingest status <document-id> --json
 ```
 
 ## Result Interpretation

--- a/tiangong-kb-ingest/references/env.md
+++ b/tiangong-kb-ingest/references/env.md
@@ -1,6 +1,6 @@
 # Environment
 
-The skill invokes the Tiangong AI CLI with `npx @tiangong-ai/cli@0.0.19` by default. The CLI calls the Tiangong KB ingest API and authenticates with an API key sent as `Authorization: Bearer <token>`.
+The skill invokes the Tiangong AI CLI with the exact reviewed entrypoint `npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai` by default. The CLI calls the Tiangong KB ingest API and authenticates with an API key sent as `Authorization: Bearer <token>`.
 
 For local file or folder uploads, load dotenv defaults from the target path
 directory before invoking the CLI: use the parent directory for a file and the
@@ -43,8 +43,25 @@ TIANGONG_AI_CLI_BIN=/absolute/path/to/tiangong-ai
 `TIANGONG_KB_API_KEY` is accepted as a fallback alias for `TIANGONG_AI_API_KEY`.
 
 `TIANGONG_AI_CLI_BIN` is optional. Set it only when intentionally overriding the
-default `npx @tiangong-ai/cli@0.0.19` entrypoint with a local or pinned
-`tiangong-ai` executable.
+default `npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai`
+entrypoint with a local or pinned `tiangong-ai` executable.
+
+## Install And Compatibility Smoke
+
+`npx skills add` installs or links the Skill files; it does not install the
+Tiangong CLI globally. After installing this Skill, verify the reviewed package
+and credential-free KB command surface explicitly:
+
+```bash
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai --version
+npx --yes --package "@tiangong-ai/cli@0.0.48" -- tiangong-ai kb --help
+```
+
+The first command must print `0.0.48`. The help command must list bulk scan,
+metadata dry-run, collection list/schema, ingest, and status commands. These
+checks do not require an API key and do not contact or mutate the KB backend.
+The exact version is intentionally fixed to the tested distribution; update it
+only with the corresponding install and command-surface smoke.
 
 Bulk ingest stores local checkpoint state in SQLite under the CLI app-data job
 directory unless `--state` is provided. It has no client-side polling limit by

--- a/tiangong-kb-ingest/scripts/tests/test_cli_compatibility.py
+++ b/tiangong-kb-ingest/scripts/tests/test_cli_compatibility.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_REPOSITORY = SKILL_ROOT.parent
+EXPECTED_CLI_VERSION = "0.0.48"
+EXPECTED_ENTRYPOINT = (
+    f'npx --yes --package "@tiangong-ai/cli@{EXPECTED_CLI_VERSION}" -- tiangong-ai'
+)
+PIN_PATTERN = re.compile(r"@tiangong-ai/cli@([0-9]+\.[0-9]+\.[0-9]+)")
+RUN_INSTALL_SMOKE = os.environ.get("TIANGONG_KB_INGEST_RUN_INSTALL_SMOKE") == "1"
+
+
+class CliPinContractTests(unittest.TestCase):
+    def test_every_runtime_literal_uses_the_reviewed_exact_cli(self) -> None:
+        for relative in ("SKILL.md", "references/env.md"):
+            text = (SKILL_ROOT / relative).read_text(encoding="utf-8")
+            versions = PIN_PATTERN.findall(text)
+            self.assertGreater(len(versions), 0, relative)
+            self.assertEqual(set(versions), {EXPECTED_CLI_VERSION}, relative)
+            self.assertIn(EXPECTED_ENTRYPOINT, text, relative)
+
+    def test_removed_cli_pin_is_absent_from_the_installed_surface(self) -> None:
+        for relative in ("SKILL.md", "references/env.md"):
+            text = (SKILL_ROOT / relative).read_text(encoding="utf-8")
+            self.assertNotIn("@tiangong-ai/cli@0.0.19", text, relative)
+
+
+@unittest.skipUnless(
+    RUN_INSTALL_SMOKE, "set TIANGONG_KB_INGEST_RUN_INSTALL_SMOKE=1"
+)
+class InstalledSkillSmokeTests(unittest.TestCase):
+    def test_npx_copy_and_symlink_installs_run_exact_cli_smoke(self) -> None:
+        if not shutil.which("npx"):
+            self.skipTest("npx is not installed")
+
+        with tempfile.TemporaryDirectory() as cache:
+            for install_mode in ("copy", "symlink"):
+                with (
+                    self.subTest(install_mode=install_mode),
+                    tempfile.TemporaryDirectory() as consumer,
+                ):
+                    consumer_root = Path(consumer)
+                    home = consumer_root / "home"
+                    home.mkdir(mode=0o700)
+                    subprocess.run(["git", "init", "-q"], cwd=consumer, check=True)
+                    environment = {
+                        **os.environ,
+                        "CI": "1",
+                        "HOME": str(home),
+                        "NO_COLOR": "1",
+                        "npm_config_cache": cache,
+                    }
+                    for name in (
+                        "TIANGONG_AI_API_KEY",
+                        "TIANGONG_KB_API_KEY",
+                        "TIANGONG_KB_API_BASE_URL",
+                        "TIANGONG_KB_DEFAULT_COLLECTION_NAME",
+                    ):
+                        environment.pop(name, None)
+
+                    install = [
+                        "npx",
+                        "--yes",
+                        "skills@1.5.22",
+                        "add",
+                        str(SKILLS_REPOSITORY),
+                        "--skill",
+                        "tiangong-kb-ingest",
+                        "--agent",
+                        "codex",
+                        "--yes",
+                    ]
+                    if install_mode == "copy":
+                        install.append("--copy")
+                    self.run_command(install, consumer_root, environment)
+
+                    installed = (
+                        consumer_root / ".agents" / "skills" / "tiangong-kb-ingest"
+                    )
+                    for relative in (
+                        "SKILL.md",
+                        "agents/openai.yaml",
+                        "references/env.md",
+                    ):
+                        self.assertTrue((installed / relative).is_file(), relative)
+                    installed_skill = (installed / "SKILL.md").read_text(
+                        encoding="utf-8"
+                    )
+                    installed_environment = (installed / "references/env.md").read_text(
+                        encoding="utf-8"
+                    )
+                    for installed_text in (installed_skill, installed_environment):
+                        self.assertIn(EXPECTED_ENTRYPOINT, installed_text)
+                        self.assertNotIn("@tiangong-ai/cli@0.0.19", installed_text)
+
+                    cli = [
+                        "npx",
+                        "--yes",
+                        "--package",
+                        f"@tiangong-ai/cli@{EXPECTED_CLI_VERSION}",
+                        "--",
+                        "tiangong-ai",
+                    ]
+                    version = self.run_command(
+                        [*cli, "--version"], consumer_root, environment
+                    )
+                    self.assertEqual(version.stdout.strip(), EXPECTED_CLI_VERSION)
+
+                    help_result = self.run_command(
+                        [*cli, "kb", "--help"], consumer_root, environment
+                    )
+                    for command in (
+                        "kb ingest bulk",
+                        "kb ingest bulk scan",
+                        "kb ingest metadata dry-run",
+                        "kb ingest status",
+                        "kb collections list",
+                        "kb collections schema",
+                    ):
+                        self.assertIn(command, help_result.stdout)
+
+                    documents = consumer_root / "documents"
+                    documents.mkdir()
+                    (documents / "sample.txt").write_text(
+                        "offline install smoke\n", encoding="utf-8"
+                    )
+                    scan = self.run_command(
+                        [
+                            *cli,
+                            "kb",
+                            "ingest",
+                            "bulk",
+                            "scan",
+                            str(documents),
+                            "--json",
+                        ],
+                        consumer_root,
+                        environment,
+                    )
+                    self.assertIsInstance(json.loads(scan.stdout), dict)
+
+    def run_command(
+        self, command: list[str], cwd: Path, environment: dict[str, str]
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            env=environment,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #80

## Summary
- replace every tiangong-kb-ingest runtime pin from CLI 0.0.19 with the exact published CLI 0.0.48 package/bin entrypoint
- add offline stale-pin coverage and a real npx skills copy/symlink install smoke
- document the install command, post-install compatibility check, and future exact-pin validation rule

## Key Decisions
- keep an exact reviewed CLI version; do not use latest, a tag, or a semver range at runtime
- use the explicit npx --package / tiangong-ai bin form so scoped-package resolution is deterministic and noninteractive
- keep the networked install smoke opt-in and run only pin contracts in the runtime-network-disabled clean container
- install smoke receives no KB credential: it checks CLI version, the aggregate KB help surface, and a local bulk scan only

## Validation
- regression before implementation: two targeted tests failed on 0.0.19 as expected
- python3 -m unittest discover -s tiangong-kb-ingest/scripts/tests -v: pass, 2 offline contracts; 1 explicit network smoke skip
- TIANGONG_KB_INGEST_RUN_INSTALL_SMOKE=1 python3 -m unittest discover -s tiangong-kb-ingest/scripts/tests -v: pass, copy and symlink installs, exact CLI version/help/local scan
- skill-creator quick_validate.py tiangong-kb-ingest: pass
- scripts/test-clean-container.sh --cold-build: pass, including routing/runtime/Policy suites, 12 thesis tests, 76 academic-download tests, KB ingest pin contracts, and SCI/report/patent wrappers
- docpact 0.1.9 strict config and staged lint: pass, zero findings
- git diff --check: pass

## Risks / Rollback
- users invoking this Skill will download CLI 0.0.48 instead of 0.0.19; the documented KB command surface was verified from the installed exact package
- revert this PR to restore the former pin and remove the compatibility smoke

## Follow-ups
- none; staged KB pipeline controls remain intentionally not planned under closed #34

## Workspace Integration
- Required after merge. Root workspace must pin the exact Skills merge commit and pass the combined cold-container and docpact gates.