### PR TITLE
Improve evidence-driven Auto Research execution and recovery guidance

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-08"
-lastReviewedCommit: "76dc843048909a54fd8a304686b75ce8f5fa15a4"
+lastReviewedAt: "2026-09-10"
+lastReviewedCommit: "741ae757974bd22b576b95de203dbe89d492ce20"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # Tiangong AI Skills
@@ -215,8 +215,12 @@ check, and independent reviewer smoke reaches complete readiness. Use explicit
 
 The bootstrap version is an explicit new-workspace choice, never `latest`, a
 tag, or a range. After apply creates `runtime-lock.json`, the installed
-orchestrator's bundled resolver runs exactly that locked version for all
-workspace operations.
+orchestrator's bundled resolver runs exactly that locked version for ordinary
+workspace operations. A reviewed upgrade-capable candidate is invoked explicitly
+when the old installation cannot plan its own upgrade; follow the candidate's
+returned apply/recovery commands and return to the activated lock. Installed
+command support and release metadata are separate, and unavailable metadata is
+not evidence that no update exists. See the installed setup reference.
 
 For acquisition-heavy work, the orchestrator uses the CLI's read-only artifact
 size and role-coverage forecasts, bounded atomic content batches, and explicit
@@ -229,6 +233,14 @@ and portable audit stay linked without extra fixed reviewer rounds. Workflow
 closure is reported separately from task completion. See
 `tiangong-auto-research/references/execution-assurance.md`; frozen history and
 scientific requirements are never silently rewritten to make a gate pass.
+
+The installed assurance reference connects already-fetched windows, closest
+literature and discriminative pilots to concrete research decisions and concise
+researcher explanations. Review findings lead to permitted repairs before a new
+bound review. Publication guidance keeps map conventions project-specific and
+visual claims conditional on actual image delivery to a capable independent
+reviewer. These instructions reuse existing records and do not add a lifecycle
+ledger or an automatic paid explanation/review round.
 
 Compatible runtimes also fulfill predeclared pending scientific objects in place,
 preserve original-request provenance, and bind computational acceptance to an

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # 天工 AI Skills
@@ -193,7 +193,10 @@ Policy 兼容性检查和独立 reviewer smoke 都完全就绪，setup 才返回
 
 bootstrap 版本是新 workspace 的显式选择，不得使用 `latest`、tag 或 range。
 apply 创建 `runtime-lock.json` 后，已安装 orchestrator 的内置 resolver 会让
-所有 workspace 操作只运行该锁定版本。
+普通 workspace 操作只运行该锁定版本。若旧安装无法规划升级，必须显式调用已审阅且
+具备升级能力的精确候选版本，按其返回的 apply/recovery 命令操作，激活后再回到锁定
+resolver。已安装命令支持与发行元数据是两件事；元数据不可用不代表没有更新。详见
+已安装 Skill 的 setup reference。
 
 资料较多时，orchestrator 使用 CLI 的只读文件大小预检、角色覆盖预测、有界原子
 批量登记与显式科学评审执行。兼容的锁定 CLI 支持在分析前于同一项目修订获取结果，
@@ -202,6 +205,11 @@ apply 创建 `runtime-lock.json` 后，已安装 orchestrator 的内置 resolver
 审计保持关联，不增加固定付费评审轮次；流程闭环与任务完成分别汇报。详见
 `tiangong-auto-research/references/execution-assurance.md`。不修改冻结历史，也不为
 通过门禁而偷偷降低科学要求。
+
+已安装的 assurance reference 将已获取窗口、最近相关文献和有区分力的方法试验
+连接到具体研究决策与简短的研究者说明。评审意见先触发被允许的修复，再获得新绑定
+评审；地图约定来自当前项目，视觉结论需要图像实际送达具备看图能力的独立评审者。
+这些指导复用现有记录，不增加生命周期账本或自动付费的解释、复审轮次。
 
 兼容的锁定 CLI 还支持在原项目追加兑现预声明的待补科学对象，区分原始请求原文、
 解释与重建，并把计算验收绑定到实际原生计算回执。完整工件可经精确绑定的按需读取

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # Skills Repository Architecture
@@ -101,6 +101,14 @@ review/audit. Compatible runtimes may explicitly reopen discovery for new
 sources without changing project identity. The Skill reports task coverage
 separately from workflow/publication status and keeps all producer work native;
 it neither implements a second state machine nor adds fixed paid reviewer rounds.
