### PR TITLE
Bind publication materials to their source analysis generation

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-10"
-lastReviewedCommit: "a3608db"
+lastReviewedCommit: "94e6b30499a621783aa9c2b62749cee03da011db"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # Skills Repository Architecture

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -66,6 +66,13 @@ than maintaining another authorization ledger. The sandboxed-IDE reference
 separates individual approval rejection from asynchronous host task pauses and
 routes recovery to the observed control layer without repeated paid retries.
 
+Publication guidance preserves the closed analysis identity while material files
+are authored, then uses the CLI-owned result-lineage schema and freeze checks.
+It includes actual figures/tables and raw-byte hashes, preserves unaffected
+evidence/materials, and routes stale core bindings back to supported base recovery.
+The Skill does not relabel old scientific results, patch the control store or
+present a mechanical binding as proof of scientific fidelity.
+
 The canonical Skill also owns the native-host research-question gate. It runs
 before setup or tool use, pauses conclusion-presupposing or
 counterevidence-excluding requests with one testable rewrite, and waits for the

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -18,7 +18,7 @@ checkPaths:
   - scripts/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-10
-lastReviewedCommit: a3608db
+lastReviewedCommit: 94e6b30499a621783aa9c2b62749cee03da011db
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/references/publication-policy.md
+++ b/tiangong-auto-research/references/publication-policy.md
@@ -91,16 +91,34 @@ launch a nested producer. The Markdown/plain-text manuscript must contain
 Abstract, Introduction, Methods (or Materials and Methods), Results,
 Discussion, Data availability, Code availability, and References/Bibliography.
 
+Before authoring the final materials, inspect the closed analysis identity and
+the installed CLI's authoritative schema through the locked resolver:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research publication lineage PROJECT --workspace /absolute/path/to/workspace --json
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
+  research schema show publication-result-lineage --json
+```
+
+The lineage view verifies existing closed/reviewed core bindings and deliberately
+returns an empty `files` template. Preserve that source identity while producing
+the manuscript, assessment, figures, tables and source data. Record each actual
+file's raw-byte hash and its source `analysisSha256`; hash binary figures as
+bytes, not decoded text. Do not populate every parent with the
+latest hash after the fact. A B artifact does not become an A result by relabeling
+it. If the locked CLI lacks this view/schema, its older freeze does not establish
+this binding; follow the reviewed upgrade procedure when this assurance is needed.
+
 Create an owner-reviewed submission manifest outside `.tiangong-research`. It
 uses `schemaVersion: 1` and distinct absolute canonical paths. Required roles
 are `cover-letter`, `title-page`, `reporting-checklist`, `data-availability`,
 `code-availability`, and `source-data`; optional roles are
-`figure-table-index`, `extended-data`, and `supplementary-methods`:
+`figure-table-index`, `extended-data`, and `supplementary-methods`. The following
+is only the manifest's `files` array, not a complete manifest:
 
 ```json
-{
-  "schemaVersion": 1,
-  "files": [
+[
     { "role": "cover-letter", "path": "/absolute/path/cover-letter.md" },
     { "role": "title-page", "path": "/absolute/path/title-page.md" },
     {
@@ -116,9 +134,33 @@ are `cover-letter`, `title-page`, `reporting-checklist`, `data-availability`,
       "path": "/absolute/path/code-availability.md"
     },
     { "role": "source-data", "path": "/absolute/path/source-data.csv" }
-  ]
-}
+]
 ```
+
+The root manifest must also contain the completed nested `resultLineage` object,
+not the entire inspection response or an extra `analysisGenerationId` field,
+conforming to the CLI schema:
+its captured base identity and a prepared entry for `manuscript`, `assessment`,
+every submission role and each `supplement-N` in one-based supplied order. Use a
+deliberate unique supplement list so deduplication cannot obscure that order. Include
+actual material figures/tables and their source inputs as submission files or
+supplements; an index is an inventory, not those artifacts. Hash verification
+establishes the declared bindings and bytes, not scientific derivation or complete
+material coverage; the producer must supply that provenance for independent review.
+Unchanged administrative files and demonstrably unaffected materials may be
+reused with their provenance and applicability checked against the current
+analysis; do not claim they were recomputed or rerendered.
+Supply those extra files with `--supplements <absolute-json-file>` at freeze;
+that file contains the ordered array of absolute material paths used for the
+`supplement-N` entries. Do not omit the actual files after recording their hashes.
+
+If freeze/status reports stale analysis, report or review-packet bindings, repair
+the affected base research through supported CLI operations while retaining
+applicable evidence. Do not edit control-store files, swap only a manifest hash,
+or repeat publication reviews against the same stale base. A changed material
+requires its actual source lineage and a coherent refreeze. Historical generations
+without lineage remain limited evidence. Qualitative work keeps its honest
+non-computational metadata; do not invent an execution to fill these fields.
 
 Inspect the assessment schema, then freeze:
 
@@ -136,7 +178,7 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 
 Freeze requires the configured native producer family and content-addresses the
 manuscript, assessment, supplements, submission files, approved Policy, final
-acquisition/content/inference snapshots, reproduced analysis, Claim-Evidence
+acquisition/content/inference snapshots, mode-bound analysis, Claim-Evidence
 Graph, reproducibility manifest, and base outputs. It validates every finding's
 exact graph topology to atoms, sources, design claims, and the analysis run; a
 graph with the right edge names but disconnected endpoints fails even if its


### PR DESCRIPTION
Preserve the closed analysis identity while preparing publication materials, then use the CLI's result-lineage schema and freeze validation. The guide now records whole/per-file analysis and byte bindings, includes actual figures/tables and ordered supplements, and directs stale report/review bindings to supported base recovery before further publication review.

The inspection response is an empty preparation template, not a certificate for old files. The guide rejects retrospective parent-hash relabeling, preserves unaffected evidence/administrative materials, distinguishes declared lineage from scientific fidelity and complete material coverage, and keeps qualitative metadata honest. An older locked CLI without the command/schema is an explicit upgrade boundary. No schema engine, authority ledger, provider request or extra fixed review is added.

Validation: full fresh and final cold Skills containers passed; quick_validate passed; strict5-rule config and full10-path docpact lint have zero findings. Four independent synthetic forward cases covered preparation, a mixed figure, stale base review and legacy qualitative work. They preserved source identity and the four existing review roles without inventing hashes or paid outcomes. Independent paired CLI source review found no blocking mechanical-contract defect and verified the actual fields/roles and current-state checks; CLI regressions had authoritative RED/GREEN, with pre-pin cold814/814 passing.

Paired CLI implementation and installed-flow qualification: https://github.com/tiangong-ai/cli/issues/122. The default immutable Skills pin and its PDFv3 companion compatibility are being qualified there. Original https://github.com/tiangong-ai/cli/issues/99 remains open until the complete paired implementation and exact root integration are delivered. No package publication or scientific-truth certification is included.

Closes #118
