### PR TITLE
Guide efficient research revision and requirement-level acceptance

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-02"
-lastReviewedCommit: "5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe"
+lastReviewedAt: "2026-09-03"
+lastReviewedCommit: "4041b5da5335fcca3015b45c06ad767b79a884f6"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # Tiangong AI Skills
@@ -206,8 +206,14 @@ workspace operations.
 For acquisition-heavy work, the orchestrator uses the CLI's read-only artifact
 size and role-coverage forecasts, bounded atomic content batches, and explicit
 prepared scientific-review execution. Recovery reuses verified discovery and
-downloaded artifacts in a reviewed successor; it never edits frozen history or
-silently changes scientific requirements to make a gate pass.
+downloaded artifacts. A compatible locked runtime can revise acquisition in the
+same project before analysis, explicitly reopening discovery only for new sources;
+design changes and later revisions retain the formal successor workflow. Original
+and currently approved task requirements, native check records, independent review
+and portable audit stay linked without extra fixed reviewer rounds. Workflow
+closure is reported separately from task completion. See
+`tiangong-auto-research/references/execution-assurance.md`; frozen history and
+scientific requirements are never silently rewritten to make a gate pass.
 
 The orchestrator gates a research question before setup or any tool call. A
 request that presupposes its conclusion or excludes contrary evidence is

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # 天工 AI Skills
@@ -185,8 +185,12 @@ apply 创建 `runtime-lock.json` 后，已安装 orchestrator 的内置 resolver
 所有 workspace 操作只运行该锁定版本。
 
 资料较多时，orchestrator 使用 CLI 的只读文件大小预检、角色覆盖预测、有界原子
-批量登记与显式科学评审执行。恢复时在经审阅的后继项目中复用已验证的 discovery
-和下载文件，不修改冻结历史，也不为通过门禁而偷偷降低科学要求。
+批量登记与显式科学评审执行。兼容的锁定 CLI 支持在分析前于同一项目修订获取结果，
+仅在需要新来源时显式重开 discovery，并复用已有回执和文件；设计变化或分析后的
+修订仍走正式后继流程。原始要求、当前批准范围、原生宿主检查、独立评审和可移植
+审计保持关联，不增加固定付费评审轮次；流程闭环与任务完成分别汇报。详见
+`tiangong-auto-research/references/execution-assurance.md`。不修改冻结历史，也不为
+通过门禁而偷偷降低科学要求。
 
 orchestrator 会在 setup 或任何工具调用之前先检查研究问题。预设结论或排除反证的
 请求会被暂停，并给出一个可检验的改写版本；只有用户明确确认后才继续。争议性主题和

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # Skills Repository Architecture
@@ -93,6 +93,14 @@ the configured isolated transport through an explicit cost-confirmed execution
 command; recovery reuses exact discovery/artifact bytes in a reviewed successor.
 These recipes do not duplicate schema evaluators or add per-record verification
 loops to the Skill.
+
+`references/execution-assurance.md` routes the canonical orchestrator through
+CLI-owned original/current task contracts, exact scope confirmation, native
+check intake, pre-analysis same-project evidence revision and task-aware
+review/audit. Compatible runtimes may explicitly reopen discovery for new
+sources without changing project identity. The Skill reports task coverage
+separately from workflow/publication status and keeps all producer work native;
+it neither implements a second state machine nor adds fixed paid reviewer rounds.
 
 `tiangong-auto-research-workbuddy` is a thin sandboxed-IDE adapter. It routes
 WorkBuddy/CodeBuddy native producer tasks back to the canonical orchestrator and

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # Skills Development Runbook
@@ -159,6 +159,14 @@ When changing sandboxed-IDE routing, keep its deterministic markers in
 `tiangong-auto-research/scripts/test-routing-contract.mjs` and require the thin
 adapter, canonical reference, exact structured bridge errors, and no-bypass
 language to pass in the clean container.