+
+The assurance reference also links saved evidence reads, closest-work decisions,
+discriminative pilot interpretation and permitted review repairs to concise
+researcher explanations. Conditional publication guidance records project map
+conventions and distinguishes text-only access from actual image review. Setup
+recipes select a reviewed explicit candidate when the old locked CLI lacks
+upgrade support, then use the candidate's returned transition commands. The
+Skill adds no provider logic, receipt schema or second lifecycle record.
 
 The same reference guides original-request provenance, same-project fulfillment
 of explicitly pending model/environment/parameter slots, actual native calculation

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-10
+lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -34,7 +34,9 @@ it has a position. It may proceed when null results, alternative explanations,
 and counterevidence remain testable. Refuse requests to fabricate, conceal, or
 misrepresent evidence.
 
-For an existing managed directory, use the bundled resolver for every CLI operation.
+For an existing managed directory, use the bundled resolver for ordinary CLI operations.
+An explicitly reviewed CLI upgrade uses the candidate entrypoint in
+[references/setup.md](references/setup.md), then returns to the activated lock.
 Resolve `AUTO_RESEARCH_CLI` from this loaded Skill's absolute directory; do not
 guess a global Skill path. The resolver accepts only the CLI package and exact
 stable version from the regular non-symlink runtime lock, or from the immutable
@@ -92,7 +94,8 @@ detailed stop and recovery rules.
 - Read [references/execution-assurance.md](references/execution-assurance.md)
   before original-task intake, pre-analysis evidence correction, scope changes,
   planned-object fulfillment, observed native calculations, packet-only artifact
-  reads, or completion reporting. Prefer supported same-project operations for
+  reads, evidence-to-design decisions, pilot interpretation, researcher-facing
+  explanations, reviewer-directed repair, or completion reporting. Prefer supported same-project operations for
   an unchanged study; preserve original/current task completion separately.
 - Read [references/evidence-pipeline.md](references/evidence-pipeline.md) before
   discovery, acquisition, evidence refresh, or an addendum.

--- a/tiangong-auto-research/references/execution-assurance.md
+++ b/tiangong-auto-research/references/execution-assurance.md
@@ -23,6 +23,74 @@ An existing project without a task contract remains **unassessed** in this
 dimension. Do not manufacture historical requirements, approvals or passing
 checks. Existing Policy/evidence safeguards still apply.
 
