### PR TITLE
fix(document-decompose): normalize escaped underscores

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-20"
-lastReviewedCommit: "eddfc711e8c86270412e161cc489fde6d2015fb4"
+lastReviewedCommit: "2bbdba83e9c1d2ef101fef82317d63ed826c5746"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -18,7 +18,7 @@ checkPaths:
   - scripts/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-08-20
-lastReviewedCommit: eddfc711e8c86270412e161cc489fde6d2015fb4
+lastReviewedCommit: 2bbdba83e9c1d2ef101fef82317d63ed826c5746
 ---
 
 # Skills Documentation Standards

--- a/document-granular-decompose/SKILL.md
+++ b/document-granular-decompose/SKILL.md
@@ -70,6 +70,8 @@ python3 scripts/mineru_fulltext_extract.py \
 
 ## Output Rules
 - Success output must be plain text fulltext only.
+- Normalize the confirmed upstream Markdown underscore escape (`\_` to `_`)
+  in both supported response paths; preserve other backslashes and escapes.
 - Fulltext source priority:
   1. `response.txt`
   2. join non-empty `response.result[].text` by blank lines

--- a/document-granular-decompose/scripts/mineru_fulltext_extract.py
+++ b/document-granular-decompose/scripts/mineru_fulltext_extract.py
@@ -197,6 +197,11 @@ def parse_api_error(error: HTTPError) -> str:
     return f"HTTP {error.code}: {payload}"
 
 
+def normalize_plain_fulltext(value: str) -> str:
+    """Normalize the confirmed Markdown underscore escape in plain-text output."""
+    return value.replace("\\_", "_")
+
+
 def request_fulltext(
     api_url: str,
     file_path: Path,
@@ -243,7 +248,7 @@ def request_fulltext(
 
     txt = payload.get("txt")
     if isinstance(txt, str) and txt.strip():
-        return txt.strip()
+        return normalize_plain_fulltext(txt.strip())
 
     result = payload.get("result")
     if isinstance(result, list):
@@ -252,7 +257,7 @@ def request_fulltext(
             if isinstance(item, dict):
                 text = item.get("text")
                 if isinstance(text, str) and text.strip():
-                    chunks.append(text.strip())
+                    chunks.append(normalize_plain_fulltext(text.strip()))
         if chunks:
             return "\n\n".join(chunks)
 

--- a/document-granular-decompose/scripts/tests/test_mineru_fulltext_extract.py
+++ b/document-granular-decompose/scripts/tests/test_mineru_fulltext_extract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "mineru_fulltext_extract.py"
+SPEC = importlib.util.spec_from_file_location("mineru_fulltext_extract", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class FulltextNormalizationTests(unittest.TestCase):
+    def request_text(self, payload: dict[str, object]) -> str:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "source.pdf"
+            source.write_bytes(b"fixture")
+            with mock.patch.object(MODULE.request, "urlopen", return_value=FakeResponse(payload)):
+                return MODULE.request_fulltext(
+                    api_url="https://unstructure.example/mineru_with_images",
+                    file_path=source,
+                    token="test-token",
+                    provider=None,
+                    model=None,
+                    timeout=1,
+                    insecure=False,
+                )
+
+    def test_direct_txt_normalizes_escaped_underscores_only(self) -> None:
+        actual = self.request_text(
+            {"txt": r"UNSTRUCTURE\_CANARY\_42 keeps C:\notes and \*literal\*"}
+        )
+
+        self.assertEqual(actual, r"UNSTRUCTURE_CANARY_42 keeps C:\notes and \*literal\*")
+
+    def test_result_chunks_normalize_escaped_underscores(self) -> None:
+        actual = self.request_text(
+            {
+                "result": [
+                    {"text": r"first\_field"},
+                    {"text": "second_field"},
+                    {"metadata": "ignored"},
+                ]
+            }
+        )
+
+        self.assertEqual(actual, "first_field\n\nsecond_field")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run-auto-research-tests.sh
+++ b/scripts/run-auto-research-tests.sh
@@ -20,6 +20,7 @@ node tiangong-auto-research/scripts/test-evidence-exhaustion-contract.mjs
 sh tiangong-auto-research/scripts/test-agent-wrapper-posix.sh
 node --test tsinghua-graduate-thesis/scripts/tests/*.test.mjs
 python3 -m unittest discover -s academic-paper-download/scripts/tests -v
+python3 -m unittest discover -s document-granular-decompose/scripts/tests -v
 python3 -m unittest discover -s tiangong-kb-ingest/scripts/tests -v
 bash tiangong-kb-sci-search/scripts/test-sci-search.sh
 bash tiangong-kb-report-search/scripts/test-report-search.sh


### PR DESCRIPTION
Part of tiangong-ai/workspace#176

## Summary
- normalize the confirmed upstream Markdown underscore escape in both supported Unstructure full-text response paths
- add hermetic direct/fallback regressions to the authoritative Auto Research clean-container suite
- document the intentionally narrow normalization contract

## Key Decisions
- Only `\_` becomes `_`; paths, other backslashes, and escapes such as `\*` remain byte-for-byte unchanged.
- The regression runs in the repository-wide clean-container entrypoint rather than relying on a host-only script test.
- The Skill trigger description is unchanged, so generated `agents/openai.yaml` metadata does not need regeneration.

## Validation
- RED: `scripts/test-clean-container.sh` failed exactly the two new assertions in a fresh container.
- GREEN: `scripts/test-clean-container.sh` passed in a second fresh container.
- Release gate: `scripts/test-clean-container.sh --cold-build` passed.
- `quick_validate.py document-granular-decompose` passed using an isolated validator environment with PyYAML 6.0.3.
- `docpact validate-config --root . --strict` passed.
- `docpact lint --root . --staged --format json --output .docpact/runs/latest.json` passed after recording completed review evidence.
- `git diff --check` passed.

## Risks / Rollback
- Risk is limited to literal backslash-underscore sequences returned as full text. Roll back this commit to restore prior preservation.
- No external service, credential, dependency, or installation behavior changed.

## Follow-ups
- The CLI companion/runtime and authoring-readiness fixes remain tracked in workspace#176 and will pin this merged Skills content before release.

## Workspace Integration
- Required after the related CLI patch is merged and published; root workspace will pin both exact child commits and record release facts.
