### PR TITLE
Guide efficient and recoverable Auto Research lifecycle

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-01"
-lastReviewedCommit: "4e22640981bca2c037dae31f47666400afefab5c"
+lastReviewedAt: "2026-09-02"
+lastReviewedCommit: "5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # Tiangong AI Skills
@@ -195,6 +195,12 @@ tag, or a range. After apply creates `runtime-lock.json`, the installed
 orchestrator's bundled resolver runs exactly that locked version for all
 workspace operations.
 
+For acquisition-heavy work, the orchestrator uses the CLI's read-only artifact
+size and role-coverage forecasts, bounded atomic content batches, and explicit
+prepared scientific-review execution. Recovery reuses verified discovery and
+downloaded artifacts in a reviewed successor; it never edits frozen history or
+silently changes scientific requirements to make a gate pass.
+
 The orchestrator gates a research question before setup or any tool call. A
 request that presupposes its conclusion or excludes contrary evidence is
 paused with one testable rewrite and resumes only after explicit user
@@ -235,9 +241,9 @@ Before discovery, the current native Codex or Claude host must also provide a
 closed, target-specific scientific design. The CLI validates and freezes the
 design. Frozen model implementations and environment locks must first enter the
 workspace through `research scientific object register`; the Skill never asks
-the user to hand-copy them into `.tiangong-research`. The CLI then enforces independent `research-design`, real-record
-`evidence-construct`, and `pilot-methods` reviews before discovery, acquisition,
-and analysis respectively. After acquisition it also requires exact
+the user to hand-copy them into `.tiangong-research`. The CLI requires independent
+`research-design` review before discovery, then real-record `evidence-construct`
+and `pilot-methods` reviews after acquisition and before analysis. After acquisition it also requires exact
 decomposition records, evidence atoms, a typed-content snapshot, a passing
 inference snapshot, a reproduced analysis, and a mechanically generated
 Claim-Evidence Graph. Publication freeze requires the complete manuscript

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # 天工 AI Skills
@@ -177,6 +177,10 @@ bootstrap 版本是新 workspace 的显式选择，不得使用 `latest`、tag �
 apply 创建 `runtime-lock.json` 后，已安装 orchestrator 的内置 resolver 会让
 所有 workspace 操作只运行该锁定版本。
 
+资料较多时，orchestrator 使用 CLI 的只读文件大小预检、角色覆盖预测、有界原子
+批量登记与显式科学评审执行。恢复时在经审阅的后继项目中复用已验证的 discovery
+和下载文件，不修改冻结历史，也不为通过门禁而偷偷降低科学要求。
+
 orchestrator 会在 setup 或任何工具调用之前先检查研究问题。预设结论或排除反证的
 请求会被暂停，并给出一个可检验的改写版本；只有用户明确确认后才继续。争议性主题和
 方向性假设只要仍允许零结果、替代解释和反面证据，就不会因为“有立场”而被拒绝；
@@ -208,8 +212,9 @@ Policy Wizard 会把所选 Markdown 复制到研究 workspace 供人类审阅；
 
 在 discovery 之前，当前原生 Codex、Claude、WorkBuddy 或 CodeBuddy host 还必须给出封闭、目标特定的科学
 设计。冻结的模型实现和环境锁必须先通过 `research scientific object register`
-进入 workspace；Skill 不会要求用户手工把文件写入 `.tiangong-research`。CLI 只负责验证和冻结设计，并依次在 discovery、acquisition、analysis 前强制
-独立的 `research-design`、真实记录 `evidence-construct`、`pilot-methods` 审查。
+进入 workspace；Skill 不会要求用户手工把文件写入 `.tiangong-research`。CLI 只负责
+验证和冻结设计：discovery 前进行独立 `research-design` 审查；acquisition 完成后、
+analysis 前依次进行真实记录 `evidence-construct` 和 `pilot-methods` 审查。
 acquisition 后还必须完成逐文件拆解、精确 evidence atom、typed-content snapshot、
 passing inference snapshot、可复现分析和机械生成的 Claim-Evidence Graph。投稿冻结
 要求完整论文章节及显式的 cover/title/checklist/data/code/source-data 文件；四个终稿

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # Skills Repository Architecture
@@ -85,6 +85,14 @@ defaults only. The CLI owns schemas, hashing, stage admission, mechanical
 evaluation, lifecycle reservations, other-family reviewer isolation, and
 semantic audit verification; the configured native Codex, Claude, WorkBuddy,
 or CodeBuddy host remains the scientific producer.
