### PR TITLE
Clarify reviewer recipient identity and host pause recovery

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-10"
-lastReviewedCommit: "741ae757974bd22b576b95de203dbe89d492ce20"
+lastReviewedCommit: "a3608db"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -59,6 +59,13 @@ interactive fallback after a declaration error, and complete-readiness gating.
 The Skill does not duplicate the closed YAML schema or parse configuration; the
 CLI-generated template and validator remain authoritative.
 
+The canonical Skill's environment reference distinguishes configured reviewer
+recipients, runtime readiness and unverified upstream identity. It preserves
+explicit custom-provider authorization and uses the CLI's routing binding rather
+than maintaining another authorization ledger. The sandboxed-IDE reference
+separates individual approval rejection from asynchronous host task pauses and
+routes recovery to the observed control layer without repeated paid retries.
+
 The canonical Skill also owns the native-host research-question gate. It runs
 before setup or tool use, pauses conclusion-presupposing or
 counterevidence-excluding requests with one testable rewrite, and waits for the

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -18,7 +18,7 @@ checkPaths:
   - scripts/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: 741ae757974bd22b576b95de203dbe89d492ce20
+lastReviewedCommit: a3608db
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/SKILL.md
+++ b/tiangong-auto-research/SKILL.md
@@ -88,7 +88,8 @@ detailed stop and recovery rules.
 - Read [references/external-skills.md](references/external-skills.md) before
   selecting a recommended external Skill, provider, license, or execution role.
 - Read [references/env.md](references/env.md) before configuring credentials,
-  agent authentication, provider checks, or wrappers.
+  agent authentication, provider checks, wrappers, or the first material-bearing
+  review; revisit its recipient guidance when routing or authorization conflicts.
 - Read [references/production-research.md](references/production-research.md)
   before production preflight, execution, recovery, or closure.
 - Read [references/execution-assurance.md](references/execution-assurance.md)
@@ -106,7 +107,8 @@ detailed stop and recovery rules.
   preparing or submitting discover, acquire, analyze, or synthesize stages.
 - Read [references/sandboxed-ide.md](references/sandboxed-ide.md) when the
   producer runs inside WorkBuddy, CodeBuddy, or another outer sandbox, or when
-  native reviewer isolation returns a nested-sandbox error.
+  native reviewer isolation returns a nested-sandbox error. Its host-pause
+  guidance also applies when an operation is rejected or a task is paused.
 - Read [references/publication-policy.md](references/publication-policy.md)
   before a top-journal project, Policy approval, final manuscript freeze,
   four-role publication review, or readiness closure.

--- a/tiangong-auto-research/references/env.md
+++ b/tiangong-auto-research/references/env.md
@@ -203,10 +203,40 @@ yourself. Doctor attests the reviewer target, wrapper, internal adapter, OS, and
 architecture and invalidates the attestation after relevant drift.
 
 For Claude, the runtime does not copy an owner `settings.json`. It extracts only
-documented authentication values and a credential-free HTTPS base URL from the
+documented authentication values, model-mapping variables and a credential-free HTTPS base URL from the
 supported environment object; hooks, permissions, extra directories, and other
 settings are excluded. On macOS, credentials held in the system keychain stay
 in the keychain.