+
+Task-assurance recipe tests copy the Skill to an isolated directory and execute
+its single-command shell examples against a capture-only Node stand-in. Check
+resolver paths, argv and exact scope-hash confirmation there; this is not a
+substitute for behavioral evaluation. Evaluate realistic recovery/completion
+decisions independently without supplying the expected answer, and run the
+corresponding protocol against the exact candidate CLI outside the repository.
+Keep native case data, captures and generated research outside Git.
 
 ## README And Marketplace Updates
 

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: 5ba8988d13cdf3f2674fbbcd182e4b15c9e2e3fe
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: 4041b5da5335fcca3015b45c06ad767b79a884f6
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -89,6 +89,10 @@ detailed stop and recovery rules.
   agent authentication, provider checks, or wrappers.
 - Read [references/production-research.md](references/production-research.md)
   before production preflight, execution, recovery, or closure.
+- Read [references/execution-assurance.md](references/execution-assurance.md)
+  before original-task intake, pre-analysis evidence correction, scope changes,
+  or completion reporting. Prefer the supported same-project revision for an
+  unchanged study; preserve original/current task completion separately.
 - Read [references/evidence-pipeline.md](references/evidence-pipeline.md) before
   discovery, acquisition, evidence refresh, or an addendum.
 - Read [references/evidence-exhaustion.md](references/evidence-exhaustion.md)
@@ -285,6 +289,13 @@ initialization. For an explicitly selected evidence-report goal, omit the
 top-journal Policy/design options; do not silently downgrade a requested
 top-journal study to make admission pass.
 
+For a new project on a compatible locked runtime, register the original-task
+checklist immediately after init and before the first review or producer stage,
+following [execution-assurance.md](references/execution-assurance.md). Use a few
+meaningful user requirements and existing design/coverage IDs, not a duplicate
+workflow or one requirement per tool call. Never invent historical acceptance
+for a project that lacks those records.
+
 ## Validate, run, and recover
 
 Production requires explicit models/prices, different producer and reviewer
@@ -320,6 +331,11 @@ generated Claim-Evidence Graph, and synthesize. Only after that may
 mechanical closure. Follow
 [references/native-execution.md](references/native-execution.md) for the exact
 commands and recovery rules.
+
+At idle stage boundaries, record the checks actually performed against each
+current requirement before launching the existing independent review. Preserve
+failed, not-run and inconclusive outcomes; a supported negative finding is not
+automatically a failure. Check hashes identify bytes, not successful execution.
 
 For a top-journal project, `research status` may require `research-design`,
 `evidence-construct`, or `pilot-methods` review before it exposes the next
@@ -366,6 +382,9 @@ journal-editor reviews, then mechanically close the publication generation.
 Any Policy, manuscript, or submission-file change invalidates downstream
 approval/review. Return
 only the CLI-computed bounded readiness language; never promise acceptance.
+Report workflow status, publication verdict, `task.originalScope` and
+`task.currentScope` separately. A closed workflow or narrower completed scope
+does not answer withdrawn or unresolved original requirements.
 Export and independently verify a portable project audit bundle before external
 handoff or archival; it must contain the formal evidence bytes and review
 objects, not merely receipts or local-path references.

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -52,7 +52,8 @@ runaway guard, never a quota:
 1. Exercise required first-pass capabilities.
 2. Use broad, high-yield queries across distinct selected channels.
 3. Inspect registered candidate IDs and coverage after each batch.
-4. Stop early when the reviewed minimums are supportable.
+4. End the broad first pass when reviewed coverage is supportable; minimum
+   counts alone do not establish task completion or scientific adequacy.
 5. Spend the remaining calls only on explicit gaps, counterevidence, missing
    dates, missing source types, applicability limits, or full-text candidates.
 
@@ -265,6 +266,9 @@ coverage. Run this once per meaningful completed acquisition batch and before
 freezing, not after every small record. Keep acquiring only the explicit gaps
 that remain lawfully actionable; retain an honest stopped audit and hand off
 when the necessary evidence is unavailable.
+The `submissionGate` distinguishes known submit blockers, such as an accepted
+binary input without readable content, from potential eligibility. Keep honest
+limited/stopped audits separate from permission to infer.
 
 ## 5. Freeze, then infer
 
@@ -373,14 +377,20 @@ snapshot, graph, packet, context, receipt, artifact, or source.
 
 ## 6. Refresh through an addendum
 