+
+Large evidence sets use the CLI's optional pre-freeze role forecast and bounded
+atomic decomposition/atom batches. File-size preflight distinguishes an
+artifact ceiling from aggregate output limits. Prepared scientific reviews use
+the configured isolated transport through an explicit cost-confirmed execution
+command; recovery reuses exact discovery/artifact bytes in a reviewed successor.
+These recipes do not duplicate schema evaluators or add per-record verification
+loops to the Skill.
 
 `tiangong-auto-research-workbuddy` is a thin sandboxed-IDE adapter. It routes
 WorkBuddy/CodeBuddy native producer tasks back to the canonical orchestrator and

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: 4e22640981bca2c037dae31f47666400afefab5c
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -324,8 +324,11 @@ full-text/date states from the frozen chain. Pass its exact, external JSON canar
 `--canary-artifacts`; an unbound digest or invented source ID is a mechanical
 failure. Reviewer prose cannot override these failures.
 
-Proceed only when doctor reports ready. Discovery uses only locked broker
-capabilities; later stages are tool-free. Doctor, preflight, dependency,
+Proceed only when doctor reports ready. Discovery uses only locked broker or
+native data evidence capabilities for formal retrieval. Acquisition uses its
+packet-governed download, parsing, and artifact-registration operations;
+analysis, synthesis, and independent review do not acquire additional evidence.
+Doctor, preflight, dependency,
 provider, and evidence-coverage failures must stop the workflow. Never silently
 downgrade a systematic task to a standalone SCI, report, patent, web, or paper
 operation; only the user may explicitly narrow the request to one isolated

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -11,6 +11,11 @@ The sequence is a correctness boundary, not merely a preferred writing style.
 Do not analyze while evidence is still mutable, and do not use analysis to
 decide what the evidence ledger claims was retrieved.
 
+Use these recipes through the workspace-locked runtime. If its help does not
+expose a needed command, request the reviewed setup/CLI upgrade rather than
+switching to a floating version or imitating the operation with control-file
+edits.
+
 ## 1. Define the coverage contract
 
 Before spending provider or model budget, describe the question as reviewed
@@ -18,6 +23,12 @@ evidence requirements: dimensions, source types, required capability IDs,
 required discovery scopes, minimum source/full-text/dated counts, and date
 boundaries. `research project preflight` is authoritative for capability,
 context, reservation, and expected-cost gaps.
+
+For scientific evidence roles, a flat `sourceTypeRequirements` array means
+all-of, not alternatives. When scientifically justified, use the CLI schema's
+explicit `allOf`, `anyOf`, and `atLeast` groups; every supplied group must hold.
+Do not add a required type merely because a search capability is available,
+or relabel a source to satisfy a missing type.
 
 Production requires an independent public-internet capability. Add every
 owner-whitelisted database whose contents matter to the question as an exact
@@ -145,7 +156,22 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 
 After provisional admission, the native `acquire` stage assesses every source
 exactly once. Use selected external acquisition/document Skills or an explicitly
-authorized browser. For every network file, capture the exact browser Download
+authorized browser. Before a large transfer with a known size, use the offline
+preflight; it reads no file body and does not contact a provider:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence artifact preflight --bytes KNOWN_BYTE_COUNT \
+  --workspace /absolute/path/to/workspace --json
+```
+
+The per-artifact limit and aggregate package-output limit are distinct. For a
+local file use `--path /absolute/path/to/exact-file` instead of `--bytes`.
+An oversized file requires a lawful provider-side subset/filter or an explicit
+reviewed size decision, not a blind download, arbitrary chunking, or a skipped
+hash/format check. Size eligibility alone never proves valid file content.
+
+For every network file, capture the exact browser Download
 object or equivalent transport completion, save it to a unique planned staging
 path, and first bind that event through `bindDownload`. A failed or cancelled
 event creates no successful binding and cannot register an artifact. Never scan
@@ -215,6 +241,31 @@ Continue only far enough to decompose everything already acquired and freeze
 the typed-content record; then request the exact access/scope handoff. Never
 report the stopped snapshot as inference-ready.
 
+Use `limitations` for nonblocking qualifications and an intentional outcome
+seal that the current gate permits. `gaps` means unresolved blocking evidence
+deficits; every entry stops inference. Never move a genuine deficit into
+`limitations` just to pass. Later Policy obligations belong in the reviewed
+design's due-gate dispositions, not a second informal to-do list.
+
+Create and register all needed readable derivatives while acquire is active.
+Before final acquisition submission, forecast the proposed audit, especially
+for a top-journal design with role-specific floors:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence content forecast PROJECT \
+  --input /absolute/path/to/acquisition-audit.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+Inspect the exact known source/artifact gaps. A forecast pass means potential
+eligibility, never that atoms, scientific relevance, or an independent review
+already passed. Metadata-only entries cannot stand in for atom-eligible role
+coverage. Run this once per meaningful completed acquisition batch and before
+freezing, not after every small record. Keep acquiring only the explicit gaps
+that remain lawfully actionable; retain an honest stopped audit and hand off
+when the necessary evidence is unavailable.
+
 ## 5. Freeze, then infer
 
 Successful acquisition creates `outputs/evidence-snapshot.json` plus an
@@ -225,10 +276,10 @@ and parent/delta lineage. File existence is not readiness; inspect the semantic
 hash and gate through `research status --json`.
 
 Before any evidence-construct assessment or analysis, disposition every
-acquired full-text/data artifact. Use the installed document/PDF/spreadsheet
-tools to create legitimate producer-readable derivatives, register each exact
-derived artifact with its parent, and record one decomposition object per
-source artifact:
+acquired full-text/data artifact. Readable derivatives must already have been
+registered during acquire and selected in its audit. After acquisition freezes,
+record one decomposition object per source artifact; do not try to register new
+files into the closed acquisition window:
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
@@ -257,7 +308,32 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 ```
 
 Do not paste an invented excerpt or cite only a source-level ID when an exact
