### PR TITLE
Ignore macOS DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.DS_Store
 __pycache__/
 *.pyc
 **/assets/config.env


### PR DESCRIPTION
## Summary

- Ignore macOS `.DS_Store` metadata files throughout the Skills repository.
- Preserve all existing local metadata files while removing them from Git status noise.

Closes #103.

## Validation

- `git check-ignore -v` against root and nested `.DS_Store` paths
- `scripts/docpact validate-config --root skills --strict`
- `scripts/docpact lint --root skills --worktree --format json --output skills/.docpact/runs/latest.json`
- `git diff --check`
