### PR TITLE
Add portable Auto Research feedback guidance and issue forms

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -8,6 +8,12 @@ repo:
 
 routing:
   intents:
+    issue-reporting:
+      paths:
+        - CONTRIBUTING.md
+        - .github/ISSUE_TEMPLATE/**
+        - tiangong-auto-research/references/issue-reporting.md
+        - scripts/tests/issue-reporting.test.mjs
     governance:
       paths:
         - AGENTS.md
@@ -43,6 +49,8 @@ routing:
 
 coverage:
   include:
+    - CONTRIBUTING.md
+    - .github/ISSUE_TEMPLATE/**
     - AGENTS.md
     - README.md
     - README.zh-CN.md
@@ -73,6 +81,7 @@ coverage:
 
 docInventory:
   include:
+    - CONTRIBUTING.md
     - AGENTS.md
     - README.md
     - README.zh-CN.md
@@ -214,3 +223,28 @@ rules:
       - path: _docs/runbooks/development.md
         mode: review_or_update
     reason: Data Skills must remain thin semantic consumers of the CLI-owned TypeScript runtime and machine contract.
+
+  - id: skills-issue-reporting
+    scope: repo
+    repo: skills
+    triggers:
+      - path: CONTRIBUTING.md
+        kind: contributor-guide
+      - path: .github/ISSUE_TEMPLATE/**
+        kind: user-feedback-form
+      - path: tiangong-auto-research/references/issue-reporting.md
+        kind: installed-feedback-workflow
+      - path: scripts/tests/issue-reporting.test.mjs
+        kind: feedback-contract-test
+    requiredDocs:
+      - path: CONTRIBUTING.md
+        mode: review_or_update
+      - path: README.md
+        mode: review_or_update
+      - path: README.zh-CN.md
+        mode: review_or_update
+      - path: _docs/architecture/repo-architecture.md
+        mode: review_or_update
+      - path: _docs/runbooks/development.md
+        mode: review_or_update
+    reason: GitHub forms and installed agent reports must share the reporting contract and remain discoverable.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+# Reporting contract: v1
+name: Bug report
+description: Report a problem / 反馈问题
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Chinese and English reports are welcome. Search existing issues and report one problem or capability per issue.
+        支持中文和英文；先搜索已有反馈，一条 Issue 聚焦一个问题或能力。Unknown / Not applicable is accepted with a reason.
+        [Reporting principles](https://github.com/tiangong-ai/workspace/blob/main/_docs/contracts/issue-reporting-policy.md) · [Contribution guide](https://github.com/tiangong-ai/skills/blob/main/CONTRIBUTING.md)
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: |
+        One observable problem and its impact. 一个问题及其影响。
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: |
+        What were you trying to accomplish? 原本想完成什么任务？
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: |
+        Choose the affected surface; Unsure is welcome. 无法判断时请选择“不确定”。
+      options:
+        - Auto Research Skill
+        - CLI
+        - Integration
+        - Unsure / 不确定
+    validations:
+      required: true
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: |
+        Actual CLI package/version and Skill revision or source used in the failing run. A managed runtime lock may differ from the global CLI. Write Unknown with a reason when unavailable; do not upgrade to collect this. 填写出错时实际使用的 CLI 和 Skill 版本，不知道可注明原因。
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        OS, Node version if known, installation method, native host (Codex / Claude Code / WorkBuddy / CodeBuddy), and model if applicable. Unknown or Not applicable is accepted. 系统、安装方式、宿主和模型；未知或不适用可注明。
+    validations:
+      required: true
+  - type: input
+    id: stage
+    attributes:
+      label: Stage
+      description: |
+        For example setup, discovery, acquisition, analysis, review, closure, another command, or Unknown. 出错阶段或命令，不确定可注明。
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: |
+        Minimal steps, sanitized command or prompt excerpt, and frequency. If it cannot be reproduced, describe the available evidence and limits. Do not rerun paid research just to report. 最小步骤、脱敏命令或提示词及发生频率；无法复现也可提交。
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: |
+        What did you expect to happen? 预期结果是什么？
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+      description: |
+        What happened, including the exact sanitized error if available? 实际结果及脱敏报错。Separate observations from suspected causes. 区分观察与推测。
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: |
+        Optional minimal sanitized logs, screenshot, or relevant run identifier. Remove keys, tokens, private paths, private research data, and unrelated chat. Do not upload the entire workspace or environment dump. 可选：最少量脱敏证据。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: CLI runtime or uncertain ownership / CLI 运行时或归属不确定
+    url: https://github.com/tiangong-ai/cli/issues/new/choose
+    about: Choose the related component when known; uncertain reports are accepted by CLI.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+# Reporting contract: v1
+name: Feature request
+description: Suggest a capability / 功能建议
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Chinese and English reports are welcome. Search existing issues and report one problem or capability per issue.
+        支持中文和英文；先搜索已有反馈，一条 Issue 聚焦一个问题或能力。Unknown / Not applicable is accepted with a reason.
+        [Reporting principles](https://github.com/tiangong-ai/workspace/blob/main/_docs/contracts/issue-reporting-policy.md) · [Contribution guide](https://github.com/tiangong-ai/skills/blob/main/CONTRIBUTING.md)
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: |
+        Name the capability you need. 想要什么能力？
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: |
+        Choose the affected surface, or Unsure. 选择组件，或“不确定”。
+      options:
+        - Auto Research Skill
+        - CLI
+        - Integration
+        - Unsure / 不确定
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: |
+        Who needs this and what task are they doing? 谁在什么场景下需要它？
+    validations:
+      required: true
+  - type: textarea
+    id: limitation
+    attributes:
+      label: Current limitation
+      description: |
+        What makes that task difficult today? 当前障碍是什么？
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed capability
+      description: |
+        Describe the desired behavior. An implementation design is not required. 描述期望行为，无需设计实现方案。
+    validations:
+      required: true
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      description: |
+        Give a user-visible example that would meet the need. 什么可观察结果说明需求已满足？
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: |
+        Optional workarounds or alternatives considered. 可选：现有替代办法。
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,9 @@ For new or modified skills, load
 `~/.codex/skills/.system/skill-creator/SKILL.md` when `CODEX_HOME` is unset.
 Use that skill's scripts by path: `scripts/init_skill.py`,
 `scripts/generate_openai_yaml.py`, and `scripts/quick_validate.py <skill-path>`.
+
+## User Feedback
+
+Read `CONTRIBUTING.md` when changing reporting forms or assisting a reporter.
+The installed Auto Research reporting reference and GitHub form core fields
+must agree; reporting does not require research setup or paid diagnostics.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+---
+docType: guide
+scope: repo
+status: current
+authoritative: true
+owner: skills
+language: en
+whenToUse: "When reporting bugs or requesting capabilities in skills."
+whenToUpdate: "When reporting forms, feedback entrypoints, or the shared reporting contract change."
+checkPaths:
+  - CONTRIBUTING.md
+  - .github/ISSUE_TEMPLATE/**
+  - README.md
+lastReviewedAt: 2026-09-02
+lastReviewedCommit: a7b4775f48d910197f3a9829cd8a9f1218d337b7
+---
+
+# Contributing Feedback / 提交反馈
+
+Chinese and English reports are welcome. Start with the
+[Bug report](https://github.com/tiangong-ai/skills/issues/new?template=bug_report.yml)
+or [Feature request](https://github.com/tiangong-ai/skills/issues/new?template=feature_request.yml).
+These implement the shared [reporting contract v1](https://github.com/tiangong-ai/workspace/blob/main/_docs/contracts/issue-reporting-policy.md).
+本仓库与另一个项目使用同一套核心字段；可以用中文或英文填写。
+
+## Where To Report / 提交到哪里
+
+- Skill instructions, prompt orchestration, references, and agent routing:
+  [Skills](https://github.com/tiangong-ai/skills/issues/new/choose).
+- Commands, setup/install failures, runtime errors, locks, and package issues:
+  [CLI](https://github.com/tiangong-ai/cli/issues/new/choose).
+- Uncertain or cross-component problems: use CLI and select `Unsure / 不确定`
+  when the component is unknown. Maintainers handle transfers or linked tasks.
+  无法判断归属时提交到 CLI；不需要在两个仓库重复提交。
+
+## Useful Reports / 填写原则
+
+Search existing issues first. Report one problem or capability at a time.
+Describe what you wanted to do, what you expected, and what actually happened.
+A root-cause diagnosis or implementation plan is optional. Unknown versions and
+unreproducible failures are accepted: explain what is known and what is missing.
+先查重复，聚焦一个问题；无需先找出根因，无法复现也可提交已有证据。
+
+For bugs, fill Summary, Goal, Component, Versions, Environment, Stage,
+Reproduction, Expected result, and Actual result. Evidence is optional. Include
+the actual CLI and Skill versions used by the failing run, native host/model,
+OS, and installation method when known. A managed workspace's locked CLI can
+differ from `tiangong-ai --version` in a global shell; use existing run records
+or read-only lock inspection and label the source. Do not update the workspace
+just to obtain a version. 填写出错时使用的实际版本，不要用升级后的版本替代。
+
+For features, fill Summary, Component, Use case, Current limitation, Proposed
+capability, and Success criteria; Alternatives is optional. No fault logs are
+required. 功能建议说明场景、障碍、期望能力和成功示例即可。
+
+Share only minimal sanitized logs, commands, or prompt excerpts. Remove keys,
+tokens, authorization headers, private paths, private research data, and
+unrelated conversation text. Do not attach an entire research directory or
+environment dump. Optional audit exports require review before sharing; do not
+run paid provider/model checks or repeat research solely to file an issue.
+仅提供最少量脱敏证据，不要上传密钥、整个工作区或完整私有对话。
+
+## Agent-Assisted Reports / 让 Agent 协助
+
+Ask the installed Auto Research Skill to prepare an issue report. It carries a
+local reporting reference and Markdown templates; a workspace source checkout
+is unnecessary. Preserve the same English section labels as the form while
+writing the content in either language. State `Unknown` or `Not applicable`
+with a reason instead of inventing details. An agent may draft locally; it posts
+or uploads only with user authorization, including authorization already given
+in the session. 可以先生成草稿；实际提交遵循用户已给出的授权。
+
+## Maintainer Handoff / 维护者接手
+
+Maintainers preserve the original report, verify component ownership, link
+duplicates, and add development scope, TODOs, acceptance criteria, validation,
+and integration requirements before starting implementation. Reporters do not
+need Project access or knowledge of internal delivery rules.
+维护者负责把反馈整理为可执行任务，不把内部交付要求转嫁给反馈者。

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Repository: https://github.com/tiangong-ai/skills
 
 Use the `skills` CLI from https://github.com/vercel-labs/skills to install, update, and manage these skills.
 
+## Report a problem or suggest a capability
+
+Use the [feedback forms](https://github.com/tiangong-ai/skills/issues/new/choose)
+and [contribution guide](CONTRIBUTING.md). Chinese and English reports are welcome.
+For CLI runtime problems or uncertain ownership, use the
+[CLI forms](https://github.com/tiangong-ai/cli/issues/new/choose). Auto Research
+can also prepare the same structured report from its installed reporting reference.
+
 ## Atomic data skills
 
 Twenty-one local candidate Skills—AirNow Hourly Observations, EPA EIS Records, Federal Register Documents, NASA

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,13 @@ lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
 
 请使用 https://github.com/vercel-labs/skills 提供的 `skills` CLI 来安装、更新和管理这些 skills。
 
+## 反馈问题或建议能力
+
+使用[反馈表单](https://github.com/tiangong-ai/skills/issues/new/choose)和
+[提交指南](CONTRIBUTING.md)，支持中文和英文。CLI 运行时问题或归属不确定时，
+使用 [CLI 表单](https://github.com/tiangong-ai/cli/issues/new/choose)。也可以让
+已安装的 Auto Research 按随包提供的反馈规范生成统一格式的 Issue 草稿。
+
 ## 原子数据 Skills
 
 当前本地候选分支中的 AirNow Hourly Observations、EPA EIS Records、Federal Register Documents、NASA FIRMS Active Fire、

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -42,3 +42,8 @@ This directory contains the repo-local source documents governed by docpact.
 - `_docs/runbooks/atomic-data-skill-migration.md`: candidate inventory, staged
   migration, cross-repo PR order, and acceptance gates for data Skills.
 - `_docs/standards/documentation-standards.md`: repo-local documentation rules.
+
+## User Feedback
+
+- [Contribution guide](../CONTRIBUTING.md)
+- [Installed Auto Research reporting workflow](../tiangong-auto-research/references/issue-reporting.md)

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -148,3 +148,13 @@ account-security semantics.
 - Consumers install skills into project or user agent directories.
 - Marketplace metadata influences discovery and install ordering for the subset
   it lists.
+
+## User Feedback
+
+`CONTRIBUTING.md` and `.github/ISSUE_TEMPLATE/**` expose the shared workspace
+reporting contract. The canonical Auto Research Skill routes feedback before
+research setup or scientific-question gating and includes complete offline
+Markdown templates in `references/issue-reporting.md`. The WorkBuddy adapter
+uses that same route, including when setup is absent. Form labels and agent
+headings stay aligned; reporting gathers existing evidence without running
+research or implicitly submitting externally.

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -114,3 +114,10 @@ assets, generated `agents/**` files, or marketplace metadata require review of:
 `.claude-plugin/marketplace.json` is curated marketplace grouping metadata. It
 may be a subset of installable skill directories unless the marketplace file is
 explicitly updated to include every skill.
+
+## User Feedback Boundary
+
+The workspace owns common reporting principles and fields. This repository
+owns its contributor guide, GitHub forms, and portable installed Skill reporting
+workflow. Maintain their shared contract together; feedback preparation must
+work before research setup and must preserve user authorization for posting.

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -165,3 +165,14 @@ language to pass in the clean container.
 Update `README.md` and `README.zh-CN.md` when installation, environment
 variables, target agents, or user-facing skill availability changes. Update
 `.claude-plugin/marketplace.json` when marketplace discovery metadata changes.
+
+## Reporting Contract
+
+When changing contribution guidance, GitHub forms, or the installed reporting
+reference, review the shared workspace reporting policy and both repositories'
+core field IDs, labels, ordering, and required flags together. Repository-only
+fields remain optional. Keep reporting instructions available in an isolated
+Skill install; never link local templates outside the installed Skill tree.
+`node --test scripts/tests/issue-reporting.test.mjs` checks isolated installation
+and form/agent heading parity, and runs in the existing clean-container suite.
+Inspect both YAML forms with a YAML parser before delivery.

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -48,3 +48,7 @@ lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
   for machine contracts; Skills documents cover semantic entrypoints,
   capability requirements, release provenance, inventory, and migration
   workflow without copying closed schemas.
+
+User-facing contribution guides and issue forms implement the shared workspace
+reporting policy. Keep required core labels/IDs stable, accept Chinese and
+English content, and ship the complete agent templates inside Auto Research.

--- a/scripts/tests/issue-reporting.test.mjs
+++ b/scripts/tests/issue-reporting.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { cp, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = new URL("../../", import.meta.url);
+const bug = ["Summary", "Goal", "Component", "Versions", "Environment", "Stage", "Reproduction", "Expected result", "Actual result", "Evidence"];
+const feature = ["Summary", "Component", "Use case", "Current limitation", "Proposed capability", "Success criteria", "Alternatives"];
+
+test("an isolated Auto Research installation carries the same report sections as its issue forms", async () => {
+  const temporary = await mkdtemp(join(tmpdir(), "reporting-skill-"));
+  try {
+    const installed = join(temporary, ".agents", "skills", "tiangong-auto-research");
+    await cp(new URL("tiangong-auto-research/", root), installed, { recursive: true });
+    const entry = await readFile(join(installed, "SKILL.md"), "utf8");
+    const route = entry.match(/\[[^\]]+\]\((references\/issue-reporting\.md)\)/);
+    assert.ok(route, "reporting must be discoverable from the installed entrypoint");
+    const reference = await readFile(join(installed, route[1]), "utf8");
+    const templates = [...reference.matchAll(/```md\n([\s\S]*?)```/g)].map((match) =>
+      [...match[1].matchAll(/^### (.+)$/gm)].map((heading) => heading[1]),
+    );
+    assert.deepEqual(templates, [bug, feature]);
+    for (const [name, headings] of [["bug_report", bug], ["feature_request", feature]]) {
+      const form = await readFile(new URL(`.github/ISSUE_TEMPLATE/${name}.yml`, root), "utf8");
+      const labels = [...form.matchAll(/^      label: (.+)$/gm)].map((match) => match[1]);
+      assert.deepEqual(labels, headings, "GitHub and offline agent reports must have identical sections");
+    }
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});

--- a/tiangong-auto-research-workbuddy/SKILL.md
+++ b/tiangong-auto-research-workbuddy/SKILL.md
@@ -5,7 +5,11 @@ description: Adapt a managed Tiangong Auto Research workflow to a native WorkBud
 
 # Tiangong Auto Research for WorkBuddy
 
-Use this adapter only inside a user-selected managed Auto Research workspace.
+For feedback or Issue requests, load the sibling `tiangong-auto-research/SKILL.md`
+and follow its reporting route before workspace inspection. Its installed
+`references/issue-reporting.md` supplies the common templates and reporting rules.
+
+Use the research workflow below only inside a user-selected managed Auto Research workspace.
 Inspect the exact workspace context first. If setup is absent, use the canonical
 Skill's setup reference; do not copy control files or invent a workspace.
 

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -1,9 +1,17 @@
 ---
 name: tiangong-auto-research
-description: Orchestrate open-ended, multi-source, evidence-backed research in the current native Codex, Claude Code, WorkBuddy, or CodeBuddy host, especially when an ancestor directory contains `.tiangong-research` or the user asks to research, investigate, build on prior outputs, compare evidence, form a conclusion, or produce a reviewed research artifact. Also use for setup, preflight, native producer execution, recovery, independent review, and closure. In an Auto Research workspace this Skill takes precedence over individual web, news, SCI, report, patent, download, or document Skills unless the user explicitly requests one isolated standalone operation outside the research workflow. Covers Chinese requests such as “研究一下”, “朝这个方向做一做”, “结合已有成果继续研究”, “查资料并形成结论”, and “系统梳理证据”.
+description: Orchestrate open-ended, multi-source, evidence-backed research in the current native Codex, Claude Code, WorkBuddy, or CodeBuddy host, especially when an ancestor directory contains `.tiangong-research` or the user asks to research, investigate, build on prior outputs, compare evidence, form a conclusion, or produce a reviewed research artifact. Also use for setup, preflight, native producer execution, recovery, independent review, closure, and requests to report Auto Research bugs or suggest capabilities (反馈问题、提交 Issue). In an Auto Research workspace this Skill takes precedence over individual web, news, SCI, report, patent, download, or document Skills unless the user explicitly requests one isolated standalone operation outside the research workflow. Covers Chinese requests such as “研究一下”, “朝这个方向做一做”, “结合已有成果继续研究”, “查资料并形成结论”, and “系统梳理证据”.
 ---
 
 # Tiangong Auto Research
+
+## Route feedback before research
+
+For requests to report a problem, suggest a capability, or prepare an Issue,
+read [references/issue-reporting.md](references/issue-reporting.md) and follow
+that reporting workflow. Reporting does not require a valid research workspace,
+setup, or scientific-question approval. Return the report without entering the
+research workflow unless the user also requests research execution.
 
 ## Gate the research question before acting
 

--- a/tiangong-auto-research/agents/openai.yaml
+++ b/tiangong-auto-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tiangong Auto Research"
-  short_description: "Run native top-journal research with audited gates"
+  short_description: "Run native research or prepare a structured issue report"
   default_prompt: "Use $tiangong-auto-research to author this study's scientific design and execute it in the current native host, pass independent scientific and final publication reviews, and export a verified portable audit bundle."

--- a/tiangong-auto-research/references/issue-reporting.md
+++ b/tiangong-auto-research/references/issue-reporting.md
@@ -1,0 +1,107 @@
+# Report An Auto Research Problem Or Capability
+
+Use this reference when the user asks to report a bug, provide feedback, or
+prepare an issue about Auto Research. This is reporting, not a new research
+request: it does not require setup, a rewritten scientific question, provider
+checks, or a working research workspace. It implements
+[reporting contract v1](https://github.com/tiangong-ai/workspace/blob/main/_docs/contracts/issue-reporting-policy.md).
+The templates below are complete and usable offline after installing this Skill.
+
+## Prepare The Report
+
+1. Identify whether this is a bug or a requested capability. Search for an
+   existing issue if GitHub access is available; if unavailable, state that the
+   duplicate search was not performed and continue preparing a local draft.
+2. Choose [Skills](https://github.com/tiangong-ai/skills/issues/new/choose) for
+   instructions, orchestration, references, or agent routing. Choose
+   [CLI](https://github.com/tiangong-ai/cli/issues/new/choose) for commands,
+   setup/install, runtime errors, schemas, locks, or packages. Uncertain and
+   cross-component reports enter CLI; `Unsure / 不确定` is a valid component.
+   Maintain one report and let maintainers transfer it or link implementation tasks.
+3. Use the current conversation and already available run evidence. Record
+   actual CLI/Skill versions, native host/model, and environment when known.
+   A managed runtime lock can differ from the global CLI. Read known regular
+   version/lock files only as needed; label which run/source the version came
+   from. Do not invoke setup, install/update, repair immutable state, rerun
+   research, or spend provider/model budget to make a report more complete.
+4. Fill the matching template with observed facts. Keep its English headings
+   and order; Chinese or English body text is welcome. Use `Unknown` or
+   `Not applicable` with a reason for missing required details. An intermittent
+   or unreproducible failure is valid: record frequency and reproduction limits.
+   Distinguish a suspected cause from an observed fact. A diagnosis or patch is
+   not required. Ask only for missing information that materially helps triage.
+5. Include minimal sanitized snippets. Remove credentials, authorization
+   headers, private paths, private research inputs, and unrelated conversation.
+   Never attach the entire research directory, secret/environment stores, or
+   complete conversation. Review any selected audit export before sharing it.
+6. Return a concise title, destination repository, and completed Markdown body.
+   Prepare a local draft unless the user has authorized external submission.
+   Existing explicit submission authorization remains valid: use an available
+   authorized GitHub tool without asking again. If submission is unavailable,
+   provide the draft and form link and accurately state that it was not posted.
+
+## Bug Template
+
+Use a short symptom as the issue title. For a CLI destination, optionally
+append `### CLI diagnostics` with an already available invocation, exit code,
+and sanitized diagnostics; do not invent them.
+
+```md
+### Summary
+<One observable problem and its impact.>
+
+### Goal
+<What the user was trying to accomplish.>
+
+### Component
+<Auto Research Skill / CLI / Integration / Unsure / 不确定>
+
+### Versions
+<Actual CLI package/version and Skill revision/source from the affected run; Unknown with a reason when unavailable.>
+
+### Environment
+<OS, Node if known, installation method, native host and model if applicable.>
+
+### Stage
+<Setup, discovery, acquisition, analysis, review, closure, another command, or Unknown.>
+
+### Reproduction
+<Minimal steps or sanitized command/prompt; frequency and limits if not reproducible.>
+
+### Expected result
+<Expected behavior.>
+
+### Actual result
+<Observed behavior and exact sanitized error if available.>
+
+### Evidence
+<Optional minimal sanitized snippets, or None provided.>
+```
+
+## Feature Template
+
+```md
+### Summary
+<The requested capability.>
+
+### Component
+<Auto Research Skill / CLI / Integration / Unsure / 不确定>
+
+### Use case
+<Who needs this and what task they are doing.>
+
+### Current limitation
+<What makes that task difficult today.>
+
+### Proposed capability
+<Desired user-facing behavior; no implementation design is required.>
+
+### Success criteria
+<An observable example of a successful outcome.>
+
+### Alternatives
+<Optional workarounds or alternatives, or None provided.>
+```
+
+Maintainers add development scope, TODOs, validation, and integration decisions
+after triage. Reporting does not require the user to know the delivery process.


### PR DESCRIPTION
Auto Research users can now prepare a structured bug or feature report from an installed Skill, including when research setup has failed. GitHub forms use the same core headings as the offline agent templates, accept Chinese or English, and allow explicit unknowns and reproduction limits.

The change adds contributor and README entrypoints, routes feedback before research execution, keeps WorkBuddy on the canonical workflow, and covers the new files with docpact. Reports use existing sanitized evidence; external submission follows the user's authorization.

Validation:
- Observed RED in the clean container: an isolated Skill installation had no reporting route.
- Full fresh-container GREEN and explicit cold-build gate passed. A stalled Debian download in the first cold attempt was terminated; the unchanged cold command passed on retry.
- Skill-creator validators passed for Auto Research and WorkBuddy.
- Parsed both repositories' YAML forms and verified equal core IDs, labels, order, types, and required flags.
- Docpact 0.1.9 strict config and committed diff lint passed with no findings; git diff checks passed.

Integration: tiangong-ai/workspace#202 coordinates the shared policy and tiangong-ai/cli#91. The CLI must audit and release the new immutable Skill pin after this merge; existing research installations receive it through their normal update flow.

Closes #93