-atom is required. Freeze the typed universe only after all acquired artifacts
+atom is required. For many records prefer the bounded atomic batch commands;
+the CLI validates a shared snapshot/artifact view once instead of reloading it
+for every record. Use the CLI-owned record schemas inside a
+`{"schemaVersion":1,"records":[...]}` envelope and the limits returned by help:
+
+Inspect `research schema show evidence-atom-batch --json` or
+`research schema show artifact-decomposition-batch --json` through the same
+locked resolver. The corresponding single-record schema names are
+`evidence-atom` and `artifact-decomposition`. These schemas describe record
+shape; real artifact, stage, lineage, and locator checks still run at admission.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence decomposition batch PROJECT \
+  --record /absolute/path/to/decomposition-batch.json \
+  --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project evidence atom batch PROJECT \
+  --record /absolute/path/to/atom-batch.json \
+  --workspace /absolute/path/to/workspace --json
+```
+
+One invalid item commits none of that batch. Correct that item and replay the
+batch; an identical committed batch is idempotent. Single-record commands remain
+appropriate for one-off additions. Do not launch a second validation loop per
+item after a successful batch. Freeze the typed universe only after all acquired artifacts
 have dispositions and all material claims have atoms:
 
 ```bash
@@ -296,6 +372,15 @@ closure re-verifies all hashes and refuses a missing, changed, or stale
 snapshot, graph, packet, context, receipt, artifact, or source.
 
 ## 6. Refresh through an addendum
+
+If acquire already completed but missing readable artifacts were discovered
+before analysis, use the recovery fork in
+[scientific-design.md](scientific-design.md). `--resume-through discover`
+reuses verified discovery and acquired files while reopening acquire in an
+explicit successor. It does not redo paid search or downloads for unchanged
+bytes. New top-journal Policy/design approval is still required; a content stop
+does not authorize editing old snapshots or repeatedly retrying a complete
+package.
 
 Never mutate a closed project. When material new evidence exists, create a new
 addendum project:

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -20,6 +20,12 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 producer stage. It is not an error and must not trigger a nested `codex exec` or
 `claude -p` call.
 
+`scientific-review-required`, `scientific-revision-required`, and
+`scientific-stopped` are different actions. Inspect the named gate and its
+`recommendedAction`; do not loop on `research run` or prepare a producer stage
+that a due scientific gate prohibits. A future gate does not prevent an
+earlier allowed discover/acquire package.
+
 For a top-journal project, `research status` can instead return a pending
 `research-design`, `evidence-construct`, or `pilot-methods` gate. Complete that
 gate before preparing a native stage. The current native host writes the
@@ -29,8 +35,8 @@ fresh independent review. See [scientific-design.md](scientific-design.md).
 The ordering is deliberate:
 
 ```text
-design review → discover → acquire and freeze evidence
-→ decompose acquired content → register atoms → freeze typed content
+design review → discover → acquire, register readable derivatives, forecast
+→ freeze acquisition → record decompositions/atoms in batches → freeze typed content
 → real-record construct review → outcome-blind methods pilot review
 → freeze inference → analyze → freeze Claim-Evidence Graph → synthesize
 ```