-If acquire already completed but missing readable artifacts were discovered
-before analysis, use the recovery fork in
-[scientific-design.md](scientific-design.md). `--resume-through discover`
-reuses verified discovery and acquired files while reopening acquire in an
-explicit successor. It does not redo paid search or downloads for unchanged
-bytes. New top-journal Policy/design approval is still required; a content stop
-does not authorize editing old snapshots or repeatedly retrying a complete
-package.
+If acquire completed but analysis has not started, first use
+[execution-assurance.md](execution-assurance.md) to choose the supported
+same-project revision. An acquisition-only correction preserves the approved
+research design while invalidating its dependent post-acquisition reviews.
+Use explicit `--include-discovery` only when a new source needs formal admission;
+reuse prior receipts and files, and do not reset the budget or repeat unchanged
+queries. Rebuild the current typed-content view; older failed decompositions
+and deselected atoms remain historical, not current evidence.
+
+When the locked runtime or snapshot cannot support that revision, or the design
+changes or analysis has started, use the formal recovery/new-generation route in
+[scientific-design.md](scientific-design.md). `--resume-through discover` can
+reuse verified discovery and files in a successor. Its target-specific
+Policy/design approval remains required. Never hand-edit frozen history.
 
 Never mutate a closed project. When material new evidence exists, create a new
 addendum project:

