### PR TITLE
Add minimal Auto Research research-question gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-22"
-lastReviewedCommit: "1c0e4b9aba85ebba7c60e760b22cdc6ebf2927f4"
+lastReviewedAt: "2026-09-01"
+lastReviewedCommit: "4104e527facd09ecc242dad7a1e9645adf9d21f0"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 1c0e4b9aba85ebba7c60e760b22cdc6ebf2927f4
+lastReviewedAt: 2026-09-01
+lastReviewedCommit: 4104e527facd09ecc242dad7a1e9645adf9d21f0
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ tag, or a range. After apply creates `runtime-lock.json`, the installed
 orchestrator's bundled resolver runs exactly that locked version for all
 workspace operations.
 
+The orchestrator gates a research question before setup or any tool call. A
+request that presupposes its conclusion or excludes contrary evidence is
+paused with one testable rewrite and resumes only after explicit user
+confirmation. Controversial topics and directional hypotheses remain allowed
+when null results, alternatives, and counterevidence are testable; evidence
+fabrication or concealment is refused.
+
 The catalog also offers the `tiangong-auto-research` workflow orchestrator,
 default-baseline Brave internet evidence, optional Tiangong SCI/document/paper
 companions, and optional Anthropic or PPT Master post-closure authoring Skills.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,6 +151,11 @@ bootstrap 版本是新 workspace 的显式选择，不得使用 `latest`、tag �
 apply 创建 `runtime-lock.json` 后，已安装 orchestrator 的内置 resolver 会让
 所有 workspace 操作只运行该锁定版本。
 
+orchestrator 会在 setup 或任何工具调用之前先检查研究问题。预设结论或排除反证的
+请求会被暂停，并给出一个可检验的改写版本；只有用户明确确认后才继续。争议性主题和
+方向性假设只要仍允许零结果、替代解释和反面证据，就不会因为“有立场”而被拒绝；
+伪造或隐瞒证据的请求会被拒绝。
+
 目录还提供 `tiangong-auto-research` 工作流 orchestrator、默认基线 Brave
 互联网证据能力、可选的 Tiangong SCI/文档解析/论文获取 companion，以及可选的
 Anthropic 或 PPT Master 闭环后创作 Skills。workspace 可以是用户指定的任意目录。

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 1c0e4b9aba85ebba7c60e760b22cdc6ebf2927f4
+lastReviewedAt: 2026-09-01
+lastReviewedCommit: 4104e527facd09ecc242dad7a1e9645adf9d21f0
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -59,6 +59,12 @@ interactive fallback after a declaration error, and complete-readiness gating.
 The Skill does not duplicate the closed YAML schema or parse configuration; the
 CLI-generated template and validator remain authoritative.
 
+The canonical Skill also owns the native-host research-question gate. It runs
+before setup or tool use, pauses conclusion-presupposing or
+counterevidence-excluding requests with one testable rewrite, and waits for the
+user. The CLI may install and verify host routing instructions, but it does not
+implement a model-driven bias classifier.
+
 `tiangong-auto-research/assets/research-policy/defaults/**` is the versioned,
 generic source pack for top-journal Policy initialization. It is immutable
 source material, not a user Policy or journal endorsement. The CLI copies a

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -56,6 +56,12 @@ marketplace grouping metadata.
   mechanical gates, reviewer-family/session enforcement, lifecycle budgets,
   authoritative generations, and semantic portable-audit verification to the
   CLI.
+- Research-question framing remains a native Skill decision before any tool
+  call. It may pause a conclusion-presupposing request and propose a testable
+  rewrite, but it must not reject controversial or directional hypotheses that
+  retain null, alternative, and counterevidence tests. The CLI owns only
+  project instruction installation and verification, not semantic bias
+  classification.
 - Sandboxed-IDE adapters must remain thin routers to the canonical
   `tiangong-auto-research` Skill. They must preserve Default Permission, record
   WorkBuddy/CodeBuddy honestly as the native producer, require an explicit

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 1c0e4b9aba85ebba7c60e760b22cdc6ebf2927f4
+lastReviewedAt: 2026-09-01
+lastReviewedCommit: 4104e527facd09ecc242dad7a1e9645adf9d21f0
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-08-22
-lastReviewedCommit: 1c0e4b9aba85ebba7c60e760b22cdc6ebf2927f4
+lastReviewedAt: 2026-09-01
+lastReviewedCommit: 4104e527facd09ecc242dad7a1e9645adf9d21f0
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -5,6 +5,27 @@ description: Orchestrate open-ended, multi-source, evidence-backed research in t
 
 # Tiangong Auto Research
 