+## Turn existing evidence into the next decision
+
+At a material stage transition or blocker, tell the researcher what changed,
+which evidence supports or limits the current claim, what that means for the
+original question, and the next useful action. Derive this from existing task,
+assessment, review and budget outputs. Distinguish an operation that ran, a
+scientific check that passed, and a question actually answered. Avoid narrating
+unchanged polls, dumping status codes, creating another status ledger, or paying
+for a separate explanation call.
+
+Before another provider request, inspect the relevant already-fetched material:
+its schema, units, covered ranges, local windows and candidate dispositions.
+Use the existing read path for unpresented rows; a new provider fetch is not a
+pagination mechanism for a saved result. Read enough for the decision or claim,
+not an arbitrary universal number of pages. Record used evidence, exclusions
+with reasons, and pending access/read work in the existing assessment/atom/task
+records. A fetched or registered object is not automatically analyzed support.
+See [evidence-pipeline.md](evidence-pipeline.md) for the actual read/binding path.
+
+Closest literature should change a decision when warranted: compare the current
+claim, estimand, data, assumptions and validation against the closest supported
+work, then keep, narrow, revise or withdraw the proposed novelty/method claim.
+Missing an exact keyword match does not establish novelty. Carry source/atom
+references and consequential counterevidence into the existing assessment and
+research narrative, rather than accumulating a bibliography with no effect.
+
+An IO/schema canary proves only the operation it exercised. Choose the smallest
+predeclared scientific pilot that can distinguish the proposed explanation or
+method from a plausible alternative or failure mode. Interpret its failures,
+nulls and inconclusive outcomes in terms of what can be claimed and what test
+would resolve the uncertainty. Preserve units, independent clusters, fair
+baselines and outcome-blind restrictions; do not select a new design after
+seeing results and label it predeclared. Change frozen assumptions only through
+the supported approval/recovery path. See [scientific-design.md](scientific-design.md).
+
+For a core variable or compatibility detector, connect its intended construct to
+required fields, lawful sources and the representation actually used. On small
+synthetic or authorized development records, contrast equivalent representations,
+changed physical values/units or study boundaries, missing fields and parse
+failures. A keyword-presence detector must not be described as value compatibility;
+either test the relevant values or lower its claim to screening with scientific
+status unresolved. Diagnose an all-zero or constant result as possible input,
+projection, extraction or detector failure before treating it as a domain finding
+or high confidence. Compare summary/full representations of the same development
+records when available; richer text need not produce a positive result. API batch
+size is not a scientific sample-size rationale; purposeful bounded sampling still
+needs a justified, bounded claim. Keep required real-record canaries and
+frozen-evidence gates in place; the synthetic contrasts qualify the development
+method only.
+
+## Repair findings before paying for another opinion
+
+For each actionable finding, identify the affected artifact/claim and the legal
+repair within the current task and frozen contracts. Reuse unaffected evidence
+and calculations. Existing explicit authorization covers the same ordinary
+in-scope repair; do not ask again merely because a review requested it. A new
+scope, design, cost or state-changing recovery operation still needs its
+applicable authorization and supported CLI path.
+
+Batch related corrections, inspect the changed output, then obtain the fresh
+bound reviews invalidated by that revision. The CLI decides which bindings and
+publication-generation reviews became stale. Re-reviewing identical failed
+bytes is not repair, and an unchanged failed receipt is not approval. On a
+transport/execution failure, first inspect the retained output and diagnostic;
+use bounded supported recovery after its cause is addressed. If no permitted
+repair can resolve the finding, preserve the limitation or request the specific
+needed decision instead of cycling reviewers.
+
 ## Record a small original-task checklist
 
 After initializing a new project and before its first scientific review or

--- a/tiangong-auto-research/references/publication-policy.md
+++ b/tiangong-auto-research/references/publication-policy.md
@@ -144,6 +144,28 @@ own hash was recomputed. It evaluates central claims, outcomes, result classes,
 evidence composition, owner-input trust, recall, novelty, reproduction, and
 pivots. File existence alone is never success.
 
+## Figures and project-specific maps
+
+Visual-quality claims require actual image delivery and inspection of the exact
+rendered figure or page. File existence, render success, paths, dimensions, SVG
+text and a verbal description are not proof that a reviewer saw the image.
+Use the host's supported visual tools and the CLI's existing artifact/read
+records where available; report what was delivered and inspected without
+inventing receipt fields. Producer visual checks do not replace independent
+review. The clean configured reviewer must actually support the delivered image
+and retain the required other-family/session boundary. If delivery or capability
+is missing, keep visual quality unverified, state the text-only review scope,
+and obtain a supported capable route before claiming visual acceptance.
+
+For a map, use the project's approved brief/Policy and source requirements for
+boundary dataset/version, study extent, labels, projection and required insets.
+Keep source/license/version and relevant presentation choices traceable in the
+figure caption or existing reproducibility materials; check the actual rendered
+map against them. Do not import a national/geopolitical default from another
+project or add an inset merely to satisfy a remembered template. When a missing
+choice materially affects interpretation, request that focused project decision.
+Unavailable map bytes or metadata remain a gap, not a guessed verification.
+
 ## Four fresh independent final reviews
 
 Prepare and submit exactly one review for each role: `evidence`,

--- a/tiangong-auto-research/references/setup.md
+++ b/tiangong-auto-research/references/setup.md
@@ -268,7 +268,7 @@ generated files byte-for-byte and removes only that recovery directory. A
 changed, symlinked, or ambiguous recovery directory blocks cleanup and is never
 overwritten or deleted automatically.
 
-After the immutable plan exists, resolve every command through the bundled
+After the immutable plan exists, resolve every ordinary command through the bundled
 Skill helper. During a partial installation it uses the reviewed plan version;
 after apply creates the runtime lock it requires the matching locked version.
 Set `AUTO_RESEARCH_CLI` to the absolute path of this selected Skill, not a
@@ -339,27 +339,49 @@ subscription change; setup never switches profiles silently.
 
 ## Update without version drift
 