--- a/tiangong-auto-research/references/execution-assurance.md
+++ b/tiangong-auto-research/references/execution-assurance.md
@@ -1,0 +1,171 @@
+# Task assurance and efficient recovery
+
+Load for original-task intake, pre-analysis evidence correction, a scope change,
+or a completion claim. Keep the current native host as the producer. The CLI
+owns schemas, authoritative state, evidence bindings and recovery; this reference
+does not define a second workflow engine.
+
+## Check the locked runtime once
+
+Inspect help and the needed schemas when entering a workspace or after an
+explicit runtime update, not before every record:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research --help
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research schema show task-contract --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research schema show task-acceptance --json
+```
+
+Use the new recipes only when that exact locked runtime exposes them. Missing
+commands require an explicit reviewed upgrade or its existing supported
+workflow; never switch to `latest`, rewrite a runtime lock, or invent a command.
+An existing project without a task contract remains **unassessed** in this
+dimension. Do not manufacture historical requirements, approvals or passing
+checks. Existing Policy/evidence safeguards still apply.
+
+## Record a small original-task checklist
+
+After initializing a new project and before its first scientific review or
+producer stage, preserve the user's scientific requirements and their acceptance
+conditions. Use stable IDs at the level of actual user requirements, not one
+requirement per file or tool call. Bind existing design-claim and coverage IDs
+where applicable. Do not invent additional scientific thresholds or require
+computation for a qualitative review or a theoretical proof.
+
+Use the CLI-owned schema, then register the declaration:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project task define PROJECT --input /absolute/path/task-contract.json --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project task status PROJECT --workspace /absolute/path/to/workspace --json
+```
+
+The returned contract and requirement hashes are authoritative. Keep the original
+request distinct from the currently approved scope. Cosmetic manuscript edits
+are not a reason to rewrite this checklist. Markdown is a human-readable view,
+not a second state file.
+
+## Correct acquisition without unnecessary new projects
+
+When acquire is complete, analysis has not started, and the question, Policy,
+design and evidence requirements are unchanged, prefer the same-project
+revision. Resolve an active session or human handoff through its existing
+authorized command first. Inspect the current snapshot and use its exact hash:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project evidence acquisition revise PROJECT --expected-snapshot CURRENT_SNAPSHOT_SHA256 --reason "Add the missing readable derivative before analysis" --workspace /absolute/path/to/workspace --json
+```
+
+This preserves the project, original requirements, approved Policy/design and
+research-design review. It reopens acquire, retains old snapshots and check
+records, and invalidates evidence-construct/pilot-methods approvals that depend
+on the acquisition. Unchanged files and parsing results are reusable. Do not
+repeat paid search, download or model work merely because an acknowledgement
+was lost; repeat the exact request to inspect its idempotent result.
+
+If a genuinely new source must enter the unchanged study, explicitly include
+discovery in the revision; do not add a source directly to a frozen audit:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project evidence acquisition revise PROJECT --expected-snapshot CURRENT_SNAPSHOT_SHA256 --reason "Admit an additional lawful source within the approved study" --include-discovery --workspace /absolute/path/to/workspace --json
+```
+
+This reopens discover then acquire. Preserve existing candidate/source IDs and
+receipts, search only the remaining actionable gaps, and formally admit new
+sources through the existing discovery commands. It does not reset the project
+budget. A revision without this option is for files/derivatives of already
+admitted sources and does not silently reopen search.
+
+Then prepare the indicated stage, register exact files/derivatives, run one
+forecast for the meaningful batch, submit the complete audit, update relevant
+decompositions/atoms in batches and freeze typed content. A failed decomposition
+may be superseded in the new acquisition snapshot; its historical record remains.
+Atoms from deselected files must not count in current coverage. Complete the
+applicable scientific gates before inference. Follow
+[evidence-pipeline.md](evidence-pipeline.md) for exact evidence operations.
+
+The preflight distinguishes `submissionGate` blockers from optimistic coverage.
+Potential eligibility is not proof that files, evidence roles or scientific
+claims have passed. A limited/stopped audit may be retained honestly; never move
+a blocking gap into limitations to advance. Hash and structure checks still run
+at admission and trust boundaries; do not add a full-corpus check after each atom.
+
+Use the existing fork/new-generation route when analysis has started or when the
+question, Policy, design or evidence contract changes. A pre-feature snapshot
+without immutable acquisition records also uses that route; there is no automatic
+in-place migration. See [scientific-design.md](scientific-design.md).
+
+## Obtain authorization for a real scope change
+
+Explain what will no longer be answered and inspect the exact before/after
+requirements. A request to continue, increase a budget or create a fork is not
+permission to change scientific scope. Preserve valid prior exact authorization;
+do not ask again merely because a read-only acknowledgement is repeated.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research schema show task-scope-change --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project task scope propose PROJECT --input /absolute/path/scope-change.json --expected-contract CURRENT_CONTRACT_SHA256 --workspace /absolute/path/to/workspace --json
+```
+
+Show `changes.details` and the proposal hash to the user. Only after explicit
+approval of that actual change:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project task scope approve PROJECT --proposal PROPOSAL_SHA256 --confirm-change PROPOSAL_SHA256 --workspace /absolute/path/to/workspace --json
+```
+
+The command records exact operator confirmation, not authenticated human identity;
+the native host must honor the user's permission. Never put `approved: true` in
+a producer declaration. Task-scope approval does not change the question,
+Policy, design or evidence requirements. Changes to those contracts need their
+formal new-generation process. A task-scope change invalidates scientific
+reviews that no longer cover it; inspect status before paying for any re-review.
+Withdrawn original requirements remain visible rather than becoming answered.
+
+## Record checks actually performed by the native host
+
+Perform the appropriate evidence examination, computation or proof work in the
+current host. At an idle stage boundary after acquisition, record its actual
+outcome using the schema above. Bind current source/atom/finding IDs and any
+explicit external portable UTF-8 result files. The CLI supplies hashes and
+immutable result copies; never scan a directory for the newest output or pass
+control-store files as new native results.
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project task acceptance record PROJECT --input /absolute/path/task-acceptance.json --workspace /absolute/path/to/workspace --json
+```
+
+Use `not-run`, `failed` or `inconclusive` honestly. A failed computation need not
+invent an output file. A supported null effect or counterexample may be a valid
+`negative-result`; unavailable data is not one. A changed record must name the
+exact prior record hash; identical replay does not repeat the check.
+
+These records have `trust=native-observation` and `executionCertified=false`.
+Byte identity does not prove successful execution. The declared command is kept
+by hash, not as a credential-bearing command line. Keep result files portable
+and secret-free. Unchanged exact dependencies can be reused; changed requirement,
+input, design or analysis bindings need revalidation. Do not invoke a generic
+CLI producer or add another model solely to judge this bookkeeping.
+
+## Review once at the existing gates and report separately
+
+Before the existing independent review, give every current requirement an honest
+check/disposition. The packet contains the original request, original/current
+requirement versions and their bound checks. Its supplied response schema is
+authoritative. Do not drop missing requirements, failed checks or counterevidence
+to fit context; report capacity limits or make a reviewed context adjustment.
+Shared results need not be pasted once per requirement.
+
+The existing review assesses the exact `taskAcceptance` context through
+`taskAssessment`; no additional fixed paid review round is needed. A producer's
+claim is only `recorded` until reviewed. A reviewer cannot promote absent, stale,
+inconclusive, failed or unexecuted checks into answered requirements. Final
+publication reviewers also receive the task context. Keep the original scientific
+and publication gates in [publication-policy.md](publication-policy.md).
+
+Report workflow completion, publication verdict, original-scope completion and
+current-scope completion separately. `research run` or base closure may be
+complete while `task.currentScope` or `task.originalScope` is incomplete. Name
+the remaining requirements and the legitimate next action; do not promise full
+task completion or editorial acceptance. Export and verify the portable audit
+with its task relationships before handoff. Audit integrity is not proof of
+authorship, authenticated human approval or real-world scientific truth.

--- a/tiangong-auto-research/references/native-execution.md
+++ b/tiangong-auto-research/references/native-execution.md
@@ -8,6 +8,11 @@ other agent family only for independent review, and closes mechanically.
 
 ## Identify the next action
 
+For a new project, record its original task before this first execution boundary.
+For recovery or scope changes, read
+[execution-assurance.md](execution-assurance.md). The returned task context is
+part of the native-stage binding; do not rewrite it while a session is active.
+
 Run the control plane after project initialization:
 
 ```bash