+
+### Reviewer recipient and authorization
+
+Before the first material-bearing review, use the locked CLI's
+`research reviewer status --workspace <absolute-path> --json`. Read native
+`runtime` or bridge `configuredReviewer`: CLI family, configured model alias,
+and `providerRouting.endpointOrigin` / `endpointSource` describe the configured
+recipient. Explicit process variables override the imported Claude settings env.
+Doctor also reports `reviewer-configured-routing`; a bridge's READY describes
+its transport. None of these proves the actual upstream provider/model.
+`identityVerification=unverified` and a null or missing endpoint remain unknown;
+older records without routing fields cannot establish historical destinations.
+Neither a Claude alias nor a `firstParty` auth label proves an official service.
+
+Describe the intended recipient and the particular packet/material scope using
+this evidence. Preserve deliberately configured custom providers, including
+CC Switch/GLM, and reuse applicable explicit user authorization. If an
+official-only description conflicts with an unverified gateway, explain that
+specific mismatch and resolve the intended recipient before sending; a vague
+request to "continue" does not settle it. Do not silently replace the gateway
+with an official endpoint or claim historical disclosure without request evidence.
+
+Reuse the inspected route while its runtime binding remains applicable; do not
+add a status/paid-smoke loop to every review. On runtime drift, inspect the new
+configured recipient and reconcile it with intent before the explicitly
+authorized refresh. Old CLI versions without this binding retain their limits;
+use the reviewed upgrade procedure when a binding is needed. Paths, credentials,
+URL queries and entire user settings files do not belong in the explanation.
+For approval rejection or a host pause, follow
+[sandboxed-ide.md](sandboxed-ide.md#host-approval-and-task-pauses).
 
 The current host application is the producer execution boundary. Discovery
 uses only the CLI's hash-bound one-shot broker command for admitted evidence;

--- a/tiangong-auto-research/references/sandboxed-ide.md
+++ b/tiangong-auto-research/references/sandboxed-ide.md
@@ -148,3 +148,21 @@ The actionable fail-closed codes are:
   or exact result no longer matches the signed request.
 
 Do not hide any of these codes behind a generic retry loop.
+
+## Host approval and task pauses
+
+An individual operation's approval rejection and an asynchronous task pause are
+different controls. For an operation rejection, report the rejected action and
+stated reason, then resolve that specific recipient/material or permission gap
+using existing authorization where applicable. A later task pause does not undo
+the evidence that the earlier gap was resolved, or reveal its own hidden cause.
+
+For a Codex task pause, inspect the notice and available findings. Continue only
+through the host's supported resume flow after reviewing whether the task can
+safely proceed; an ended task or a surface without resume cannot be resumed
+there. Preserve the packet, receipts and uncertainty about past requests. The
+CLI can correct its routing/attestation layer; repeated calls, larger budgets,
+provider switches or a fresh task are not documented cures for host monitoring.
+Do not infer a provider ban or disable controls. If findings are insufficient,
+report the specific observable limitation with sanitized context for upstream
+diagnosis. See [OpenAI's safety-monitoring guidance](https://learn.chatgpt.com/docs/agent-approvals-security#safety-monitoring-and-paused-tasks).


### PR DESCRIPTION
Clarify the reviewer recipient before research material is sent: the CLI family, configured model alias, endpoint source and runtime readiness do not prove upstream or historical provider identity. Preserve explicitly approved CC Switch/GLM routes, resolve concrete recipient/material conflicts, and distinguish individual action rejection from asynchronous host task pauses.

The guidance stays in the existing environment and sandboxed-IDE references, with narrow entrypoint links. It reuses applicable authorization and routing evidence, adds no provider registry, runtime gate, retry loop or authorization ledger, and treats older CLI routing data as unknown.

Validation: Skill quick_validate passed; full Skills fresh-container and final cold gates passed; strict docpact config passed and full 12-path diff lint has zero findings. Four independent synthetic forward cases against baseline and candidate produced appropriate high-level decisions in both; no general accuracy uplift or real provider verification is claimed. The independent paired source-contract review found a mapped-response-model mismatch; CLI75fb1e0 separates configured identity from sanitized self-report telemetry, and the reviewer verified the fix with synthetic reuse/null/redaction checks. The paired fresh container passed809/809. All three Skills hosted checks passed on the exact PR head. No paid provider calls or private research data were used.

Paired implementation: https://github.com/tiangong-ai/cli/issues/120. Original https://github.com/tiangong-ai/cli/issues/108 remains open until both owning-repo changes are integrated. No package publication is included. Roll back by restoring the prior Skills pin if required.

Closes #116