@@ -48,6 +54,10 @@ locks are permitted only until their declared gate and only when an exact
 planned Policy rule owns them. They are not usable results. Freeze replacements
 through a new authoritative generation before the deadline; at the due gate the
 CLI must stop on the corresponding mechanical error.
+
+The same early obligation list includes ordinary planned Policy rules, not just
+model and uncertainty objects. Plan any required successor before its due gate;
+an assessment cannot silently resolve or rewrite the frozen design.
 
 For `evidence-construct`, write one or more bounded JSON canary artifacts outside
 `.tiangong-research`. Put their exact SHA-256 values in the assessment and pass
@@ -144,6 +154,12 @@ content freeze`. Do not leave acquired PDFs, spreadsheets, archives, or
 structured files as unexamined binary attachments. `research status` must show
 the typed content as verified; a stopped content/acquisition gate requires a
 scope/access handoff rather than analysis.
+
+Use the artifact byte preflight and acquisition forecast described in
+[evidence-pipeline.md](evidence-pipeline.md) before final submission. Register
+readable derivatives during the active acquire stage; only decomposition/atom
+records are added after that snapshot freezes. Prefer batch registration when
+there are many records, without repeating full verification for each item.
 
 ## Submit producer output
 

--- a/tiangong-auto-research/references/scientific-design.md
+++ b/tiangong-auto-research/references/scientific-design.md
@@ -158,6 +158,12 @@ error code, exact due gate, object IDs, and owning Policy rule IDs. At the due
 gate the same condition becomes a blocking mechanical error unless a new
 authoritative generation freezes replacement objects.
 
+This list also exposes ordinary `planned` Policy rules with their exact due
+gate. A rule deferred to evidence-construct is not already discharged because
+research-design passed. Resolve it in a reviewed successor before its deadline
+when new design content is required. Do not mark it satisfied with an invented
+assessment or wait until a frozen acquisition makes an avoidable gap costly.
+
 ## Three early scientific gates
 
 `research status` returns the next gate and a safe command. Do not prepare a
@@ -209,10 +215,25 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
   research schema show scientific-review-research-design --json
 
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
-  research project scientific review submit PROJECT \
-  --role research-design --review /absolute/path/to/review.json \
+  research project scientific review execute PROJECT \
+  --role research-design --confirm-review-cost \
   --workspace /absolute/path/to/workspace --json
 ```
+
+Obtain user approval for the bounded reviewer cost before adding
+`--confirm-review-cost`. Execution uses the configured `native-direct` or
+`sandbox-bridge` transport, validates the prepared packet, and records a
+sanitized execution receipt before mechanical submission. It never starts a
+nested producer. Inspect `research reviewer status` for that configured
+transport; a native-direct workspace does not need a bridge sidecar.
+
+An already saved successful execution can be replayed without another model
+call. A failed attempt requires inspection and explicit `--retry` after the
+cause is corrected; do not blindly repeat it. A mechanically nonpassing packet
+can receive an independent stop/handoff verdict, but reviewer prose cannot
+upgrade its evidence. The manual `scientific review submit --review` path
+remains available for an independently produced, exactly bound review; never
+fabricate reviewer output in the producer session.
 
 Repeat with `evidence-construct`, adding
 `--canary-artifacts /absolute/path/to/canary-paths.json`, and then with
@@ -253,6 +274,28 @@ generation starts at the applicable pending gates; a later ready package cannot
 bypass an earlier gate. The source becomes explicitly superseded, the default
 status shows only the authoritative descendant, and `--all` remains the history
 view.