@@ -160,6 +165,10 @@ Use the artifact byte preflight and acquisition forecast described in
 readable derivatives during the active acquire stage; only decomposition/atom
 records are added after that snapshot freezes. Prefer batch registration when
 there are many records, without repeating full verification for each item.
+For a missing derivative after acquire completed, prefer the compatible CLI's
+same-project revision before analysis. A new source requires explicit discovery
+reopening and formal admission, not a direct edit to acquisition JSON. Preserve
+unchanged files/receipts and inspect the resulting current snapshot.
 
 ## Submit producer output
 
@@ -211,6 +220,13 @@ Claim-Evidence Graph. The same run command may then launch only the configured
 independent reviewer CLI and, after a passing review, perform mechanical
 closure.
 
+Before the run that may launch review, record an honest check/disposition for
+every current task requirement at an idle boundary. Computational work remains
+in this native host; the CLI records exact result/evidence bindings without
+self-certifying execution. Follow
+[execution-assurance.md](execution-assurance.md); do not add a separate paid
+reviewer round or treat a missing check as a reason to repeat the research.
+
 For a top-journal project, this is the base research closure, not the final
 publication verdict. Continue in the same current native host to author and
 freeze the manuscript, then use four fresh independent publication-review
@@ -237,3 +253,5 @@ Before an external handoff or archival milestone, export and verify the project
 audit bundle described in [scientific-design.md](scientific-design.md). A local
 manifest or receipt hash without the referenced evidence bytes is not a
 portable audit package.
+Read the task completion fields as well as workflow status. `status=complete`
+for the workflow can coexist with inconclusive or withdrawn task requirements.

--- a/tiangong-auto-research/references/publication-policy.md
+++ b/tiangong-auto-research/references/publication-policy.md
@@ -175,6 +175,11 @@ assessment, submission files, supplements, mechanical result, role, reviewer,
 and schema. Review cannot add evidence. A manuscript or submission-file
 revision creates a new generation and invalidates every old review; a Policy
 change or expiry blocks publication.
+When task tracking is configured, the frozen generation and each existing
+reviewer packet also bind the original request and original/current requirement
+check matrix. Read that context; a native check record is not a certified run.
+Use the existing role's findings for missing task coverage, not an extra fixed
+review round. See [execution-assurance.md](execution-assurance.md).
 
 ## Close and report bounded language
 
@@ -187,6 +192,8 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 
 Closure re-verifies every hash and requires all four reviews. Report only the
 returned verdict, bounded statement, limitations, and pivots.
+Report original/current task completion alongside that publication verdict.
+A narrower approved scope does not erase unanswered original requirements.
 `target-journal-submission-ready` means the frozen artifact passed its declared
 gates; it does not predict or guarantee editorial acceptance.
 

--- a/tiangong-auto-research/references/scientific-design.md
+++ b/tiangong-auto-research/references/scientific-design.md
@@ -256,7 +256,12 @@ packet-file digest. Do not interchange those two hash meanings.
 
 ## Scope change and authoritative generations
 