-`update --check` is read-only. The currently installed generation stays pinned:
+Separate the installed CLI's supported commands from release availability.
+The locked resolver deliberately keeps selecting the old CLI; a new document
+or successful metadata query does not add commands to that installation.
+Inspect its help once. With support available, `research setup update --check`
+is a local catalog comparison; `--candidate-version X.Y.Z` checks one explicitly
+selected exact stable release. An unavailable query means unknown, not no update.
+Do not select `latest`, infer a candidate, or rewrite the runtime lock.
+
+When an upgrade-capable exact candidate has been reviewed and authorized, invoke
+that candidate to plan the transition. In a regular host, use a reviewed Node.js
+24/npx environment:
 
 ```bash
-node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
-  research setup update --check \
+REVIEWED_UPGRADE_CLI_VERSION=X.Y.Z # replace with the reviewed exact stable release
+npx --yes --registry=https://registry.npmjs.org \
+  --@tiangong-ai:registry=https://registry.npmjs.org --strict-ssl=true \
+  --package "@tiangong-ai/cli@$REVIEWED_UPGRADE_CLI_VERSION" -- tiangong-ai \
+  research setup upgrade --plan --confirm-upgrade \
   --workspace /absolute/path/to/research-workspace --json
 ```
 
-An upgrade is a new immutable plan, never an in-place floating update. Review
-new licenses and pins, then apply the newly generated plan:
+A sandboxed IDE retains its approved Node/adapter and reviewer transport;
+unsupported candidate invocation requires a reviewed compatible path, not an
+ambient-runtime or permission bypass. See [sandboxed-ide.md](sandboxed-ide.md).
 
-```bash
-node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/research-workspace -- \
-  research setup upgrade \
-  --plan --confirm-upgrade \
-  --accept-license <every-selected-current-license-id> \
-  --workspace /absolute/path/to/research-workspace --json
-```
+Planning leaves the active generation intact. Review the returned `planPath`,
+ownership/changes and license choices, then execute its exact `applyCommand`.
+The updater verifies prior-owned bytes, stages changed trees and reuses verified
+unchanged material. Owner modifications, linked targets and ambiguous ownership
+remain conflicts; do not delete or overwrite directories to make Doctor pass.
+Preserve models, pricing, custom launchers, credentials, evidence and budgets.
+Unchanged accepted choices carry forward; additional consent applies to actual
+new licenses, downloads, global writes or costs.
 
-The previous plan/state/report/config generation is archived under
-`.tiangong-research/setup-history/<plan-sha256>/` for audit and recovery.
+For an interrupted transition, inspect status and use the same candidate's
+returned apply/recovery command or `rollbackCommand`. Do not reconstruct the
+previous generation or repair a mixed plan/lock by hand. Ordinary research
+resumes only after coherent activation and the required readiness checks. If a
+paid check started but its result was lost, inspect the recorded attempt before
+requesting another; old readiness never certifies changed bytes. Return to the
+locked resolver after activation and start a new native session when routing
+instructions changed. Retained private recovery preimages are not public audit
+exports or permission to discard owner work.
 
 ## Run selected companion adapters
 

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -413,4 +413,40 @@ try {
   await rm(recipeFixture, { recursive: true, force: true });
 }
 