+## Gate the research question before acting
+
+Before any CLI, browser, search, database, or file operation, inspect the
+user's research request. Continue when it leaves the result open to evidence.
+Pause and require a rewrite when it assumes the conclusion, asks to prove a
+predetermined position, requests only supporting evidence, excludes contrary
+evidence, or treats an unsupported causal or normative judgment as fact.
+
+When paused:
+
+1. Do not call tools or begin setup.
+2. Identify the problematic assumption in one concise sentence.
+3. Offer one testable rewrite that preserves the intended topic, scope,
+   population, geography, and time period.
+4. Wait for the user's explicit confirmation or edited question.
+
+Do not reject a controversial topic or directional hypothesis merely because
+it has a position. It may proceed when null results, alternative explanations,
+and counterevidence remain testable. Refuse requests to fabricate, conceal, or
+misrepresent evidence.
+
 For an existing managed directory, use the bundled resolver for every CLI operation.
 Resolve `AUTO_RESEARCH_CLI` from this loaded Skill's absolute directory; do not
 guess a global Skill path. The resolver accepts only the CLI package and exact

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -175,6 +175,9 @@ The Wizard then guides the user through:
   media profiles are visibly marked subscription-dependent;
 - explicit project-local installation of the `tiangong-auto-research`
   orchestrator (recommended) so normal research requests enter this workflow;
+- project-scoped host routing bound into the reviewed plan: one managed Codex
+  block in the workspace-root `AGENTS.md` and one dedicated Claude rule under
+  `.claude/rules/`, without replacing owner instructions;
 - optional Tiangong companions and post-closure authoring Skills; for PPT
   creation it presents PPT Master as preferred while keeping Anthropic PPTX as
   a compatible situational choice;
@@ -188,6 +191,15 @@ The Wizard then guides the user through:
   and separately authorized paid agent smoke checks;
 - a full plan preview, network confirmation, immutable plan creation, and
   optional apply.
+
+Project instruction routing is installed only when the orchestrator and
+project scope are selected. Conflicting, modified, linked, or otherwise unsafe
+targets stop before mutation. A replacement plan removes only bytes still
+proven to be setup-owned. Global Skill scope does not write project instruction
+files. After apply, start a new native-host session: Codex and Claude Code load
+project instructions at session startup, while WorkBuddy/CodeBuddy continue to
+use the separately installed thin adapter Skill rather than an assumed private
+instruction filename.
 
 Apply defaults to yes after all required values are available. Secure/stdin
 values live only for that apply, are persisted to the existing owner-only store
@@ -274,7 +286,9 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
 
 Static doctor checks installed tree hashes, required settings, owner-only
 credential stores, Node/git/npx, the reviewer sandbox/CLI, Python, and pinned
-Python requirements. `--live` uses provider network/quota. A synthetic document
+Python requirements. It also verifies each planned project instruction target;
+structural success is reported separately from the required new-session
+activation. `--live` uses provider network/quota. A synthetic document
 upload also requires `--allow-synthetic-unstructure-upload`; reviewer smoke
 requires `--agent-smoke --confirm-agent-smoke-cost`. Doctor does not launch the
 native producer. It probes a required capability only once and skips the paid

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -50,6 +50,37 @@ const sandboxedIdeReference = await readFile(
   "utf8",
 );
 
+const questionGateHeading = "## Gate the research question before acting";
+const questionGateIndex = autoResearchSkill.indexOf(questionGateHeading);
+const firstManagedCommandIndex = autoResearchSkill.indexOf(
+  "For an existing managed directory",
+);
+assert.ok(questionGateIndex > 0, "Auto Research must define the research-question gate");
+assert.ok(
+  questionGateIndex < firstManagedCommandIndex,
+  "The research-question gate must run before setup, resolver, or other tool instructions",
+);
+const normalizedQuestionGate = autoResearchSkill
+  .slice(questionGateIndex, firstManagedCommandIndex)
+  .toLowerCase()
+  .replace(/\s+/g, " ");
+for (const marker of [
+  "before any cli, browser, search, database, or file operation",
+  "do not call tools or begin setup",
+  "one testable rewrite",
+  "explicit confirmation",
+  "directional hypothesis",
+  "null results",
+  "alternative explanations",
+  "counterevidence",
+  "fabricate, conceal, or misrepresent evidence",
+]) {
+  assert.ok(
+    normalizedQuestionGate.includes(marker),
+    `Research-question gate must preserve the observable behavior: ${marker}`,
+  );
+}
+
 for (const marker of [
   ".tiangong-research/setup.yaml",
   "research setup init",


### PR DESCRIPTION
## Summary

- gate Auto Research questions before setup or tool use;
- pause conclusion-presupposing or counterevidence-excluding requests with one testable rewrite;
- wait for explicit user confirmation while preserving legitimate controversial and directional hypotheses;
- refuse evidence fabrication or concealment;
- document the behavior in English/Chinese setup surfaces and lock its ordering in the routing contract.

## Validation

- clean-container RED observed before implementation;
- `scripts/test-clean-container.sh` passed;
- `scripts/test-clean-container.sh --cold-build` passed;
- `quick_validate.py` passed for the canonical and WorkBuddy adapter Skills;
- docpact 0.1.9 strict config and worktree lint passed;
- `git diff --check` passed.

## Risk and rollback

The change is instruction-only and performs no runtime/model call. False-positive risk is bounded by requiring a rewrite rather than rejecting controversial research, and by explicitly permitting falsifiable directional hypotheses. Roll back this commit to restore the prior entry behavior.

Closes #89.