-Never edit a frozen design or old project in place. A top-journal fork or
+Never edit frozen bytes by hand. The CLI's bounded pre-analysis acquisition and
+task-scope revisions are described in
+[execution-assurance.md](execution-assurance.md); they do not rewrite the
+scientific design. An actual design change still requires a new generation.
+Explain and obtain exact authorization for changed task requirements; a generic
+continue/fork instruction is not that authorization. A top-journal fork or
 addendum requires an approved Policy and scientific design whose `projectId`
 matches the new target generation, plus a fresh native producer session:
 
@@ -275,8 +280,11 @@ bypass an earlier gate. The source becomes explicitly superseded, the default
 status shows only the authoritative descendant, and `--all` remains the history
 view.
 
-For an acquisition-only correction before analysis, preserve discovery and
-verified acquired artifacts instead of repeating search and download:
+Prefer the supported same-project acquisition revision before analysis when
+the study is unchanged. It preserves the existing research-design approval and
+reopens only the explicitly selected evidence stages. The following fork is the
+fallback when that revision is unavailable or a new generation is required;
+it preserves discovery and files rather than repeating search and download:
 
 ```bash
 node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
@@ -332,3 +340,8 @@ capsules, and unrelated files. Export refuses an existing/symlink destination,
 host-specific workspace paths, sensitive text, missing evidence bytes, semantic
 drift, or any hash drift. Verification rejects every extra, missing, or changed
 byte; it never scans a Downloads directory or substitutes a newer file.
+With task tracking configured, `researchChain.task` binds the task history and
+check context. Verification checks the original/current requirements,
+authorization/check references, current dependencies and bound review as well
+as bytes. It remains a portable integrity/relationship check, not independent
+proof that a human approved the scope or that a computation actually ran.

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { chmod, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const skillsRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -317,6 +319,59 @@ const fixtures = [
 ];
 for (const [prompt, managed, expected] of fixtures) {
   assert.equal(expectedRoute(prompt, managed), expected, prompt);
+}
+
+// Execute the installed recipes against a capture-only Node stand-in. This
+// validates portable argv and consent binding, not model reasoning or CLI state.
+const recipeFixture = await mkdtemp(join(tmpdir(), "research-task-recipes-"));
+try {
+  const installed = join(recipeFixture, "installed-skill");
+  await cp(join(skillsRoot, "tiangong-auto-research"), installed, { recursive: true });
+  const referencePath = join(installed, "references", "execution-assurance.md");
+  const reference = await readFile(referencePath, "utf8");
+  const installedEntry = await readFile(join(installed, "SKILL.md"), "utf8");
+  assert.ok(installedEntry.includes("references/execution-assurance.md"),
+    "The execution-assurance workflow must be discoverable from the installed Skill");
+  for (const [, href] of reference.matchAll(/\[[^\]]+\]\(([^)#]+\.md)(?:#[^)]*)?\)/g)) {
+    const target = resolve(dirname(referencePath), href);
+    assert.ok(target.startsWith(installed + sep), "Reference must not escape the installed Skill");
+    await readFile(target);
+  }
+  const bin = join(recipeFixture, "bin");
+  await mkdir(bin);
+  const trace = join(recipeFixture, "argv.jsonl");
+  const standIn = join(bin, "node");
+  await writeFile(standIn, `#!${process.execPath}\nconst fs = require("node:fs");\nfs.appendFileSync(process.env.TASK_RECIPE_TRACE, JSON.stringify(process.argv.slice(2)) + "\\n");\n`);
+  await chmod(standIn, 0o700);
+  const resolver = join(installed, "scripts", "research_cli.mjs");
+  const recipes = [...reference.matchAll(/```bash\n([\s\S]*?)```/g)].flatMap((match) =>
+    match[1].replace(/\\\n\s*/g, " ").split("\n").map((line) => line.trim()).filter((line) => line && !line.startsWith("#")));
+  assert.ok(recipes.length > 0, "The workflow needs executable command examples");
+  for (const line of recipes) {
+    assert.ok(line.startsWith('node "$AUTO_RESEARCH_CLI" '), "Recipes must use the installed locked resolver");
+    assert.ok(!/[`;|&<>]/.test(line) && !line.includes("$("), "Recipe must be a single bounded argv invocation");
+    const run = spawnSync("sh", ["-eu", "-c", line], {encoding: "utf8", cwd: recipeFixture,
+      env: {...process.env, PATH: bin + delimiter + process.env.PATH, AUTO_RESEARCH_CLI: resolver, TASK_RECIPE_TRACE: trace}});
+    assert.equal(run.status, 0, run.stderr);
+  }
+  const invocations = (await readFile(trace, "utf8")).trim().split("\n").map(JSON.parse);
+  for (const argv of invocations) {
+    assert.equal(argv[0], resolver);
+    assert.equal(argv[argv.indexOf("--workspace") + 1], argv[argv.lastIndexOf("--workspace") + 1]);
+  }
+  const commands = invocations.map((argv) => argv.slice(argv.indexOf("--") + 1));
+  for (const prefix of [
+    ["research", "project", "task", "define"],
+    ["research", "project", "task", "status"],
+    ["research", "project", "task", "scope", "propose"],
+    ["research", "project", "task", "scope", "approve"],
+    ["research", "project", "task", "acceptance", "record"],
+    ["research", "project", "evidence", "acquisition", "revise"],
+  ]) assert.ok(commands.some((argv) => prefix.every((part, index) => argv[index] === part)), `Missing executable recipe: ${prefix.join(" ")}`);
+  const approval = commands.find((argv) => argv.includes("scope") && argv.includes("approve"));
+  assert.equal(approval[approval.indexOf("--proposal") + 1], approval[approval.indexOf("--confirm-change") + 1]);
+} finally {
+  await rm(recipeFixture, { recursive: true, force: true });
 }
 
 process.stdout.write("Auto Research routing contract tests passed\n");


### PR DESCRIPTION
## Summary

Closes #95. Companion runtime task: tiangong-ai/cli#95 under
tiangong-ai/workspace#206.

- Keep SKILL.md concise; add one first-level execution-assurance reference for
  original-task intake, same-project pre-analysis acquisition repair, exact scope
  approval, native actual-check records and completion reporting.
- Prefer existing files, receipts, parsing results and batch boundaries. Reopen
  discovery only explicitly for new sources; preserve unchanged scientific design.
- Keep producer reasoning in the current native host and use existing reviewer
  gates. No new fixed paid review round or CLI reasoning executor.
- Distinguish original/current task completion, workflow completion and publication
  verdict. Hashes do not certify execution or authenticated human approval.
- Discover the exact locked runtime's commands/schemas once; older runtimes use
  their explicit supported recovery or a reviewed upgrade, never fabricated commands.
- Update existing references and English/Chinese integration documentation.

## Validation

- Installed-reference regression first failed in a fresh offline Docker runtime;
  the updated full suite passed in a separate runtime and in the final combined
  workspace cold gate. Full paper download discovery: 76 tests, existing opt-in
  skip retained; no real provider/login/CAPTCHA test calls.
- The installed recipe test executes every new bash example via a capture-only
  resolver, checking exact CLI/workspace/approval bindings and self-contained links.
  It is explicitly not model-behavior or scientific-validation proof.
- Independent fresh-context behavioral RED/GREEN tests moved the same repair
  scenario from fork/Policy/research-design repetition to the supported same-project
  revision, refused generic-continue scope withdrawal, and reported incomplete
  original scope honestly. No extra model was added to the product workflow.
- Runtime companion: 642 CLI tests and a fresh macOS packed-candidate canary with
  two actual NOAA files, native calculations, one deterministic platform-capsule
  reviewer, and moved portable audit verification. This validates protocol only,
  not scientific quality or top-journal readiness.
  Native downloads used explicit local-input admission in smoke/evidence-report mode;
  this is not an additional qualification of broker or publisher access.
- Canonical skill-creator quick_validate, both language docs, strict child docpact,
  explicit-diff lint and git diff --check passed. Trigger/agents UI metadata unchanged.

## Dependencies and delivery boundary

New recipes are conditional on runtime command/schema discovery and depend on
the linked CLI feature; no unmerged runtime or Skill pin is distributed by this PR.
CLI predecessor PR94 remains a separate dependency. Native case files/caches and
source responses remain outside Git. No version, root pointer, merge or release
is included; parent #206 and integration-document reviews remain pending.

Rollback: revert these guidance/recipe-test changes together. Never delete user
task/evidence records or loosen runtime scientific/reviewer gates.