+
+For an acquisition-only correction before analysis, preserve discovery and
+verified acquired artifacts instead of repeating search and download:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research project fork OLD --to NEW --resume-through discover \
+  --design /absolute/path/to/new-scientific-design.json \
+  --design-producer-agent codex \
+  --design-producer-session FRESH_NATIVE_SESSION \
+  --workspace /absolute/path/to/workspace --json
+```
+
+First approve the target-specific Policy and design as required for every
+top-journal successor. The fork retains source download provenance and exact
+artifact bytes, reopens acquire, and keeps old snapshots/reviews immutable.
+Use the successor's status and artifact IDs to select unchanged files in its
+new acquisition audit, then obtain only the missing lawful evidence. Rerun
+typed-content and scientific reviews for that successor; inherited evidence is
+not inherited scientific approval. For an evidence-report project without a
+scientific design, omit the design options. Neither path is an in-place edit of
+the old generation.
 
 Freezing previously pending uncertainty values, executable model bytes, or an
 exact environment lock is a material design change. Create the successor before

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -137,6 +137,8 @@ for (const marker of [
 }
 
 const managedDataGuidance = `${autoResearchSkill}\n${evidencePipelineReference}`;
+assert.doesNotMatch(autoResearchSkill, /later stages are tool-free/u,
+  "Acquisition must retain packet-governed download/parsing operations after discovery");
 assert.match(
   managedDataGuidance,
   /node "\$AUTO_RESEARCH_CLI"[\s\S]*?--[\s\\\n]+data describe <capability-id> --json/,

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -49,6 +49,41 @@ const sandboxedIdeReference = await readFile(
   join(skillsRoot, "tiangong-auto-research", "references", "sandboxed-ide.md"),
   "utf8",
 );
+const scientificDesignReference = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "references", "scientific-design.md"),
+  "utf8",
+);
+const nativeExecutionReference = await readFile(
+  join(skillsRoot, "tiangong-auto-research", "references", "native-execution.md"),
+  "utf8",
+);
+
+// Test the installed command recipes and their ordering, not a second runtime
+// implementation. Behavioral decisions are evaluated independently before release.
+function researchRecipes(reference) {
+  return [...reference.matchAll(/```bash\n([\s\S]*?)```/g)].flatMap((match) =>
+    match[1].replace(/\\\n\s*/g, " ").split("\n")
+      .filter((line) => line.startsWith('node "$AUTO_RESEARCH_CLI"'))
+      .map((line) => line.slice(line.indexOf(" -- ") + 4).trim()),
+  );
+}
+const evidenceRecipes = researchRecipes(evidencePipelineReference);
+const forecastRecipe = evidenceRecipes.findIndex((line) => line.startsWith("research project evidence content forecast "));
+const freezeRecipe = evidenceRecipes.findIndex((line) => line.startsWith("research project evidence content freeze "));
+assert.ok(forecastRecipe >= 0 && forecastRecipe < freezeRecipe,
+  "The installed acquisition recipe must forecast before the immutable typed-content boundary");
+for (const prefix of [
+  "research project evidence artifact preflight ",
+  "research project evidence decomposition batch ",
+  "research project evidence atom batch ",
+]) assert.ok(evidenceRecipes.some((line) => line.startsWith(prefix)), `Missing public efficient recipe: ${prefix}`);
+const scientificRecipes = researchRecipes(scientificDesignReference);
+assert.ok(scientificRecipes.some((line) => line.startsWith("research project scientific review execute ") && line.includes("--confirm-review-cost")),
+  "The installed scientific-review recipe must use explicit isolated execution with cost consent");
+assert.ok(scientificRecipes.some((line) => line.startsWith("research project fork ") && line.includes("--resume-through discover")),
+  "Acquisition recovery must preserve discovery through the supported fork boundary");
+assert.match(nativeExecutionReference, /scientific-stopped/u,
+  "Native routing must distinguish stopped scientific work from a producer action");
 
 const questionGateHeading = "## Gate the research question before acting";
 const questionGateIndex = autoResearchSkill.indexOf(questionGateHeading);


### PR DESCRIPTION
## Summary

- guide pre-transfer artifact sizing and pre-freeze role coverage forecasting without mistaking potential eligibility for scientific approval
- preserve packet-governed acquisition operations and register readable derivatives before its immutable boundary
- prefer bounded atomic decomposition/atom batches and public CLI-owned schemas for large evidence sets
- execute prepared independent scientific reviews explicitly with cost consent and configured transport; no nested producer or blind retry
- recover acquisition with a reviewed successor that reuses verified discovery/downloaded artifacts instead of rewriting frozen history
- clarify all-of/grouped source constraints and blocking gaps versus permitted limitations

Closes #91.

## Validation

- new command-recipe and acquisition-boundary regressions observed RED in separate fresh Docker runtimes
- cached GREEN and final cold Skills container pass, including full academic-paper-download unittest discovery
- canonical and WorkBuddy Skill quick_validate pass in an isolated Python 3.12/PyYAML 6.0.3 validator environment
- docpact 0.1.9 strict config, exact branch lint, and git diff --check pass
- independent forward evaluation identified metadata-only forecast eligibility and overly broad tool-free guidance; regression fixes applied in owning CLI/Skill scope

## Risk and compatibility

The Skill delegates all machine contracts to the workspace-locked CLI and asks for an explicit reviewed upgrade if a needed command is unavailable. It preserves scientific stop/handoff rules and does not silently weaken requirements. No credential, private research artifact, or live provider data is included. UI metadata and triggering description are unchanged.

## Rollback

Revert the Skill change and publish a later CLI pin if required; do not edit installed immutable setup plans or retarget public versions.