+// Exercise the installed upgrade example with an old locked resolver and a
+// separately selected candidate. Capture-only launchers prohibit network work.
+const upgradeFixture = await mkdtemp(join(tmpdir(), "research-upgrade-recipe-"));
+try {
+  const installed = join(upgradeFixture, "installed-skill");
+  await cp(join(skillsRoot, "tiangong-auto-research"), installed, {recursive: true});
+  const setup = await readFile(join(installed, "references", "setup.md"), "utf8");
+  const block = [...setup.matchAll(/```bash\n([\s\S]*?)```/g)]
+    .map(match => match[1]).find(code => /research setup upgrade/.test(code));
+  assert.ok(block, "An installed upgrade recipe must be executable");
+  const bin = join(upgradeFixture, "bin");
+  await mkdir(bin);
+  const trace = join(upgradeFixture, "calls.jsonl");
+  for (const command of ["node", "npx"]) {
+    const executable = join(bin, command);
+    await writeFile(executable, `#!${process.execPath}\nconst fs=require("node:fs");fs.appendFileSync(process.env.UPGRADE_RECIPE_TRACE,JSON.stringify({launcher:${JSON.stringify(command)},argv:process.argv.slice(2)})+"\\n");\n`);
+    await chmod(executable, 0o700);
+  }
+  const recipe = block.replaceAll("X.Y.Z", "0.0.62")
+    .replaceAll("<every-selected-current-license-id>", "synthetic-license");
+  const run = spawnSync("sh", ["-eu", "-c", recipe], {encoding: "utf8", cwd: upgradeFixture,
+    env: {...process.env, PATH: bin + delimiter + process.env.PATH,
+      AUTO_RESEARCH_CLI: join(installed, "scripts", "research_cli.mjs"), UPGRADE_RECIPE_TRACE: trace}});
+  assert.equal(run.status, 0, run.stderr);
+  const calls = (await readFile(trace, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].launcher, "npx", "An unsupported old locked CLI must not be asked to create its own upgrade candidate");
+  const argv = calls[0].argv;
+  assert.equal(argv[argv.indexOf("--package") + 1], "@tiangong-ai/cli@0.0.62");
+  for (const flag of ["--registry=https://registry.npmjs.org", "--@tiangong-ai:registry=https://registry.npmjs.org", "--strict-ssl=true"]) assert.ok(argv.includes(flag));
+  assert.deepEqual(argv.slice(argv.indexOf("--") + 1, argv.indexOf("--") + 5), ["tiangong-ai", "research", "setup", "upgrade"]);
+  assert.ok(argv.includes("--plan") && argv.includes("--confirm-upgrade"));
+} finally {
+  await rm(upgradeFixture, {recursive: true, force: true});
+}
+
 process.stdout.write("Auto Research routing contract tests passed\n");


### PR DESCRIPTION
Makes Auto Research's existing evidence, pilot and repair paths explicit in installed guidance. Saved windows feed concrete decisions before new provider work; closest literature affects novelty/method claims; IO success remains distinct from a discriminative pilot. Researcher explanations derive from existing records, and review findings lead to permitted batched repairs before a fresh bound review.

Project map conventions remain traceable and local to the study. Visual approval requires actual image delivery and a capable clean other-family reviewer; missing capability stays unverified. No receipt fields, provider logic, lifecycle engine or fixed paid review rounds are added.

The upgrade example now invokes an explicitly reviewed exact candidate instead of asking the old locked resolver to provide new upgrade semantics. It pins npm registry/scope/SSL and follows the candidate's returned apply/recovery commands, preserving owner changes and returning to the activated lock. Installed command support and unavailable release metadata remain distinct.

Validation:

- Separate clean-container RED/GREEN executed the installed shell recipe against capture-only launchers. The original used the locked Node route; the corrected example selects the exact candidate package and required registry/consent arguments. This validates executable routing, not publisher authenticity or a real 0.0.62 release.
- Final full cold gate passed; required Skill validator, strict config and complete-diff docpact passed. Existing optional installation/live smoke skips remain explicit.
- Independent baseline/candidate contexts used identical privacy-safe raw cases for evidence/pilot, repair/visual/map, upgrade support and construct compatibility. Both already made sound broad decisions, so no general accuracy/speed uplift is claimed. Candidate plans make the operational path explicit and preserve uncertainty, scope and review boundaries.
- In the construct case, both identified 5 of 6 failures in a supplied keyword-only detector. A candidate isolated development prototype passed 6 supplied and 5 supplemental checks; the main agent independently replayed its inspected script. It remains development-only, without held-out/source validation and is not shipped as a CLI algorithm.
- An exact local CLI c6b15d5 protocol smoke outside Git created an empty-source setup and upgrade candidate while preserving 8 active JSON files and returning apply/rollback commands. Doctor was deliberately skipped: initial apply remained partially-ready, not research-ready. No candidate apply or provider call was used to claim an upgrade outcome.
- Independent source review found no actionable blockers. Runtime controls, scientific-object fulfillment and formal stage/review schemas remain unchanged; this is guidance/recipe qualification, not a new live native research or visual-channel certification.

Closes #114. Fixes #104. Fixes #106. Fixes #108. Fixes #109. Fixes #110. Fixes #111. Fixes #112. Fixes #113. Fixes tiangong-ai/cli#112.

Parent tiangong-ai/workspace#223 remains open for other original issues and comparative evaluations. Exact root integration is required after merge. No package/tag publication.
