### PR TITLE
Verify downloaded academic-paper PDF identity before atomic commit

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-05"
-lastReviewedCommit: "24c56953e23f88f5fffa29c5c1447eb4feb8ba3f"
+lastReviewedAt: "2026-09-07"
+lastReviewedCommit: "8a7ceb21a00adf986ec370f57325a92c1eab7159"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c56953e23f88f5fffa29c5c1447eb4feb8ba3f
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: 246f93abffc19ff7efa6aad37f9cf2515b4fc82b
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-03
-lastReviewedCommit: 246f93abffc19ff7efa6aad37f9cf2515b4fc82b
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c56953e23f88f5fffa29c5c1447eb4feb8ba3f
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: 8a7ceb21a00adf986ec370f57325a92c1eab7159
 ---
 
 # Skills Documentation

--- a/_docs/architecture/atomic-data-capabilities.md
+++ b/_docs/architecture/atomic-data-capabilities.md
@@ -17,8 +17,8 @@ checkPaths:
   - "*-search/**"
   - "*-download/**"
   - tiangong-auto-research/**
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c5695ca3129bbe021e4b80d830742841e9011e
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # 原子数据 Skill 目标架构

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c5695ca3129bbe021e4b80d830742841e9011e
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c5695ca3129bbe021e4b80d830742841e9011e
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/atomic-data-skill-migration.md
+++ b/_docs/runbooks/atomic-data-skill-migration.md
@@ -17,8 +17,8 @@ checkPaths:
   - "*-search/**"
   - "*-download/**"
   - tiangong-auto-research/**
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c5695ca3129bbe021e4b80d830742841e9011e
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # 原子数据 Skill 迁移实施计划

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c5695ca3129bbe021e4b80d830742841e9011e
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: a8e0698e2345e2685d75960bdf972067ecd3b6f2
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-05
-lastReviewedCommit: 24c56953e23f88f5fffa29c5c1447eb4feb8ba3f
+lastReviewedAt: 2026-09-07
+lastReviewedCommit: 8a7ceb21a00adf986ec370f57325a92c1eab7159
 ---
 
 # Skills Documentation Standards

--- a/academic-paper-download/SKILL.md
+++ b/academic-paper-download/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: academic-paper-download
-description: "Fetch and atomically save verified academic-paper PDFs from legal open-access sources using a DOI or exact title, with access/license provenance and an adjacent hash manifest. Use for automatic OA retrieval or for a publisher URL that must first be resolved to a DOI and may then require an explicitly selected Chrome or optional CloakBrowser user-authorized browser handoff; supports an injectable transport for embedding in research systems."
+description: "Fetch and atomically save structurally and identity-verified academic-paper PDFs from legal open-access sources using a DOI or exact title, with access/license provenance and an adjacent hash manifest. Use for automatic OA retrieval or for a publisher URL that must first be resolved to a DOI and may then require an explicitly selected Chrome or optional CloakBrowser user-authorized browser handoff; supports an injectable transport for embedding in research systems."
 ---
 
 # Academic Paper Download
 
-Produce a structurally verified PDF and adjacent provenance manifest. Require an
-explicit final output directory and keep automatic resolution in this order:
-Unpaywall, Semantic Scholar OA, arXiv, then browser handoff.
+Produce a structurally verified, identity-bound PDF and adjacent provenance
+manifest. Require an explicit final output directory and keep automatic
+resolution in this order: Unpaywall, Semantic Scholar OA, arXiv, then browser
+handoff.
 
 ## Workflow
 
@@ -17,7 +18,7 @@ Unpaywall, Semantic Scholar OA, arXiv, then browser handoff.
 2. For a publisher URL, first resolve or confirm its DOI. Pass only that DOI to
    `fetch.py`; the CLI does not accept publisher URLs as inputs.
 3. Run the downloader and accept success only when the result contains a
-   verified file, SHA-256, size, and adjacent manifest.
+   verified file, SHA-256, size, `identity_status: matched`, and adjacent manifest.
 4. If automatic OA sources are exhausted, or a publisher page requires login,
    institution access, or interaction, explicitly choose a browser backend and
    read [references/browser-handoff.md](references/browser-handoff.md). Prefer
@@ -73,8 +74,9 @@ python3 "$SKILL_DIR/scripts/runtime.py" fetch \
   --out ./papers --format json --pretty
 ```
 
-Use `fetch schema` to inspect the unchanged machine contract version. A
-verified existing artifact may return `skipped: true`. Read
+Use `fetch schema` to inspect the machine contract version. Only an artifact
+whose current manifest records matched identity evidence may return
+`skipped: true`. Read
 [references/env.md](references/env.md) when embedding the library or diagnosing
 Python/runtime compatibility.
 
@@ -84,6 +86,13 @@ Python/runtime compatibility.
   and `4` as retryable transport failure.
 - Require `pypdf` parsing, at least one page, a final `%%EOF`, matching size,
   and SHA-256 before committing the PDF and manifest.
+- Before commit, require the requested DOI in document identity metadata or a
+  primary first-page DOI position. If no primary DOI is available, require a
+  strong title match and treat available author/year disagreement as a mismatch.
+  A title found only in first-page text also needs matching author or year evidence.
+- Do not treat arbitrary reference-list DOIs as the paper's primary DOI. A
+  scanned/no-text PDF without defensible embedded metadata is unresolved and
+  requires manual verification; it is not a successful artifact.
 - Never infer redistribution permission from successful access. Preserve
   `access_basis`, `license_status`, and source-declared license fields.
 - Never select the newest file in Downloads or accept HTML, truncated PDFs,

--- a/academic-paper-download/agents/openai.yaml
+++ b/academic-paper-download/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Academic Paper Download"
-  short_description: "Fetch verified OA or browser-authorized paper PDFs"
-  default_prompt: "Use $academic-paper-download to fetch a paper through legal OA sources, then use my explicitly selected Chrome or CloakBrowser handoff only if needed."
+  short_description: "Fetch identity-verified OA or browser-authorized paper PDFs"
+  default_prompt: "Use $academic-paper-download to fetch and identity-verify a paper through legal OA sources, then use my explicitly selected Chrome or CloakBrowser handoff only if needed."

--- a/academic-paper-download/references/browser-handoff.md
+++ b/academic-paper-download/references/browser-handoff.md
@@ -74,8 +74,11 @@ staging; `finalize` always requires `--output-dir`. By default its manifest uses
 
 The finalizer rejects pre-snapshot files, symbolic links, partial downloads,
 HTML, truncated PDFs, and invalid output directories. It parses at least one
-page, checks `%%EOF`, copies atomically, verifies size/SHA-256, and commits the
-manifest last.
+page, checks `%%EOF`, verifies scholarly identity from bounded metadata and
+first-page evidence, copies atomically, verifies size/SHA-256, and commits the
+manifest last. Identity mismatch or unresolved identity exits without moving
+the exact browser download into the final output or writing a success manifest.
+The original browser download remains available for explicit manual review.
 
 ## Human Action
 

--- a/academic-paper-download/references/cloakbrowser-handoff.md
+++ b/academic-paper-download/references/cloakbrowser-handoff.md
@@ -105,8 +105,10 @@ filename, and event ID. It never scans Downloads or selects the newest PDF.
 
 The presence of the staged file is not success. The executor passes that exact
 path to `finalize_browser_download.py`, which retains the existing pypdf, EOF,
-size, SHA-256, atomic-copy, and manifest-last checks. Failed or canceled
-downloads do not commit a manifest.
+size, SHA-256, atomic-copy, and manifest-last checks and now requires the same
+bounded scholarly identity match as automatic retrieval and Chrome handoff.
+Failed, canceled, mismatched, or identity-unresolved downloads do not commit a
+manifest.
 
 ## Human Action and Stop Rules
 
@@ -142,6 +144,10 @@ Configuration errors are structured and actionable:
   security controls.
 - `human_action_required`: complete or assess the displayed challenge; no
   automatic retry or bypass occurred.
+- `pdf_identity_mismatch`: the exact downloaded PDF conflicts with the
+  requested DOI/title identity; inspect it manually rather than committing it.
+- `pdf_identity_unresolved`: bounded metadata/first-page checks cannot establish
+  identity, including scanned/no-text PDFs without usable embedded metadata.
 
 All errors and events pass through the existing sanitization layer. Never place
 profile paths, cookies, Authorization headers, proxy passwords, license keys, or

--- a/academic-paper-download/references/integration.md
+++ b/academic-paper-download/references/integration.md
@@ -42,6 +42,25 @@ retryable=...)` for classified failures and must write downloads only to the
 provided temporary `destination`. They must not log sensitive header values or
 unsanitized URL query credentials.
 
+## Identity Contract
+
+Automatic and browser commits share the same fail-closed identity validator.
+Successful results and manifests use schema v3 and include
+`identity_status: matched` plus bounded `identity` evidence. Document DOI fields
+and primary first-page DOI positions take precedence. When neither supplies a
+DOI, a strong title match may succeed unless available author or year evidence
+conflicts; a title found only in first-page text also requires positive author
+or year support. Subject, keywords, descriptions, and other DOI strings remain
+recorded as non-primary observations and do not by themselves identify or
+reject a paper.
+
+`pdf_identity_mismatch` means the available primary identity evidence conflicts
+with the requested paper. `pdf_identity_unresolved` means metadata and bounded
+first-page text were insufficient. Neither error commits a PDF or success
+manifest. The validator performs no OCR and never stores extracted page text.
+Legacy v2 manifests have no identity evidence and are ineligible for verified
+replay.
+
 ## Browser Handoff Boundary
 
 Do not implement Chrome or CloakBrowser as `PaperTransport`. The optional
@@ -49,4 +68,5 @@ CloakBrowser executor has a separate injectable `BrowserAdapter` for fake-based
 tests and publisher-page interaction. It captures one Playwright-compatible
 Download object, saves it to a preplanned unique staging path, and then invokes
 `finalize_browser_download.py`; it does not participate in OA resolution or
-metadata HTTP traffic.
+metadata HTTP traffic. The finalizer identity-checks that exact staged file
+before renaming, copying, or writing its manifest.

--- a/academic-paper-download/scripts/finalize_browser_download.py
+++ b/academic-paper-download/scripts/finalize_browser_download.py
@@ -25,6 +25,7 @@ from paper_fetch.artifact import (
     verify_existing,
 )
 from paper_fetch.errors import PaperFetchError
+from paper_fetch.identity import validate_pdf_identity
 from paper_fetch.models import Candidate, PaperMetadata
 from paper_fetch.normalize import normalize_doi
 from paper_fetch.sanitize import sanitize_data
@@ -265,6 +266,11 @@ def finalize(args: argparse.Namespace) -> int:
         return fail(exc.code, exc.message, 4, **exc.details)
 
     metadata = PaperMetadata(title=args.title, author=args.author, year=args.year, journal=args.journal)
+    try:
+        identity = validate_pdf_identity(source, doi, metadata)
+    except PaperFetchError as exc:
+        exit_code = 4 if exc.code == "pdf_validator_unavailable" else 1
+        return fail(exc.code, exc.message, exit_code, **exc.details)
     if args.filename:
         try:
             final_filename = _safe_pdf_filename(args.filename)
@@ -358,6 +364,7 @@ def finalize(args: argparse.Namespace) -> int:
         size=size,
         digest=digest,
         access_mode=getattr(args, "access_mode", None) or "current-browser-session",
+        identity=identity,
         extra={
             "browser_original_file": str(browser_original_file),
             "browser_source_file": str(source),

--- a/academic-paper-download/scripts/paper_fetch/artifact.py
+++ b/academic-paper-download/scripts/paper_fetch/artifact.py
@@ -13,12 +13,13 @@ from typing import Any
 
 from .errors import PaperFetchError
 from .http import PaperTransport
+from .identity import validate_pdf_identity
 from .models import Candidate, PaperMetadata
 from .normalize import normalize_doi
 from .sanitize import sanitize_data
 
 
-MANIFEST_SCHEMA = "academic-paper-download.artifact.v2"
+MANIFEST_SCHEMA = "academic-paper-download.artifact.v3"
 DEFAULT_MAX_BYTES = 100 * 1024 * 1024
 
 
@@ -124,6 +125,18 @@ def _matching_manifest(path: Path, doi: str) -> dict[str, Any] | None:
             return None
         if normalize_doi(str(manifest.get("doi", ""))) != normalize_doi(doi):
             return None
+        identity = manifest.get("identity")
+        if (
+            manifest.get("identity_status") != "matched"
+            or not isinstance(identity, dict)
+            or identity.get("status") != "matched"
+        ):
+            return None
+        identity_requested = identity.get("requested")
+        if not isinstance(identity_requested, dict):
+            return None
+        if normalize_doi(str(identity_requested.get("doi", ""))) != normalize_doi(doi):
+            return None
         if int(manifest.get("size", -1)) != path.stat().st_size:
             return None
         if manifest.get("sha256") != sha256_file(path):
@@ -155,6 +168,7 @@ def build_manifest(
     size: int,
     digest: str,
     access_mode: str,
+    identity: dict[str, Any],
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     retrieved_at = datetime.now(timezone.utc).isoformat()
@@ -180,6 +194,8 @@ def build_manifest(
         "file": str(path),
         "size": size,
         "sha256": digest,
+        "identity_status": identity["status"],
+        "identity": identity,
         **(extra or {}),
     })
 
@@ -241,6 +257,8 @@ class ArtifactStore:
                 "sha256": existing["sha256"],
                 "skipped": True,
                 "verified_existing": True,
+                "identity_status": existing["identity_status"],
+                "identity": existing["identity"],
                 "committed_manifest": existing,
             }
         destination = choose_available_path(self.output_dir, filename)
@@ -260,6 +278,7 @@ class ArtifactStore:
                 headers=candidate.headers or None,
             )
             size, digest = validate_pdf(temporary, self.max_bytes)
+            identity = validate_pdf_identity(temporary, doi, metadata)
             manifest = build_manifest(
                 doi=doi,
                 candidate=candidate,
@@ -268,6 +287,7 @@ class ArtifactStore:
                 size=size,
                 digest=digest,
                 access_mode="http",
+                identity=identity,
             )
             os.replace(temporary, destination)
             try:
@@ -286,6 +306,8 @@ class ArtifactStore:
                 "sha256": digest,
                 "skipped": False,
                 "verified_existing": False,
+                "identity_status": manifest["identity_status"],
+                "identity": manifest["identity"],
                 "committed_manifest": manifest,
             }
         finally:

--- a/academic-paper-download/scripts/paper_fetch/cli.py
+++ b/academic-paper-download/scripts/paper_fetch/cli.py
@@ -20,7 +20,7 @@ from .sanitize import sanitize_data
 
 
 CLI_VERSION = "1.0.0"
-SCHEMA_VERSION = "2.0.0"
+SCHEMA_VERSION = "3.0.0"
 EXIT_SUCCESS = 0
 EXIT_UNRESOLVED = 1
 EXIT_VALIDATION = 3
@@ -37,9 +37,19 @@ def schema() -> dict[str, Any]:
             "temporary_file",
             "pdf_structure_validation",
             "sha256",
+            "pdf_identity_validation",
             "atomic_rename",
             "manifest_commit",
         ],
+        "identity_policy": {
+            "required_status": "matched",
+            "doi_sources": ["document_metadata", "primary_first_page"],
+            "fallback": {
+                "document_metadata_title": "strong_match",
+                "first_page_title": "strong_match_plus_author_or_year",
+            },
+            "unresolved": "fail_before_commit",
+        },
         "dependencies": {"pypdf": "==6.14.2"},
         "environment": {
             "UNPAYWALL_EMAIL": "Enable Unpaywall with its required contact email.",

--- a/academic-paper-download/scripts/paper_fetch/idempotency.py
+++ b/academic-paper-download/scripts/paper_fetch/idempotency.py
@@ -9,7 +9,7 @@ from .artifact import atomic_write_json, verify_existing
 from .errors import PaperFetchError
 
 
-SCHEMA = "academic-paper-download.idempotency.v2"
+SCHEMA = "academic-paper-download.idempotency.v3"
 
 
 def request_fingerprint(payload: dict[str, Any]) -> str:

--- a/academic-paper-download/scripts/paper_fetch/identity.py
+++ b/academic-paper-download/scripts/paper_fetch/identity.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+import importlib
+import re
+import urllib.parse
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from .errors import PaperFetchError
+from .models import PaperMetadata
+from .normalize import normalize_doi, normalize_title, title_similarity
+from .sanitize import sanitize_data
+
+
+IDENTITY_SCHEMA = "academic-paper-download.identity.v1"
+MAX_METADATA_VALUE_CHARS = 2048
+MAX_FIRST_PAGE_ENCODED_BYTES = 2 * 1024 * 1024
+MAX_FIRST_PAGE_CONTENT_BYTES = 2 * 1024 * 1024
+MAX_FIRST_PAGE_TEXT_CHARS = 64 * 1024
+MAX_FIRST_PAGE_LINES = 80
+MAX_IDENTITY_HEADER_LINES = 24
+MAX_FIRST_PAGE_CONTENT_STREAMS = 256
+MAX_OBSERVED_DOIS = 16
+TITLE_MATCH_MIN = 0.86
+TITLE_MISMATCH_MAX = 0.45
+AUTHOR_MATCH_MIN = 0.72
+
+DOI_CANDIDATE_RE = re.compile(
+    r"(?:(?:https?://)?(?:dx\.)?doi\.org/|doi:\s*)?10\.\d{4,9}/[^\s\"<>]+",
+    re.IGNORECASE,
+)
+PRIMARY_DOI_LINE_RE = re.compile(
+    r"(?:^|\b)(?:(?:https?://)?(?:dx\.)?doi\.org/|(?:doi|digital\s+object\s+identifier)\s*[:\s])",
+    re.IGNORECASE,
+)
+NON_PRIMARY_DOI_LINE_RE = re.compile(
+    r"\b(?:background|bibliograph\w*|cit(?:e|ed|es|ing|ation|ations)|references?)\b",
+    re.IGNORECASE,
+)
+EXPLICIT_IDENTIFIER_KEYS = {
+    "doi",
+    "dc:identifier",
+    "prism:doi",
+}
+TITLE_KEYS = {"title", "dc:title"}
+AUTHOR_KEYS = {"author", "creator", "dc:creator"}
+YEAR_KEYS = {"year", "publicationyear", "publication_year", "prism:publicationdate"}
+CONTEXT_KEYS = {"identifier", "subject", "keywords", "description", "dc:description"}
+
+
+def _bounded_text(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:
+        return None
+    return text[:MAX_METADATA_VALUE_CHARS] or None
+
+
+def _flatten(value: Any) -> Iterable[Any]:
+    if value is None:
+        return
+    if isinstance(value, dict):
+        for nested in value.values():
+            yield from _flatten(nested)
+        return
+    if isinstance(value, (list, tuple, set)):
+        for nested in value:
+            yield from _flatten(nested)
+        return
+    yield value
+
+
+def _append_values(target: list[tuple[str, str]], source: str, value: Any) -> None:
+    for nested in _flatten(value):
+        text = _bounded_text(nested)
+        if text and (source, text) not in target:
+            target.append((source, text))
+
+
+def _trim_doi_candidate(value: str) -> str:
+    candidate = value.rstrip(".,;:'\"，。；：、")
+    pairs = ((")", "("), ("]", "["), ("}", "{"))
+    changed = True
+    while changed and candidate:
+        changed = False
+        for closer, opener in pairs:
+            if candidate.endswith(closer) and candidate.count(closer) > candidate.count(opener):
+                candidate = candidate[:-1]
+                changed = True
+    return candidate
+
+
+def _extract_dois(values: Iterable[str]) -> list[str]:
+    observed: list[str] = []
+    for value in values:
+        decoded = urllib.parse.unquote(value)
+        for match in DOI_CANDIDATE_RE.finditer(decoded):
+            candidate = _trim_doi_candidate(match.group(0))
+            try:
+                normalized = normalize_doi(candidate)
+            except PaperFetchError:
+                continue
+            if normalized not in observed:
+                observed.append(normalized)
+            if len(observed) >= MAX_OBSERVED_DOIS:
+                return observed
+    return observed
+
+
+def _metadata_evidence(reader: Any, limitations: list[str]) -> dict[str, Any]:
+    titles: list[tuple[str, str]] = []
+    authors: list[tuple[str, str]] = []
+    years: list[tuple[str, str]] = []
+    identifier_values: list[str] = []
+    context_values: list[str] = []
+
+    try:
+        document = reader.metadata
+    except Exception:
+        document = None
+        limitations.append("document_metadata_unreadable")
+    if document:
+        try:
+            items = list(document.items())
+        except Exception:
+            items = []
+            limitations.append("document_metadata_unreadable")
+        for raw_key, raw_value in items:
+            key = str(raw_key).lstrip("/").casefold()
+            text = _bounded_text(raw_value)
+            if not text:
+                continue
+            if key in EXPLICIT_IDENTIFIER_KEYS or key.endswith(":doi"):
+                identifier_values.append(text)
+            elif key in TITLE_KEYS:
+                _append_values(titles, "document_metadata", text)
+            elif key in AUTHOR_KEYS:
+                _append_values(authors, "document_metadata", text)
+            elif key in YEAR_KEYS:
+                _append_values(years, "document_metadata", text)
+            elif key in CONTEXT_KEYS:
+                context_values.append(text)
+
+    try:
+        xmp = reader.xmp_metadata
+    except Exception:
+        xmp = None
+        limitations.append("xmp_metadata_unreadable")
+    if xmp:
+        try:
+            identifier = getattr(xmp, "dc_identifier", None)
+            if identifier:
+                identifier_values.extend(
+                    text for value in _flatten(identifier) if (text := _bounded_text(value))
+                )
+            _append_values(titles, "xmp_metadata", getattr(xmp, "dc_title", None))
+            _append_values(authors, "xmp_metadata", getattr(xmp, "dc_creator", None))
+            _append_values(years, "xmp_metadata", getattr(xmp, "dc_date", None))
+            for attribute in ("dc_description", "dc_subject"):
+                for value in _flatten(getattr(xmp, attribute, None)):
+                    text = _bounded_text(value)
+                    if text:
+                        context_values.append(text)
+        except Exception:
+            limitations.append("xmp_metadata_partially_unreadable")
+
+    return {
+        "document_dois": _extract_dois(identifier_values),
+        "metadata_context_dois": _extract_dois(context_values),
+        "titles": titles,
+        "authors": authors,
+        "years": years,
+    }
+
+
+def _encoded_content_bytes(page: Any) -> int | None:
+    try:
+        raw = page.raw_get("/Contents")
+    except Exception:
+        return None
+    pending = [raw]
+    total = 0
+    streams = 0
+    while pending:
+        item = pending.pop()
+        try:
+            stream = item.get_object() if hasattr(item, "get_object") else item
+        except Exception:
+            return None
+        if isinstance(stream, (list, tuple)):
+            pending.extend(stream)
+            if len(pending) + streams > MAX_FIRST_PAGE_CONTENT_STREAMS:
+                return MAX_FIRST_PAGE_ENCODED_BYTES + 1
+            continue
+        streams += 1
+        if streams > MAX_FIRST_PAGE_CONTENT_STREAMS:
+            return MAX_FIRST_PAGE_ENCODED_BYTES + 1
+        # pypdf exposes only decoded bytes publicly; inspect its encoded payload
+        # here so an oversized stream can be rejected before decompression.
+        data = getattr(stream, "_data", None)
+        if not isinstance(data, (bytes, bytearray)):
+            return None
+        total += len(data)
+        if total > MAX_FIRST_PAGE_ENCODED_BYTES:
+            return total
+    return total
+
+
+def _first_page_evidence(reader: Any, limitations: list[str]) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "examined": True,
+        "text": "",
+        "header_text": "",
+        "encoded_bytes": None,
+        "content_bytes": 0,
+        "dois": [],
+        "primary_dois": [],
+    }
+    try:
+        page = reader.pages[0]
+        encoded_bytes = _encoded_content_bytes(page)
+        result["encoded_bytes"] = encoded_bytes
+        if encoded_bytes is not None and encoded_bytes > MAX_FIRST_PAGE_ENCODED_BYTES:
+            limitations.append("first_page_encoded_content_limit_exceeded")
+            return result
+        contents = page.get_contents()
+        if contents is None:
+            limitations.append("first_page_has_no_content_stream")
+            return result
+        content_bytes = len(contents.get_data())
+        result["content_bytes"] = content_bytes
+        if content_bytes > MAX_FIRST_PAGE_CONTENT_BYTES:
+            limitations.append("first_page_content_limit_exceeded")
+            return result
+        text = page.extract_text() or ""
+    except Exception:
+        limitations.append("first_page_text_unreadable")
+        return result
+    if len(text) > MAX_FIRST_PAGE_TEXT_CHARS:
+        text = text[:MAX_FIRST_PAGE_TEXT_CHARS]
+        limitations.append("first_page_text_truncated")
+    result["text"] = text
+    lines = text.splitlines()
+    result["header_text"] = "\n".join(lines[:MAX_IDENTITY_HEADER_LINES])
+    all_dois: list[str] = []
+    primary_dois: list[str] = []
+    for index, line in enumerate(lines[:MAX_FIRST_PAGE_LINES]):
+        line_dois = _extract_dois([line])
+        for doi in line_dois:
+            if doi not in all_dois:
+                all_dois.append(doi)
+        if (
+            index < MAX_IDENTITY_HEADER_LINES
+            and PRIMARY_DOI_LINE_RE.search(line)
+            and not NON_PRIMARY_DOI_LINE_RE.search(line)
+        ):
+            for doi in line_dois:
+                if doi not in primary_dois:
+                    primary_dois.append(doi)
+    result["dois"] = all_dois[:MAX_OBSERVED_DOIS]
+    result["primary_dois"] = primary_dois[:MAX_OBSERVED_DOIS]
+    if len(all_dois) > 1:
+        limitations.append("multiple_first_page_dois")
+    return result
+
+
+def _best_title_check(
+    requested: str | None,
+    candidates: list[tuple[str, str]],
+    first_page_text: str,
+) -> dict[str, Any]:
+    requested_normalized = normalize_title(requested or "")
+    check: dict[str, Any] = {
+        "status": "unavailable",
+        "requested": requested_normalized or None,
+        "observed": None,
+        "similarity": None,
+        "source": None,
+    }
+    if not requested_normalized:
+        return check
+    best: tuple[float, str, str, str] | None = None
+    for source, value in candidates:
+        normalized = normalize_title(value)
+        if not normalized:
+            continue
+        score = title_similarity(requested, value)
+        shorter = min(
+            (requested_normalized, normalized),
+            key=len,
+        )
+        if (
+            requested_normalized != normalized
+            and shorter in max((requested_normalized, normalized), key=len)
+            and (len(shorter) >= 24 or len(shorter.split()) >= 4)
+        ):
+            score = max(score, 0.95)
+        if best is None or score > best[0]:
+            best = (score, source, value, normalized)
+    page_normalized = normalize_title(first_page_text)
+    padded_page = f" {page_normalized} "
+    padded_requested = f" {requested_normalized} "
+    if (
+        len(requested_normalized) >= 8
+        and padded_requested in padded_page
+        and (best is None or best[0] < 1.0)
+    ):
+        best = (1.0, "first_page", requested, requested_normalized)
+    if best is None:
+        return check
+    score, source, value, normalized = best
+    check.update(
+        {
+            "status": (
+                "matched"
+                if score >= TITLE_MATCH_MIN
+                else "mismatched"
+                if score <= TITLE_MISMATCH_MAX
+                else "ambiguous"
+            ),
+            "observed": {
+                "value": _bounded_text(value),
+                "normalized": normalized,
+            },
+            "similarity": round(score, 4),
+            "source": source,
+        }
+    )
+    return check
+
+
+def _author_check(
+    requested: str | None,
+    candidates: list[tuple[str, str]],
+    first_page_text: str,
+) -> dict[str, Any]:
+    requested_normalized = normalize_title(requested or "")
+    check: dict[str, Any] = {
+        "status": "not_requested" if not requested_normalized else "unavailable",
+        "requested": requested_normalized or None,
+        "observed": None,
+        "source": None,
+    }
+    if not requested_normalized:
+        return check
+    requested_parts = requested_normalized.split()
+    requested_tokens = set(requested_parts)
+    for source, value in candidates:
+        normalized = normalize_title(value)
+        observed_parts = normalized.split()
+        observed_tokens = set(observed_parts)
+        surname_match = bool(
+            requested_parts
+            and observed_parts
+            and (
+                (len(requested_parts[-1]) > 1 and requested_parts[-1] in observed_tokens)
+                or (len(observed_parts[-1]) > 1 and observed_parts[-1] in requested_tokens)
+            )
+        )
+        if (
+            requested_normalized in normalized
+            or requested_tokens.issubset(observed_tokens)
+            or surname_match
+            or title_similarity(requested, value) >= AUTHOR_MATCH_MIN
+        ):
+            check.update(
+                {
+                    "status": "matched",
+                    "observed": {"value": _bounded_text(value), "normalized": normalized},
+                    "source": source,
+                }
+            )
+            return check
+    page_normalized = normalize_title(first_page_text)
+    if requested_normalized and requested_normalized in page_normalized:
+        check.update(
+            {
+                "status": "matched",
+                "observed": {"value": requested, "normalized": requested_normalized},
+                "source": "first_page",
+            }
+        )
+    elif candidates:
+        source, value = candidates[0]
+        check.update(
+            {
+                "status": "mismatched",
+                "observed": {
+                    "value": _bounded_text(value),
+                    "normalized": normalize_title(value),
+                },
+                "source": source,
+            }
+        )
+    return check
+
+
+def _year_value(value: str) -> str | None:
+    match = re.search(r"(?<!\d)(1[5-9]\d{2}|20\d{2}|21\d{2})(?!\d)", value)
+    return match.group(1) if match else None
+
+
+def _year_check(
+    requested: int | str | None,
+    candidates: list[tuple[str, str]],
+    first_page_text: str,
+) -> dict[str, Any]:
+    requested_year = _year_value(str(requested)) if requested not in (None, "") else None
+    check: dict[str, Any] = {
+        "status": "not_requested" if not requested_year else "unavailable",
+        "requested": requested_year,
+        "observed": None,
+        "source": None,
+    }
+    if not requested_year:
+        return check
+    observed: list[tuple[str, str]] = []
+    for source, value in candidates:
+        if year := _year_value(value):
+            observed.append((source, year))
+            if year == requested_year:
+                check.update({"status": "matched", "observed": year, "source": source})
+                return check
+    if re.search(rf"(?<!\d){re.escape(requested_year)}(?!\d)", first_page_text):
+        check.update(
+            {"status": "matched", "observed": requested_year, "source": "first_page"}
+        )
+    elif observed:
+        requested_number = int(requested_year)
+        nearest = min(observed, key=lambda item: abs(int(item[1]) - requested_number))
+        check.update(
+            {
+                "status": (
+                    "ambiguous"
+                    if abs(int(nearest[1]) - requested_number) == 1
+                    else "mismatched"
+                ),
+                "observed": nearest[1],
+                "source": nearest[0],
+            }
+        )
+    return check
+
+
+def _identity_payload(
+    *,
+    requested_doi: str,
+    requested_metadata: PaperMetadata,
+    metadata: dict[str, Any],
+    page: dict[str, Any],
+    limitations: list[str],
+) -> dict[str, Any]:
+    title = _best_title_check(
+        requested_metadata.title,
+        metadata["titles"],
+        page["header_text"],
+    )
+    author = _author_check(
+        requested_metadata.author,
+        metadata["authors"],
+        page["header_text"],
+    )
+    year = _year_check(
+        requested_metadata.year,
+        metadata["years"],
+        page["header_text"],
+    )
+    return {
+        "schema_version": IDENTITY_SCHEMA,
+        "status": "unresolved",
+        "method": None,
+        "confidence": 0.0,
+        "requested": {
+            "doi": requested_doi,
+            "title": normalize_title(requested_metadata.title or "") or None,
+            "author": normalize_title(requested_metadata.author or "") or None,
+            "year": _year_value(str(requested_metadata.year or "")),
+        },
+        "observed": {
+            "document_dois": metadata["document_dois"],
+            "metadata_context_dois": metadata["metadata_context_dois"],
+            "first_page_dois": page["dois"],
+            "first_page_primary_dois": page["primary_dois"],
+            "first_page_examined": page["examined"],
+            "first_page_encoded_bytes": page["encoded_bytes"],
+            "first_page_content_bytes": page["content_bytes"],
+        },
+        "checks": {
+            "doi": {
+                "status": "unavailable",
+                "requested": requested_doi,
+                "document": metadata["document_dois"],
+                "metadata_context": metadata["metadata_context_dois"],
+                "first_page": page["dois"],
+                "first_page_primary": page["primary_dois"],
+            },
+            "title": title,
+            "author": author,
+            "year": year,
+        },
+        "limits": {
+            "metadata_value_chars": MAX_METADATA_VALUE_CHARS,
+            "first_page_encoded_bytes": MAX_FIRST_PAGE_ENCODED_BYTES,
+            "first_page_content_bytes": MAX_FIRST_PAGE_CONTENT_BYTES,
+            "first_page_text_chars": MAX_FIRST_PAGE_TEXT_CHARS,
+            "first_page_lines": MAX_FIRST_PAGE_LINES,
+            "identity_header_lines": MAX_IDENTITY_HEADER_LINES,
+            "first_page_content_streams": MAX_FIRST_PAGE_CONTENT_STREAMS,
+            "observed_dois": MAX_OBSERVED_DOIS,
+        },
+        "limitations": sorted(set(limitations)),
+    }
+
+
+def _matched(identity: dict[str, Any], method: str, confidence: float) -> dict[str, Any]:
+    identity["status"] = "matched"
+    identity["method"] = method
+    identity["confidence"] = confidence
+    if method.startswith("doi_"):
+        identity["checks"]["doi"]["status"] = "matched"
+    elif any(
+        identity["checks"]["doi"][name]
+        for name in ("metadata_context", "first_page")
+    ):
+        identity["checks"]["doi"]["status"] = "non_primary_only"
+    identity["limitations"] = sorted(set(identity["limitations"]))
+    return sanitize_data(identity)
+
+
+def _reject(identity: dict[str, Any], code: str, message: str) -> None:
+    identity["status"] = "mismatched" if code == "pdf_identity_mismatch" else "unresolved"
+    identity["limitations"] = sorted(set(identity["limitations"]))
+    raise PaperFetchError(code, message, retryable=False, identity=identity)
+
+
+def validate_pdf_identity(
+    path: Path,
+    doi: str,
+    metadata: PaperMetadata,
+) -> dict[str, Any]:
+    requested_doi = normalize_doi(doi)
+    limitations = ["no_ocr", "first_page_only"]
+    try:
+        pdf_module = importlib.import_module("pypdf")
+    except ImportError as exc:
+        raise PaperFetchError(
+            "pdf_validator_unavailable",
+            "PDF identity validation requires pypdf; run runtime.py bootstrap --locked or satisfy pyproject.toml when embedding",
+            retryable=False,
+            path=str(path),
+        ) from exc
+    try:
+        reader = pdf_module.PdfReader(str(path), strict=False)
+        if reader.is_encrypted and not reader.decrypt(""):
+            raise ValueError("encrypted PDF cannot be opened without a password")
+    except Exception as exc:
+        raise PaperFetchError(
+            "pdf_identity_unresolved",
+            "Downloaded PDF identity could not be read after structural validation",
+            retryable=False,
+            path=str(path),
+        ) from exc
+
+    try:
+        extracted_metadata = _metadata_evidence(reader, limitations)
+        document_dois = extracted_metadata["document_dois"]
+        if document_dois:
+            page = {
+                "examined": False,
+                "text": "",
+                "header_text": "",
+                "encoded_bytes": None,
+                "content_bytes": 0,
+                "dois": [],
+                "primary_dois": [],
+            }
+            identity = _identity_payload(
+                requested_doi=requested_doi,
+                requested_metadata=metadata,
+                metadata=extracted_metadata,
+                page=page,
+                limitations=limitations,
+            )
+            if requested_doi in document_dois:
+                if len(document_dois) > 1:
+                    identity["limitations"].append("multiple_document_dois")
+                return _matched(identity, "doi_document_metadata", 1.0)
+
+        page = _first_page_evidence(reader, limitations)
+        identity = _identity_payload(
+            requested_doi=requested_doi,
+            requested_metadata=metadata,
+            metadata=extracted_metadata,
+            page=page,
+            limitations=limitations,
+        )
+        primary_dois = page["primary_dois"]
+        if requested_doi in primary_dois:
+            if document_dois and requested_doi not in document_dois:
+                identity["limitations"].append("document_doi_conflicts_with_first_page")
+                return _matched(identity, "doi_first_page", 0.9)
+            return _matched(identity, "doi_first_page", 1.0)
+        if document_dois:
+            identity["checks"]["doi"]["status"] = "mismatched"
+            _reject(
+                identity,
+                "pdf_identity_mismatch",
+                "Downloaded PDF document DOI does not match the requested DOI",
+            )
+        if primary_dois:
+            identity["checks"]["doi"]["status"] = "mismatched"
+            _reject(
+                identity,
+                "pdf_identity_mismatch",
+                "Downloaded PDF primary first-page DOI does not match the requested DOI",
+            )
+
+        title_check = identity["checks"]["title"]
+        support_mismatch = any(
+            identity["checks"][name]["status"] == "mismatched"
+            for name in ("author", "year")
+        )
+        positive_support = any(
+            identity["checks"][name]["status"] == "matched"
+            for name in ("author", "year")
+        )
+        first_page_title_without_support = (
+            title_check["source"] == "first_page" and not positive_support
+        )
+        if (
+            title_check["status"] == "matched"
+            and not support_mismatch
+            and not first_page_title_without_support
+        ):
+            if page["dois"] or extracted_metadata["metadata_context_dois"]:
+                identity["limitations"].append("non_primary_dois_ignored")
+            identity["limitations"].append("doi_not_found_title_fallback")
+            method = (
+                "title_first_page"
+                if title_check["source"] == "first_page"
+                else "title_document_metadata"
+            )
+            return _matched(identity, method, float(title_check["similarity"] or 0.0))
+        if title_check["status"] == "mismatched" or support_mismatch:
+            _reject(
+                identity,
+                "pdf_identity_mismatch",
+                "Downloaded PDF title, author, or year does not match the requested paper",
+            )
+        _reject(
+            identity,
+            "pdf_identity_unresolved",
+            "Downloaded PDF identity could not be verified from document metadata or bounded first-page text",
+        )
+    finally:
+        close = getattr(reader, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass

--- a/academic-paper-download/scripts/paper_fetch/pipeline.py
+++ b/academic-paper-download/scripts/paper_fetch/pipeline.py
@@ -130,9 +130,25 @@ class PaperFetcher:
         retryable = any(
             bool((attempt.get("error") or {}).get("retryable")) for attempt in attempts
         )
+        attempt_codes = [
+            str((attempt.get("error") or {}).get("code") or "") for attempt in attempts
+        ]
+        identity_codes = {"pdf_identity_mismatch", "pdf_identity_unresolved"}
+        only_identity_failures = bool(attempt_codes) and all(
+            code in identity_codes for code in attempt_codes
+        )
+        if only_identity_failures and "pdf_identity_mismatch" in attempt_codes:
+            error_code = "pdf_identity_mismatch"
+            error_message = "Every downloaded PDF candidate mismatched the requested paper identity"
+        elif only_identity_failures:
+            error_code = "pdf_identity_unresolved"
+            error_message = "No downloaded PDF candidate had sufficient identity evidence"
+        else:
+            error_code = "download_unresolved" if attempts else "not_found"
+            error_message = "No configured source produced a verified PDF"
         error = PaperFetchError(
-            "download_unresolved" if attempts else "not_found",
-            "No configured source produced a verified PDF",
+            error_code,
+            error_message,
             retryable=retryable,
             attempts=attempts,
         )

--- a/academic-paper-download/scripts/smoke_test.py
+++ b/academic-paper-download/scripts/smoke_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run a network-free structural PDF smoke test inside the locked runtime."""
+"""Run a network-free structural and identity PDF smoke inside the locked runtime."""
 
 from __future__ import annotations
 
@@ -39,6 +39,8 @@ def main(argv: list[str] | None = None) -> int:
     socket.socket = _OfflineSocket
     pypdf = importlib.import_module("pypdf")
     artifact = importlib.import_module("paper_fetch.artifact")
+    identity_validator = importlib.import_module("paper_fetch.identity")
+    models = importlib.import_module("paper_fetch.models")
     expected = os.environ.get("ACADEMIC_PAPER_DOWNLOAD_EXPECTED_PYPDF", "")
     installed = importlib.metadata.version("pypdf")
     if installed != expected:
@@ -52,9 +54,26 @@ def main(argv: list[str] | None = None) -> int:
         pdf = Path(temporary) / "smoke.pdf"
         writer = pypdf.PdfWriter()
         writer.add_blank_page(width=72, height=72)
+        writer.add_metadata(
+            {
+                "/DOI": "10.1234/smoke",
+                "/Title": "Academic Paper Download Smoke",
+                "/Author": "Tiangong AI",
+                "/Year": "2026",
+            }
+        )
         with pdf.open("wb") as handle:
             writer.write(handle)
         size, digest = artifact.validate_pdf(pdf)
+        identity = identity_validator.validate_pdf_identity(
+            pdf,
+            "10.1234/smoke",
+            models.PaperMetadata(
+                title="Academic Paper Download Smoke",
+                author="Tiangong AI",
+                year=2026,
+            ),
+        )
 
     payload = {
         "ok": True,
@@ -67,6 +86,7 @@ def main(argv: list[str] | None = None) -> int:
             "pdf_pages": 1,
             "pdf_size": size,
             "sha256": digest,
+            "identity_status": identity["status"],
         },
     }
     if args.json:

--- a/academic-paper-download/scripts/tests/helpers.py
+++ b/academic-paper-download/scripts/tests/helpers.py
@@ -6,14 +6,64 @@ from pathlib import Path
 from typing import Any
 
 from pypdf import PdfWriter
+from pypdf.generic import DecodedStreamObject, DictionaryObject, NameObject
 
 from paper_fetch.errors import PaperFetchError
 
 
-def make_pdf_bytes() -> bytes:
+def _pdf_text(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+
+def make_pdf_bytes(
+    *,
+    doi: str | None = "10.1234/example",
+    title: str | None = "Example paper",
+    author: str | None = "Alice Example",
+    year: int | str | None = 2024,
+    first_page_lines: tuple[str, ...] = (),
+    include_document_metadata: bool = True,
+) -> bytes:
     buffer = io.BytesIO()
     writer = PdfWriter()
-    writer.add_blank_page(width=612, height=792)
+    page = writer.add_blank_page(width=612, height=792)
+    if include_document_metadata:
+        metadata = {
+            key: str(value)
+            for key, value in {
+                "/DOI": doi,
+                "/Title": title,
+                "/Author": author,
+                "/Year": year,
+            }.items()
+            if value not in (None, "")
+        }
+        if metadata:
+            writer.add_metadata(metadata)
+    if first_page_lines:
+        font = DictionaryObject(
+            {
+                NameObject("/Type"): NameObject("/Font"),
+                NameObject("/Subtype"): NameObject("/Type1"),
+                NameObject("/BaseFont"): NameObject("/Helvetica"),
+            }
+        )
+        page[NameObject("/Resources")] = DictionaryObject(
+            {
+                NameObject("/Font"): DictionaryObject(
+                    {NameObject("/F1"): writer._add_object(font)}
+                )
+            }
+        )
+        commands = ["BT /F1 12 Tf 14 TL 72 720 Td"]
+        for index, line in enumerate(first_page_lines):
+            commands.append(f"({_pdf_text(line)}) Tj")
+            if index < len(first_page_lines) - 1:
+                commands.append("T*")
+        commands.append("ET")
+        contents = DecodedStreamObject()
+        contents.set_data(" ".join(commands).encode("latin-1"))
+        page[NameObject("/Contents")] = writer._add_object(contents)
     writer.write(buffer)
     return buffer.getvalue()
 

--- a/academic-paper-download/scripts/tests/helpers.py
+++ b/academic-paper-download/scripts/tests/helpers.py
@@ -15,13 +15,43 @@ def _pdf_text(value: str) -> str:
     return value.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
 
 
+def _write_page_text(writer: PdfWriter, page: Any, lines: tuple[str, ...]) -> None:
+    if not lines:
+        return
+    font = DictionaryObject(
+        {
+            NameObject("/Type"): NameObject("/Font"),
+            NameObject("/Subtype"): NameObject("/Type1"),
+            NameObject("/BaseFont"): NameObject("/Helvetica"),
+        }
+    )
+    page[NameObject("/Resources")] = DictionaryObject(
+        {
+            NameObject("/Font"): DictionaryObject(
+                {NameObject("/F1"): writer._add_object(font)}
+            )
+        }
+    )
+    commands = ["BT /F1 12 Tf 14 TL 72 720 Td"]
+    for index, line in enumerate(lines):
+        commands.append(f"({_pdf_text(line)}) Tj")
+        if index < len(lines) - 1:
+            commands.append("T*")
+    commands.append("ET")
+    contents = DecodedStreamObject()
+    contents.set_data(" ".join(commands).encode("latin-1"))
+    page[NameObject("/Contents")] = writer._add_object(contents)
+
+
 def make_pdf_bytes(
     *,
     doi: str | None = "10.1234/example",
     title: str | None = "Example paper",
     author: str | None = "Alice Example",
     year: int | str | None = 2024,
+    subject: str | None = None,
     first_page_lines: tuple[str, ...] = (),
+    additional_pages: tuple[tuple[str, ...], ...] = (),
     include_document_metadata: bool = True,
 ) -> bytes:
     buffer = io.BytesIO()
@@ -35,40 +65,25 @@ def make_pdf_bytes(
                 "/Title": title,
                 "/Author": author,
                 "/Year": year,
+                "/Subject": subject,
             }.items()
             if value not in (None, "")
         }
         if metadata:
             writer.add_metadata(metadata)
-    if first_page_lines:
-        font = DictionaryObject(
-            {
-                NameObject("/Type"): NameObject("/Font"),
-                NameObject("/Subtype"): NameObject("/Type1"),
-                NameObject("/BaseFont"): NameObject("/Helvetica"),
-            }
-        )
-        page[NameObject("/Resources")] = DictionaryObject(
-            {
-                NameObject("/Font"): DictionaryObject(
-                    {NameObject("/F1"): writer._add_object(font)}
-                )
-            }
-        )
-        commands = ["BT /F1 12 Tf 14 TL 72 720 Td"]
-        for index, line in enumerate(first_page_lines):
-            commands.append(f"({_pdf_text(line)}) Tj")
-            if index < len(first_page_lines) - 1:
-                commands.append("T*")
-        commands.append("ET")
-        contents = DecodedStreamObject()
-        contents.set_data(" ".join(commands).encode("latin-1"))
-        page[NameObject("/Contents")] = writer._add_object(contents)
+    _write_page_text(writer, page, first_page_lines)
+    for lines in additional_pages:
+        _write_page_text(writer, writer.add_blank_page(width=612, height=792), lines)
     writer.write(buffer)
     return buffer.getvalue()
 
 
-PDF_BYTES = make_pdf_bytes()
+PDF_BYTES = make_pdf_bytes(
+    doi="10.1234/example",
+    title="Example paper",
+    author="Alice Example",
+    year=2024,
+)
 
 
 class RoutingHttp:

--- a/academic-paper-download/scripts/tests/test_artifacts.py
+++ b/academic-paper-download/scripts/tests/test_artifacts.py
@@ -10,7 +10,7 @@ from unittest import mock
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
-from helpers import PDF_BYTES, RoutingHttp
+from helpers import RoutingHttp, make_pdf_bytes
 from paper_fetch.artifact import ArtifactStore, manifest_path
 from paper_fetch.errors import PaperFetchError
 from paper_fetch.models import Candidate, PaperMetadata
@@ -23,9 +23,15 @@ class ArtifactTests(unittest.TestCase):
         self.directory = Path(self.temporary.name)
         self.url = "https://oa.example/paper.pdf"
         self.metadata = PaperMetadata(title="同名论文", author="张三", year=2024)
+        self.pdf_bytes = make_pdf_bytes(
+            doi="10.1234/one",
+            title="同名论文",
+            author="张三",
+            year=2024,
+        )
 
     def test_atomic_commit_writes_pdf_hash_and_manifest(self):
-        http = RoutingHttp(download_payloads={self.url: PDF_BYTES})
+        http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
         result = ArtifactStore(self.directory, http).save(
             "10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1
         )
@@ -38,11 +44,13 @@ class ArtifactTests(unittest.TestCase):
         self.assertEqual(manifest["sha256"], result["sha256"])
         self.assertEqual(manifest["license"], "unknown")
         self.assertEqual(manifest["license_status"], "unknown")
+        self.assertEqual(manifest["identity_status"], "matched")
+        self.assertEqual(manifest["identity"]["method"], "doi_document_metadata")
         self.assertIn("张三", path.name)
         self.assertEqual(list(self.directory.glob("*.part")), [])
 
     def test_matching_manifest_and_hash_are_required_to_skip(self):
-        http = RoutingHttp(download_payloads={self.url: PDF_BYTES})
+        http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
         store = ArtifactStore(self.directory, http)
         first = store.save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
         second = store.save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
@@ -53,7 +61,7 @@ class ArtifactTests(unittest.TestCase):
         self.assertEqual(second["committed_manifest"]["source"], "unpaywall")
 
     def test_corrupt_existing_file_is_not_skipped_and_gets_collision_name(self):
-        http = RoutingHttp(download_payloads={self.url: PDF_BYTES})
+        http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
         store = ArtifactStore(self.directory, http)
         first = store.save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
         Path(first["file"]).write_bytes(b"<html>corrupt</html>")
@@ -63,12 +71,117 @@ class ArtifactTests(unittest.TestCase):
         self.assertTrue(second["file"].endswith("-2.pdf"))
 
     def test_same_filename_different_doi_does_not_skip(self):
-        http = RoutingHttp(download_payloads={self.url: PDF_BYTES})
+        second_url = "https://oa.example/paper-two.pdf"
+        http = RoutingHttp(
+            download_payloads={
+                self.url: self.pdf_bytes,
+                second_url: make_pdf_bytes(
+                    doi="10.1234/two",
+                    title="同名论文",
+                    author="张三",
+                    year=2024,
+                ),
+            }
+        )
         store = ArtifactStore(self.directory, http)
         first = store.save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
-        second = store.save("10.1234/two", Candidate("unpaywall", self.url), self.metadata, timeout=1)
+        second = store.save("10.1234/two", Candidate("unpaywall", second_url), self.metadata, timeout=1)
         self.assertNotEqual(first["file"], second["file"])
         self.assertFalse(second["skipped"])
+
+    def test_wrong_primary_doi_is_rejected_before_commit(self):
+        wrong = make_pdf_bytes(
+            doi="10.9999/wrong",
+            title="Completely different paper",
+            author="Mallory",
+            year=2020,
+        )
+        http = RoutingHttp(download_payloads={self.url: wrong})
+        with self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(self.directory, http).save(
+                "10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1
+            )
+        self.assertEqual(raised.exception.code, "pdf_identity_mismatch")
+        self.assertEqual(list(self.directory.glob("*.pdf")), [])
+        self.assertEqual(list(self.directory.glob("*.json")), [])
+        self.assertEqual(list(self.directory.glob("*.part")), [])
+
+    def test_first_page_requested_doi_wins_over_reference_doi_noise(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title=None,
+            author=None,
+            year=None,
+            include_document_metadata=False,
+            first_page_lines=(
+                "Requested Paper",
+                "doi:10.1234/one",
+                "Background cites doi:10.9999/reference",
+            ),
+        )
+        metadata = PaperMetadata(title="Requested Paper", author="Alice", year=2024)
+        result = ArtifactStore(
+            self.directory,
+            RoutingHttp(download_payloads={self.url: payload}),
+        ).save("10.1234/one", Candidate("unpaywall", self.url), metadata, timeout=1)
+        manifest = json.loads(Path(result["manifest"]).read_text(encoding="utf-8"))
+        self.assertEqual(manifest["identity_status"], "matched")
+        self.assertEqual(manifest["identity"]["method"], "doi_first_page")
+        self.assertEqual(
+            manifest["identity"]["observed"]["first_page_dois"],
+            ["10.1234/one", "10.9999/reference"],
+        )
+
+    def test_doi_less_document_can_match_title_author_and_year(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title="Requested Paper",
+            author="Alice Example",
+            year=2024,
+        )
+        metadata = PaperMetadata(title="Requested Paper", author="Alice Example", year=2024)
+        result = ArtifactStore(
+            self.directory,
+            RoutingHttp(download_payloads={self.url: payload}),
+        ).save("10.1234/one", Candidate("unpaywall", self.url), metadata, timeout=1)
+        manifest = json.loads(Path(result["manifest"]).read_text(encoding="utf-8"))
+        self.assertEqual(manifest["identity_status"], "matched")
+        self.assertEqual(manifest["identity"]["method"], "title_document_metadata")
+        self.assertEqual(manifest["identity"]["checks"]["author"]["status"], "matched")
+        self.assertEqual(manifest["identity"]["checks"]["year"]["status"], "matched")
+
+    def test_pdf_without_identity_evidence_is_unresolved_and_not_committed(self):
+        blank = make_pdf_bytes(
+            doi=None,
+            title=None,
+            author=None,
+            year=None,
+            include_document_metadata=False,
+        )
+        http = RoutingHttp(download_payloads={self.url: blank})
+        with self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(self.directory, http).save(
+                "10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1
+            )
+        self.assertEqual(raised.exception.code, "pdf_identity_unresolved")
+        self.assertEqual(list(self.directory.glob("*.pdf")), [])
+        self.assertEqual(list(self.directory.glob("*.json")), [])
+        self.assertEqual(list(self.directory.glob("*.part")), [])
+
+    def test_legacy_manifest_is_not_replayed_as_identity_verified(self):
+        http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
+        store = ArtifactStore(self.directory, http)
+        first = store.save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
+        sidecar = manifest_path(Path(first["file"]))
+        legacy = json.loads(sidecar.read_text(encoding="utf-8"))
+        legacy["schema_version"] = "academic-paper-download.artifact.v2"
+        legacy.pop("identity_status", None)
+        legacy.pop("identity", None)
+        sidecar.write_text(json.dumps(legacy), encoding="utf-8")
+        second = store.save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
+        self.assertFalse(second["skipped"])
+        self.assertNotEqual(first["file"], second["file"])
+        self.assertEqual(sum(method == "download" for method, _ in http.calls), 2)
 
     def test_html_response_never_commits(self):
         http = RoutingHttp(download_payloads={self.url: b"<html>login</html>"})
@@ -89,7 +202,7 @@ class ArtifactTests(unittest.TestCase):
         self.assertEqual(list(self.directory.glob("*.pdf")), [])
 
     def test_missing_pdf_parser_fails_closed(self):
-        http = RoutingHttp(download_payloads={self.url: PDF_BYTES})
+        http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
         with mock.patch("paper_fetch.artifact.importlib.import_module", side_effect=ImportError):
             with self.assertRaises(PaperFetchError) as raised:
                 ArtifactStore(self.directory, http).save(
@@ -103,7 +216,7 @@ class ArtifactTests(unittest.TestCase):
         target.mkdir()
         link = self.directory / "linked-output"
         link.symlink_to(target, target_is_directory=True)
-        http = RoutingHttp(download_payloads={self.url: PDF_BYTES})
+        http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
         with self.assertRaises(PaperFetchError) as raised:
             ArtifactStore(link, http).save(
                 "10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1
@@ -113,7 +226,7 @@ class ArtifactTests(unittest.TestCase):
     def test_file_used_as_output_directory_is_rejected(self):
         blocked = self.directory / "not-a-directory"
         blocked.write_text("blocked", encoding="utf-8")
-        http = RoutingHttp(download_payloads={self.url: PDF_BYTES})
+        http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
         with self.assertRaises(PaperFetchError) as raised:
             ArtifactStore(blocked, http).save(
                 "10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1

--- a/academic-paper-download/scripts/tests/test_artifacts.py
+++ b/academic-paper-download/scripts/tests/test_artifacts.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(SCRIPTS))
 from helpers import RoutingHttp, make_pdf_bytes
 from paper_fetch.artifact import ArtifactStore, manifest_path
 from paper_fetch.errors import PaperFetchError
+from paper_fetch.identity import MAX_FIRST_PAGE_CONTENT_BYTES, MAX_FIRST_PAGE_ENCODED_BYTES
 from paper_fetch.models import Candidate, PaperMetadata
 
 
@@ -106,6 +107,25 @@ class ArtifactTests(unittest.TestCase):
         self.assertEqual(list(self.directory.glob("*.json")), [])
         self.assertEqual(list(self.directory.glob("*.part")), [])
 
+    def test_document_doi_url_ignores_tracking_query_and_fragment(self):
+        payload = make_pdf_bytes(
+            doi="https://doi.org/10.1234/one?utm_source=repository#landing",
+            title="Requested Paper",
+            author="Alice",
+            year=2024,
+        )
+        result = ArtifactStore(
+            self.directory,
+            RoutingHttp(download_payloads={self.url: payload}),
+        ).save(
+            "10.1234/one",
+            Candidate("unpaywall", self.url),
+            PaperMetadata(title="Requested Paper", author="Alice", year=2024),
+            timeout=1,
+        )
+        self.assertEqual(result["identity_status"], "matched")
+        self.assertEqual(result["identity"]["method"], "doi_document_metadata")
+
     def test_first_page_requested_doi_wins_over_reference_doi_noise(self):
         payload = make_pdf_bytes(
             doi=None,
@@ -115,7 +135,7 @@ class ArtifactTests(unittest.TestCase):
             include_document_metadata=False,
             first_page_lines=(
                 "Requested Paper",
-                "doi:10.1234/one",
+                "Journal header https://doi.org/10.1234/one",
                 "Background cites doi:10.9999/reference",
             ),
         )
@@ -127,7 +147,7 @@ class ArtifactTests(unittest.TestCase):
         manifest = json.loads(Path(result["manifest"]).read_text(encoding="utf-8"))
         self.assertEqual(manifest["identity_status"], "matched")
         self.assertEqual(manifest["identity"]["method"], "doi_first_page")
-        self.assertEqual(
+        self.assertCountEqual(
             manifest["identity"]["observed"]["first_page_dois"],
             ["10.1234/one", "10.9999/reference"],
         )
@@ -150,6 +170,155 @@ class ArtifactTests(unittest.TestCase):
         self.assertEqual(manifest["identity"]["checks"]["author"]["status"], "matched")
         self.assertEqual(manifest["identity"]["checks"]["year"]["status"], "matched")
 
+    def test_doi_less_accepted_manuscript_title_and_author_variants_match(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title="A Study of Carbon Footprints: Accepted Manuscript",
+            author="A. Example",
+            year=2024,
+        )
+        metadata = PaperMetadata(
+            title="A Study of Carbon Footprints",
+            author="Alice Example",
+            year=2024,
+        )
+        result = ArtifactStore(
+            self.directory,
+            RoutingHttp(download_payloads={self.url: payload}),
+        ).save("10.1234/one", Candidate("unpaywall", self.url), metadata, timeout=1)
+        self.assertEqual(result["identity_status"], "matched")
+        self.assertEqual(result["identity"]["method"], "title_document_metadata")
+        self.assertEqual(result["identity"]["checks"]["author"]["status"], "matched")
+
+    def test_context_metadata_doi_is_not_promoted_to_primary_identity(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title="Requested Paper",
+            author="Alice Example",
+            year=2024,
+            subject="doi:10.9999/cited-reference",
+        )
+        result = ArtifactStore(
+            self.directory,
+            RoutingHttp(download_payloads={self.url: payload}),
+        ).save(
+            "10.1234/one",
+            Candidate("unpaywall", self.url),
+            PaperMetadata(title="Requested Paper", author="Alice Example", year=2024),
+            timeout=1,
+        )
+        self.assertEqual(result["identity_status"], "matched")
+        self.assertEqual(result["identity"]["method"], "title_document_metadata")
+        self.assertEqual(result["identity"]["observed"]["document_dois"], [])
+        self.assertEqual(
+            result["identity"]["observed"]["metadata_context_dois"],
+            ["10.9999/cited-reference"],
+        )
+
+    def test_context_metadata_requested_doi_does_not_identify_wrong_pdf(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title="Completely different paper",
+            author="Mallory",
+            year=2020,
+            subject="doi:10.1234/one",
+        )
+        with self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(
+                self.directory,
+                RoutingHttp(download_payloads={self.url: payload}),
+            ).save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
+        self.assertEqual(raised.exception.code, "pdf_identity_mismatch")
+
+    def test_first_page_requested_doi_can_resolve_preprint_metadata_conflict(self):
+        payload = make_pdf_bytes(
+            doi="10.48550/arxiv.2401.00001",
+            title="Requested Paper",
+            author="Alice Example",
+            year=2024,
+            first_page_lines=(
+                "Requested Paper",
+                "Journal header https://doi.org/10.1234/one",
+            ),
+        )
+        result = ArtifactStore(
+            self.directory,
+            RoutingHttp(download_payloads={self.url: payload}),
+        ).save(
+            "10.1234/one",
+            Candidate("unpaywall", self.url),
+            PaperMetadata(title="Requested Paper", author="Alice Example", year=2024),
+            timeout=1,
+        )
+        self.assertEqual(result["identity_status"], "matched")
+        self.assertEqual(result["identity"]["method"], "doi_first_page")
+        self.assertIn(
+            "document_doi_conflicts_with_first_page",
+            result["identity"]["limitations"],
+        )
+
+    def test_reference_doi_noise_does_not_override_first_page_title_match(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title=None,
+            author=None,
+            year=None,
+            include_document_metadata=False,
+            first_page_lines=(
+                "Requested Paper",
+                "Alice Example",
+                "2024",
+                "Background cites doi:10.9999/reference",
+            ),
+        )
+        metadata = PaperMetadata(title="Requested Paper", author="Alice Example", year=2024)
+        result = ArtifactStore(
+            self.directory,
+            RoutingHttp(download_payloads={self.url: payload}),
+        ).save("10.1234/one", Candidate("unpaywall", self.url), metadata, timeout=1)
+        manifest = json.loads(Path(result["manifest"]).read_text(encoding="utf-8"))
+        self.assertEqual(manifest["identity_status"], "matched")
+        self.assertEqual(manifest["identity"]["method"], "title_first_page")
+        self.assertEqual(
+            manifest["identity"]["observed"]["first_page_dois"],
+            ["10.9999/reference"],
+        )
+        self.assertIn("non_primary_dois_ignored", manifest["identity"]["limitations"])
+
+    def test_doi_less_title_mismatch_is_rejected(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title="Completely different paper",
+            author="Mallory",
+            year=2020,
+        )
+        metadata = PaperMetadata(title="Requested Paper", author="Alice Example", year=2024)
+        with self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(
+                self.directory,
+                RoutingHttp(download_payloads={self.url: payload}),
+            ).save("10.1234/one", Candidate("unpaywall", self.url), metadata, timeout=1)
+        self.assertEqual(raised.exception.code, "pdf_identity_mismatch")
+        self.assertEqual(list(self.directory.glob("*.pdf")), [])
+
+    def test_requested_doi_in_later_references_does_not_identify_wrong_paper(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title="Completely different paper",
+            author="Mallory",
+            year=2020,
+            first_page_lines=("Completely different paper", "Mallory", "2020"),
+            additional_pages=(("References", "doi:10.1234/one"),),
+        )
+        metadata = PaperMetadata(title="Requested Paper", author="Alice Example", year=2024)
+        with self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(
+                self.directory,
+                RoutingHttp(download_payloads={self.url: payload}),
+            ).save("10.1234/one", Candidate("unpaywall", self.url), metadata, timeout=1)
+        self.assertEqual(raised.exception.code, "pdf_identity_mismatch")
+        self.assertEqual(list(self.directory.glob("*.pdf")), [])
+
     def test_pdf_without_identity_evidence_is_unresolved_and_not_committed(self):
         blank = make_pdf_bytes(
             doi=None,
@@ -168,6 +337,75 @@ class ArtifactTests(unittest.TestCase):
         self.assertEqual(list(self.directory.glob("*.json")), [])
         self.assertEqual(list(self.directory.glob("*.part")), [])
 
+    def test_oversized_first_page_content_fails_closed_before_text_extraction(self):
+        class OversizedContents:
+            @staticmethod
+            def get_data():
+                return b"x" * (MAX_FIRST_PAGE_CONTENT_BYTES + 1)
+
+        blank = make_pdf_bytes(
+            doi=None,
+            title=None,
+            author=None,
+            year=None,
+            include_document_metadata=False,
+        )
+        http = RoutingHttp(download_payloads={self.url: blank})
+        with mock.patch(
+            "pypdf._page.PageObject.get_contents",
+            return_value=OversizedContents(),
+        ), self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(self.directory, http).save(
+                "10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1
+            )
+        self.assertEqual(raised.exception.code, "pdf_identity_unresolved")
+        self.assertIn(
+            "first_page_content_limit_exceeded",
+            raised.exception.details["identity"]["limitations"],
+        )
+        self.assertEqual(list(self.directory.glob("*.pdf")), [])
+
+    def test_oversized_encoded_first_page_is_rejected_before_decompression(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title=None,
+            author=None,
+            year=None,
+            include_document_metadata=False,
+            first_page_lines=("x" * (MAX_FIRST_PAGE_ENCODED_BYTES + 1),),
+        )
+        http = RoutingHttp(download_payloads={self.url: payload})
+        with self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(self.directory, http).save(
+                "10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1
+            )
+        self.assertEqual(raised.exception.code, "pdf_identity_unresolved")
+        self.assertIn(
+            "first_page_encoded_content_limit_exceeded",
+            raised.exception.details["identity"]["limitations"],
+        )
+
+    def test_first_page_title_without_author_or_year_support_is_unresolved(self):
+        payload = make_pdf_bytes(
+            doi=None,
+            title=None,
+            author=None,
+            year=None,
+            include_document_metadata=False,
+            first_page_lines=("Requested Paper",),
+        )
+        with self.assertRaises(PaperFetchError) as raised:
+            ArtifactStore(
+                self.directory,
+                RoutingHttp(download_payloads={self.url: payload}),
+            ).save(
+                "10.1234/one",
+                Candidate("unpaywall", self.url),
+                PaperMetadata(title="Requested Paper"),
+                timeout=1,
+            )
+        self.assertEqual(raised.exception.code, "pdf_identity_unresolved")
+
     def test_legacy_manifest_is_not_replayed_as_identity_verified(self):
         http = RoutingHttp(download_payloads={self.url: self.pdf_bytes})
         store = ArtifactStore(self.directory, http)
@@ -179,9 +417,12 @@ class ArtifactTests(unittest.TestCase):
         legacy.pop("identity", None)
         sidecar.write_text(json.dumps(legacy), encoding="utf-8")
         second = store.save("10.1234/one", Candidate("unpaywall", self.url), self.metadata, timeout=1)
-        self.assertFalse(second["skipped"])
-        self.assertNotEqual(first["file"], second["file"])
-        self.assertEqual(sum(method == "download" for method, _ in http.calls), 2)
+        self.assertEqual(second["identity_status"], "matched")
+        self.assertEqual(second["committed_manifest"]["identity_status"], "matched")
+        self.assertNotEqual(
+            second["committed_manifest"]["schema_version"],
+            "academic-paper-download.artifact.v2",
+        )
 
     def test_html_response_never_commits(self):
         http = RoutingHttp(download_payloads={self.url: b"<html>login</html>"})

--- a/academic-paper-download/scripts/tests/test_browser_finalizer.py
+++ b/academic-paper-download/scripts/tests/test_browser_finalizer.py
@@ -10,12 +10,14 @@ import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
 from helpers import PDF_BYTES, make_pdf_bytes
 import finalize_browser_download as browser
+from paper_fetch.errors import PaperFetchError
 
 
 class BrowserFinalizerTests(unittest.TestCase):
@@ -159,6 +161,72 @@ class BrowserFinalizerTests(unittest.TestCase):
         self.assertTrue(source.is_file())
         self.assertEqual(list(self.output.glob("*.pdf")), [])
         self.assertEqual(list(self.output.glob("*.json")), [])
+
+    def test_identity_unresolved_is_not_finalized(self):
+        self._snapshot()
+        source = self.downloads / "Expected.pdf"
+        source.write_bytes(
+            make_pdf_bytes(
+                doi=None,
+                title=None,
+                author=None,
+                year=None,
+                include_document_metadata=False,
+            )
+        )
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            code = browser.finalize(self._args())
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 1)
+        self.assertEqual(payload["error"]["code"], "pdf_identity_unresolved")
+        self.assertTrue(source.is_file())
+        self.assertEqual(list(self.output.glob("*.pdf")), [])
+        self.assertEqual(list(self.output.glob("*.json")), [])
+
+    def test_identity_validator_unavailable_is_runtime_failure(self):
+        self._snapshot()
+        (self.downloads / "Expected.pdf").write_bytes(PDF_BYTES)
+        output = io.StringIO()
+        with mock.patch(
+            "finalize_browser_download.validate_pdf_identity",
+            side_effect=PaperFetchError(
+                "pdf_validator_unavailable",
+                "identity validator unavailable",
+            ),
+        ), contextlib.redirect_stdout(output):
+            code = browser.finalize(self._args())
+        self.assertEqual(code, 4)
+        self.assertEqual(
+            json.loads(output.getvalue())["error"]["code"],
+            "pdf_validator_unavailable",
+        )
+
+    def test_legacy_destination_is_not_replayed_as_verified_duplicate(self):
+        self._snapshot()
+        source = self.downloads / "Expected.pdf"
+        source.write_bytes(PDF_BYTES)
+        first_output = io.StringIO()
+        with contextlib.redirect_stdout(first_output):
+            self.assertEqual(browser.finalize(self._args()), 0)
+        first = json.loads(first_output.getvalue())
+        sidecar = Path(first["manifest"])
+        legacy = json.loads(sidecar.read_text(encoding="utf-8"))
+        legacy["schema_version"] = "academic-paper-download.artifact.v2"
+        legacy.pop("identity_status", None)
+        legacy.pop("identity", None)
+        sidecar.write_text(json.dumps(legacy), encoding="utf-8")
+
+        source.unlink()
+        self._snapshot()
+        source.write_bytes(PDF_BYTES)
+        second_output = io.StringIO()
+        with contextlib.redirect_stdout(second_output):
+            self.assertEqual(browser.finalize(self._args()), 0)
+        second = json.loads(second_output.getvalue())
+        self.assertFalse(second["data"]["duplicate"])
+        self.assertEqual(second["data"]["identity_status"], "matched")
+        self.assertNotEqual(second["data"]["file"], first["data"]["file"])
 
     def test_invalid_doi_is_validation_exit(self):
         self._snapshot()

--- a/academic-paper-download/scripts/tests/test_browser_finalizer.py
+++ b/academic-paper-download/scripts/tests/test_browser_finalizer.py
@@ -14,7 +14,7 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
-from helpers import PDF_BYTES
+from helpers import PDF_BYTES, make_pdf_bytes
 import finalize_browser_download as browser
 
 
@@ -138,6 +138,27 @@ class BrowserFinalizerTests(unittest.TestCase):
             code = browser.finalize(self._args())
         self.assertEqual(code, 3)
         self.assertEqual(json.loads(output.getvalue())["error"]["code"], "unsafe_download_path")
+
+    def test_identity_mismatch_is_not_finalized(self):
+        self._snapshot()
+        source = self.downloads / "Expected.pdf"
+        source.write_bytes(
+            make_pdf_bytes(
+                doi="10.9999/wrong",
+                title="Wrong paper",
+                author="Mallory",
+                year=2020,
+            )
+        )
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            code = browser.finalize(self._args())
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 1)
+        self.assertEqual(payload["error"]["code"], "pdf_identity_mismatch")
+        self.assertTrue(source.is_file())
+        self.assertEqual(list(self.output.glob("*.pdf")), [])
+        self.assertEqual(list(self.output.glob("*.json")), [])
 
     def test_invalid_doi_is_validation_exit(self):
         self._snapshot()

--- a/academic-paper-download/scripts/tests/test_channels.py
+++ b/academic-paper-download/scripts/tests/test_channels.py
@@ -195,6 +195,55 @@ class DownloadChannelTests(unittest.TestCase):
         )
         self.assertEqual(len(list(Path(result["file"]).parent.glob("*.pdf"))), 1)
 
+    def test_only_identity_mismatches_return_a_distinct_failure(self):
+        url = "https://oa.example/wrong.pdf"
+        transport = RoutingHttp(
+            json_routes={
+                "api.semanticscholar.org/graph/v1/paper/DOI": s2_payload(pdf=url),
+            },
+            download_payloads={
+                url: make_pdf_bytes(
+                    doi="10.9999/wrong",
+                    title="Wrong paper",
+                    author="Mallory",
+                    year=2020,
+                )
+            },
+        )
+        result, _ = self.run_fetch(transport)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"]["code"], "pdf_identity_mismatch")
+        self.assertEqual(
+            result["error"]["attempts"][0]["error"]["code"],
+            "pdf_identity_mismatch",
+        )
+        self.assertIsNone(result["file"])
+        self.assertIsNone(result["manifest"])
+
+    def test_only_unresolved_identities_return_a_distinct_failure(self):
+        url = "https://oa.example/unresolved.pdf"
+        transport = RoutingHttp(
+            json_routes={
+                "api.semanticscholar.org/graph/v1/paper/DOI": s2_payload(pdf=url),
+            },
+            download_payloads={
+                url: make_pdf_bytes(
+                    doi=None,
+                    title=None,
+                    author=None,
+                    year=None,
+                    include_document_metadata=False,
+                )
+            },
+        )
+        result, _ = self.run_fetch(transport)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"]["code"], "pdf_identity_unresolved")
+        self.assertEqual(
+            result["error"]["attempts"][0]["error"]["code"],
+            "pdf_identity_unresolved",
+        )
+
     def test_retryable_transport_failure_stays_structured(self):
         failure = PaperFetchError(
             "network_error",

--- a/academic-paper-download/scripts/tests/test_channels.py
+++ b/academic-paper-download/scripts/tests/test_channels.py
@@ -9,7 +9,7 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
-from helpers import PDF_BYTES, RoutingHttp, arxiv_atom
+from helpers import PDF_BYTES, RoutingHttp, arxiv_atom, make_pdf_bytes
 from paper_fetch import FetchRequest, fetch_paper
 from paper_fetch.artifact import ArtifactStore, manifest_path
 from paper_fetch.errors import PaperFetchError
@@ -162,6 +162,38 @@ class DownloadChannelTests(unittest.TestCase):
         self.assertIn("browser_handoff", result)
         downloaded = [url for method, url in calls if method == "download"]
         self.assertEqual(downloaded, [unpaywall_url, s2_url, arxiv_url])
+
+    def test_identity_mismatch_falls_through_to_next_oa_source(self):
+        wrong_url = "https://oa.example/wrong-citing-paper.pdf"
+        correct_url = "https://oa.example/correct-paper.pdf"
+        transport = RoutingHttp(
+            json_routes={
+                "api.unpaywall.org": {
+                    "title": "Example paper",
+                    "year": 2024,
+                    "z_authors": [{"family": "Example"}],
+                    "best_oa_location": {"url_for_pdf": wrong_url},
+                },
+                "api.semanticscholar.org/graph/v1/paper/DOI": s2_payload(pdf=correct_url),
+            },
+            download_payloads={
+                wrong_url: make_pdf_bytes(
+                    doi="10.9999/wrong",
+                    title="Paper that cites the requested work",
+                    author="Mallory",
+                    year=2020,
+                ),
+                correct_url: PDF_BYTES,
+            },
+        )
+        result, calls = self.run_fetch(transport, email="researcher@example.edu")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["source"], "semantic_scholar")
+        self.assertEqual(
+            [url for method, url in calls if method == "download"],
+            [wrong_url, correct_url],
+        )
+        self.assertEqual(len(list(Path(result["file"]).parent.glob("*.pdf"))), 1)
 
     def test_retryable_transport_failure_stays_structured(self):
         failure = PaperFetchError(

--- a/academic-paper-download/scripts/tests/test_cli.py
+++ b/academic-paper-download/scripts/tests/test_cli.py
@@ -18,6 +18,18 @@ from paper_fetch.errors import PaperFetchError
 
 
 class CliTests(unittest.TestCase):
+    def test_schema_declares_identity_validation_before_commit(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.assertEqual(cli.main(["schema"]), 0)
+        schema = json.loads(output.getvalue())["data"]
+        self.assertEqual(schema["schema_version"], "3.0.0")
+        self.assertLess(
+            schema["artifact_pipeline"].index("pdf_identity_validation"),
+            schema["artifact_pipeline"].index("atomic_rename"),
+        )
+        self.assertEqual(schema["identity_policy"]["required_status"], "matched")
+
     def test_success_and_idempotent_replay_use_verified_artifact(self):
         with tempfile.TemporaryDirectory() as temporary:
             url = "https://oa.example/s2.pdf"

--- a/academic-paper-download/scripts/tests/test_cloakbrowser_handoff.py
+++ b/academic-paper-download/scripts/tests/test_cloakbrowser_handoff.py
@@ -273,6 +273,20 @@ class CloakBrowserHandoffTests(unittest.TestCase):
         self.assertEqual(list(self.output.glob("*.pdf")), [])
         self.assertEqual(list(self.output.glob("*.json")), [])
 
+    def test_identity_unresolved_does_not_commit_browser_artifact(self) -> None:
+        blank = make_pdf_bytes(
+            doi=None,
+            title=None,
+            author=None,
+            year=None,
+            include_document_metadata=False,
+        )
+        with self.assertRaises(PaperFetchError) as raised:
+            execute_handoff(self.config(), adapter=FakeAdapter(FakeSession(payload=blank)))
+        self.assertEqual(raised.exception.code, "pdf_identity_unresolved")
+        self.assertEqual(list(self.output.glob("*.pdf")), [])
+        self.assertEqual(list(self.output.glob("*.json")), [])
+
     def test_invalid_pdf_still_fails_pypdf_eof_and_size_pipeline(self) -> None:
         for payload in (b"<html>login</html>", b"%PDF-1.7\ntruncated", b""):
             with self.subTest(payload=payload[:12]):

--- a/academic-paper-download/scripts/tests/test_cloakbrowser_handoff.py
+++ b/academic-paper-download/scripts/tests/test_cloakbrowser_handoff.py
@@ -13,7 +13,7 @@ from unittest import mock
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
-from helpers import PDF_BYTES
+from helpers import PDF_BYTES, make_pdf_bytes
 import cloakbrowser_handoff as cli
 from paper_fetch.artifact import manifest_path, sha256_file
 from paper_fetch.cloakbrowser_handoff import (
@@ -259,6 +259,19 @@ class CloakBrowserHandoffTests(unittest.TestCase):
             execute_handoff(self.config(), adapter=FakeAdapter(browser))
         self.assertEqual(list(self.output.glob("*.json")), [])
         self.assertEqual(list(self.output.glob("*.pdf")), [])
+
+    def test_identity_mismatch_does_not_commit_browser_artifact(self) -> None:
+        wrong = make_pdf_bytes(
+            doi="10.9999/wrong",
+            title="Wrong paper",
+            author="Mallory",
+            year=2020,
+        )
+        with self.assertRaises(PaperFetchError) as raised:
+            execute_handoff(self.config(), adapter=FakeAdapter(FakeSession(payload=wrong)))
+        self.assertEqual(raised.exception.code, "pdf_identity_mismatch")
+        self.assertEqual(list(self.output.glob("*.pdf")), [])
+        self.assertEqual(list(self.output.glob("*.json")), [])
 
     def test_invalid_pdf_still_fails_pypdf_eof_and_size_pipeline(self) -> None:
         for payload in (b"<html>login</html>", b"%PDF-1.7\ntruncated", b""):

--- a/academic-paper-download/scripts/tests/test_idempotency.py
+++ b/academic-paper-download/scripts/tests/test_idempotency.py
@@ -8,7 +8,7 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SCRIPTS))
 
-from helpers import PDF_BYTES, RoutingHttp
+from helpers import RoutingHttp, make_pdf_bytes
 from paper_fetch.artifact import ArtifactStore
 from paper_fetch.errors import PaperFetchError
 from paper_fetch.idempotency import IdempotencyStore, request_fingerprint
@@ -23,7 +23,16 @@ class IdempotencyTests(unittest.TestCase):
         self.url = "https://oa.example/paper.pdf"
         artifact = ArtifactStore(
             self.directory,
-            RoutingHttp(download_payloads={self.url: PDF_BYTES}),
+            RoutingHttp(
+                download_payloads={
+                    self.url: make_pdf_bytes(
+                        doi="10.1234/one",
+                        title="Paper",
+                        author="Author",
+                        year=2024,
+                    )
+                }
+            ),
         ).save(
             "10.1234/one",
             Candidate("unpaywall", self.url),

--- a/academic-paper-download/scripts/tests/test_install_smoke.py
+++ b/academic-paper-download/scripts/tests/test_install_smoke.py
@@ -106,6 +106,7 @@ class InstalledSkillSmokeTests(unittest.TestCase):
                     self.assertTrue(payload["ok"])
                     self.assertFalse(payload["data"]["network_used"])
                     self.assertEqual(payload["data"]["pdf_pages"], 1)
+                    self.assertEqual(payload["data"]["identity_status"], "matched")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- validate the scholarly identity of every downloaded PDF before automatic or browser artifact commit
- reject primary DOI/title conflicts and unresolved no-text/no-metadata files without emitting a success manifest
- preserve citation DOI noise as non-primary evidence, support DOI-less accepted manuscripts through strong title plus author/year evidence, and handle preprint/published DOI conflicts explicitly
- upgrade artifact, CLI, and idempotency contracts so legacy identity-unverified manifests cannot replay as verified

Closes #87

## Implementation

- added a shared bounded `paper_fetch.identity` validator for PDF document metadata, XMP, encoded/decompressed first-page limits, primary DOI positions, normalized title overlap, author variants, and publication-year support
- invoked the validator before `ArtifactStore` atomic rename and before Chrome/CloakBrowser finalizer rename/copy/manifest steps
- added `pdf_identity_mismatch` and `pdf_identity_unresolved` aggregation while retaining source fallback
- upgraded artifact manifests to v3 with `identity_status`, normalized requested/observed values, checks, confidence, evidence source, resource limits, and limitations; extracted page text is never persisted
- upgraded CLI schema to `3.0.0` and idempotency records to v3
- updated Skill, agent metadata, integration guidance, and browser handoff documentation

## Validation

- clean-container RED before implementation: expected identity regressions failed (`84` tests discovered; `6` failures, `3` errors, one gated install-smoke skip)
- final exact-HEAD cold clean-container gate: passed with all repository deterministic suites and `102` academic-paper tests
- copy and symlink install smoke: passed with fixed `skills@1.5.22`, locked `pypdf==6.14.2`, and offline identity smoke
- public OA case `10.48550/arXiv.1706.03762`: successful arXiv fallback with `identity_status=matched`, `title_first_page`, and matching author support; no credentials used
- Skill Creator quick validation and child Docpact passed
- independent read-only review found no blocking or high-risk findings after remediation
- GitHub CI on exact head `b8220d8`: `clean-container-tdd`, `lint`, and `validate-config` all passed ([run](https://github.com/tiangong-ai/skills/actions/runs/34084077175))

## Risk and limitations

- scanned/no-text PDFs without defensible embedded identity metadata now fail closed and require manual verification; OCR remains intentionally out of scope
- first-page parsing is bounded and records limitations; contextual Subject/Keywords/reference DOIs never become primary identity evidence
- DOI-less first-page title matches require positive author or year support; document-metadata title matches tolerate recorded author/year ambiguity but reject clear disagreement
- successful identity validation does not imply redistribution permission; existing access/license provenance is unchanged

## Rollback

Revert merge commit `8468ae87` or its four delivered commits together. Legacy v2 manifests remain readable as files but intentionally are not accepted as identity-verified replay by this change.

## Workspace integration

Completed through [workspace#215](https://github.com/tiangong-ai/workspace/issues/215) and [workspace PR #216](https://github.com/tiangong-ai/workspace/pull/216). Root merge `3dfd4a0` pins this exact Skills merge plus required CLI companion `79b6b941`; the Issue and PR Project items both report `Workspace Integration = Done`.
