### PR TITLE
Check representative authorized full text before large acquisition

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-11"
-lastReviewedCommit: "dd1ea71"
+lastReviewedCommit: "142b727"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ checkPaths:
   - scripts/**
   - _docs/**
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ closure is reported separately from task completion. See
 `tiangong-auto-research/references/execution-assurance.md`; frozen history and
 scientific requirements are never silently rewritten to make a gate pass.
 
+Before large acquisition that depends on institutional or other authorized full
+text, the orchestrator checks a small relevant sample through the actual planned
+route and reuses applicable exact successes. It distinguishes article identity
+and readable content from HTTP success or a downloaded binary. Sufficient lawful
+OA evidence needs no campus-network gate; unknown failures do not diagnose VPN
+or subscription coverage. See `references/fulltext-access-preflight.md` inside
+the installed Auto Research Skill.
+
 For repeated diagnostic calculations, a compatible locked CLI provides a bounded
 investigation tied to one computational requirement. The native host can test
 approved configurations without per-trial confirmation, inspect immutable

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # 天工 AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -207,6 +207,12 @@ CLI 还可在分析前，经用户批准精确计划，修订既有 planned 规�
 `tiangong-auto-research/references/execution-assurance.md`。不修改冻结历史，也不为
 通过门禁而偷偷降低科学要求。
 
+当大量取材依赖机构订阅或其他授权全文时，orchestrator 先通过实际计划使用的
+路线检查少量相关文献，并复用仍适用的精确成功工件。它区分论文身份与可读正文、
+HTTP 成功和已下载二进制文件；合法 OA 资料已足够时不增加校园网络门槛，也不凭
+不明失败诊断 VPN 或订阅范围。详见已安装 Auto Research Skill 的
+`references/fulltext-access-preflight.md`。
+
 需要多轮诊断计算时，兼容的锁定 CLI 可将有界 investigation 绑定到同一个计算
 要求。原生宿主在批准范围内试验配置，无需逐次确认，并从不可变历史和剩余额度恢复
 上下文；候选晋级仍需单独批准、冻结、重新认证 Canary 和现有科学评审。探索结果

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -13,7 +13,7 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # Skills Documentation

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -124,6 +124,13 @@ authorship, and reuses valid evidence and fulfillment while requiring the
 CLI-reported new scientific reviews. Substantive and post-analysis design
 changes remain successor work; the CLI owns version history and recovery.
 
+`references/fulltext-access-preflight.md` is conditional acquisition guidance
+for a small representative check of materially necessary authorized full text.
+It uses existing exact route/receipt/artifact and handoff channels, distinguishes
+browser access from another transport, and reuses still-applicable content. It
+adds no network diagnostics, entitlement classifier, VPN/login mutation or global
+setup gate; machine validation and durable access state remain CLI-owned.
+
 `references/bounded-investigation.md` adds a conditional path for multiple native
 trials on one computational requirement. It consumes CLI-owned envelope,
 status, candidate and promotion schemas; it adds no executor or automatic loop.

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -14,7 +14,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -18,7 +18,7 @@ checkPaths:
   - scripts/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -18,7 +18,7 @@ checkPaths:
   - .claude-plugin/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -14,7 +14,7 @@ checkPaths:
   - _docs/**
   - "*/SKILL.md"
 lastReviewedAt: 2026-09-11
-lastReviewedCommit: dd1ea71
+lastReviewedCommit: 142b727
 ---
 
 # Skills Documentation Standards

--- a/tiangong-auto-research/references/evidence-pipeline.md
+++ b/tiangong-auto-research/references/evidence-pipeline.md
@@ -188,6 +188,12 @@ node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- \
 
 ## 4. Audit acquisition before inference
 
+When required full text depends on institutional or other authorized access,
+read [full-text route preflight](fulltext-access-preflight.md) before large
+acquisition. Verify a few relevant materials through the actual planned route,
+reuse applicable successes and keep OA-sufficient work moving without a campus
+network requirement. This does not replace the coverage or access-handoff rules.
+
 After provisional admission, the native `acquire` stage assesses every source
 exactly once. Use selected external acquisition/document Skills or an explicitly
 authorized browser. Before a large transfer with a known size, use the offline

--- a/tiangong-auto-research/references/fulltext-access-preflight.md
+++ b/tiangong-auto-research/references/fulltext-access-preflight.md
@@ -1,0 +1,75 @@
+# Check the intended full-text route before large acquisition
+
+Use this conditional check after the project's material needs and lawful
+acquisition routes are known, before spending heavily on acquisition that depends
+on institutional or other authorized full text. It checks actual access to needed
+content, not campus-network location or general API connectivity. Sufficient
+lawful OA or owner-provided evidence needs no institutional-access gate.
+
+## Select a small relevant check
+
+Identify the required evidence role, exact article/candidate and intended route.
+Use the smallest representative sample that tests materially necessary access;
+add publisher/year variants only when those coverage differences matter. Confirm
+that a subscription sample is within the owner's authorized scope from supplied
+entitlement information or an official institutional resource listing. Do not
+invent subscription coverage. If it is unknown and necessary, identify the
+specific authorization/material information needed before exercising that route.
+Existing authorization covers the matching retrieval; do not ask again per paper.
+
+First reuse already verified exact files, readable derivatives and receipts when
+their identity, route and required content remain applicable. A prior browser
+success proves that browser occurrence, not an API/downloader route. If a route,
+authenticated session or relevant coverage changed, recheck only what changed.
+There is no universal expiry interval and no need to redownload a usable exact
+artifact merely to obtain a newer success timestamp.
+
+For an existing managed project, inspect its authoritative route/access state:
+
+```bash
+node "$AUTO_RESEARCH_CLI" --workspace /absolute/path/to/workspace -- research project access status PROJECT --workspace /absolute/path/to/workspace --json
+```
+
+This command's readiness/status is not itself proof of publisher full-text
+access. Use the selected route's existing broker/native/download mechanism for
+the actual small retrieval, retaining the exact route ID and occurrence. Reuse
+[acquisition binding and registration](evidence-pipeline.md#4-audit-acquisition-before-inference)
+and the selected installed downloader's supported interface; do not add an
+unrecorded direct HTTP workaround or repeat unrelated Tiangong API checks.
+
+## Check the returned content
+
+Require the expected article identity and readable main text needed for the
+role. Inspect DOI/title/authors/version as available and the relevant body or
+methods/results sections; a title page alone does not establish full content.
+HTTP success, a `.pdf` suffix, a publisher landing page, an abstract, or a login
+page saved as PDF is insufficient. Keep transport completion, structurally valid
+file, identity match and producer-readable content as separate facts. Use the
+existing exact download binding, artifact registration and readable-derivative
+channels. A registered binary is not automatically producer-readable full text.
+Do not mark unobserved visual inspection or entire-document reading complete.
+
+Report briefly which exact materials and routes were verified, which remain
+unverified, the concrete failure evidence, and the next actionable step. One
+success does not establish all publishers, years, articles or institutional
+rights. A 403, timeout or missing text alone does not diagnose an absent
+subscription, VPN trouble or the cause of the failure. State a cause only when
+observed evidence supports it; otherwise retain uncertainty and route details.
+
+## Pause dependent work and resume with evidence
+
+For an actual login/entitlement/interactive challenge, use the existing
+[access handoff](evidence-exhaustion.md#distinguish-immediate-challenges-from-true-exhaustion).
+Name the exact missing material, approved route and minimal user action, with a
+resume criterion such as a successful authorized retrieval and identity-matched
+readable artifact. Do not automatically change VPN, system proxy, login state
+or browser backend, or bypass access controls. Do not call an untried legal
+alternative exhausted; follow the frozen route and handoff rules.
+
+Preserve successful artifacts and supported extraction work. Missing essential
+text blocks the analysis that depends on it; it does not turn that requirement
+into a negative scientific result. Do not silently replace it with an abstract,
+reduce the original scope or call a preliminary manuscript complete. Respect the
+existing durable handoff's pause boundary. Once the requested condition is true,
+resolve through the supported recovery path and continue from retained evidence,
+with original/current task completion still reported separately.

--- a/tiangong-auto-research/scripts/test-routing-contract.mjs
+++ b/tiangong-auto-research/scripts/test-routing-contract.mjs
@@ -349,7 +349,8 @@ try {
   await cp(join(skillsRoot, "tiangong-auto-research"), installed, { recursive: true });
   const referencePath = join(installed, "references", "execution-assurance.md");
   const reference = await readFile(referencePath, "utf8") + "\n" +
-    await readFile(join(installed, "references", "bounded-investigation.md"), "utf8");
+    await readFile(join(installed, "references", "bounded-investigation.md"), "utf8") + "\n" +
+    await readFile(join(installed, "references", "fulltext-access-preflight.md"), "utf8");
   for (const marker of ["requestProvenance", "verbatim", "interpreted", "reconstructed", "unrecorded", "nativeRunSha256", "unverified-execution", "on-demand", "no total context-length"]) {
     assert.ok(reference.includes(marker), `Installed task assurance must explain ${marker}`);
   }
@@ -391,6 +392,7 @@ try {
   }
   const commands = invocations.map((argv) => argv.slice(argv.indexOf("--") + 1));
   for (const prefix of [
+    ["research", "project", "access", "status"],
     ["research", "project", "investigation", "plan"],
     ["research", "project", "investigation", "approve"],
     ["research", "project", "investigation", "attempt"],


### PR DESCRIPTION
When research depends on institutional or other authorized full text, check a small relevant sample through the actual planned acquisition route before a large batch. The installed conditional guide distinguishes correct readable article content from HTTP success, a binary file or browser access on another route; reuses applicable exact artifacts; and retains uncertainty about 403/VPN/subscription causes.

Sufficient lawful OA evidence adds no campus-network requirement. Essential missing text follows the existing actionable access handoff and resume rules without silent abstract substitution, scope reduction, login/proxy/VPN mutation or a new CLI diagnostics engine.

Closes #124
Original request: tiangong-ai/cli#106, retained until exact installed-source and root integration delivery.

Validation: installed recipe/reference regression failed in a fresh clean container before implementation, then passed in a separate new container; full cold gate and system skill-creator validator passed. Seven independent raw-case decisions correctly handled OA sufficiency, route mismatch, login PDF, reuse, already-authorized sample, unknown403 and a changed browser session with still-valid local content. No real entitlement or publisher reachability was asserted, and no external access action occurred. Strict config/full12-path docpact passed with no findings. English/Chinese README and architecture align with the installed reference.

Rollback removes the conditional guidance; it creates no research state. Required remaining delivery is an exact merged source/catalog install and workspace integration. No package publication or provider-readiness claim.
