### PR TITLE
Unify Tiangong KB search Skill CLI runtime

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-11"
-lastReviewedCommit: "6b620e9"
+lastReviewedAt: "2026-09-12"
+lastReviewedCommit: "c5f8fe3ff43313f69b8deb4d970261c4013c5310"
 
 repo:
   id: skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - scripts/**
   - _docs/**
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # Tiangong AI Skills Agent Contract

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # Tiangong AI Skills

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # 天工 AI Skills

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -12,8 +12,8 @@ checkPaths:
   - .docpact/config.yaml
   - .github/workflows/docpact.yml
   - _docs/**
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # Skills Documentation

--- a/_docs/architecture/atomic-data-capabilities.md
+++ b/_docs/architecture/atomic-data-capabilities.md
@@ -17,8 +17,8 @@ checkPaths:
   - "*-search/**"
   - "*-download/**"
   - tiangong-auto-research/**
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # 原子数据 Skill 目标架构

--- a/_docs/architecture/repo-architecture.md
+++ b/_docs/architecture/repo-architecture.md
@@ -13,8 +13,8 @@ checkPaths:
   - README.zh-CN.md
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # Skills Repository Architecture

--- a/_docs/contracts/repo-contract.md
+++ b/_docs/contracts/repo-contract.md
@@ -17,8 +17,8 @@ checkPaths:
   - Dockerfile.clean-test
   - scripts/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # Skills Repository Contract

--- a/_docs/runbooks/atomic-data-skill-migration.md
+++ b/_docs/runbooks/atomic-data-skill-migration.md
@@ -17,8 +17,8 @@ checkPaths:
   - "*-search/**"
   - "*-download/**"
   - tiangong-auto-research/**
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 76dc843048909a54fd8a304686b75ce8f5fa15a4
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # 原子数据 Skill 迁移实施计划

--- a/_docs/runbooks/development.md
+++ b/_docs/runbooks/development.md
@@ -17,8 +17,8 @@ checkPaths:
   - scripts/**
   - .claude-plugin/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # Skills Development Runbook

--- a/_docs/standards/documentation-standards.md
+++ b/_docs/standards/documentation-standards.md
@@ -13,8 +13,8 @@ checkPaths:
   - .github/workflows/docpact.yml
   - _docs/**
   - "*/SKILL.md"
-lastReviewedAt: 2026-09-11
-lastReviewedCommit: 6b620e9
+lastReviewedAt: 2026-09-12
+lastReviewedCommit: c5f8fe3ff43313f69b8deb4d970261c4013c5310
 ---
 
 # Skills Documentation Standards

--- a/scripts/tests/tiangong-kb-search-pin.test.mjs
+++ b/scripts/tests/tiangong-kb-search-pin.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const CLI_VERSION = "0.0.62";
+const SKILLS = [
+  ["tiangong-kb-sci-search", "sci_search.sh"],
+  ["tiangong-kb-patent-search", "patent_search.sh"],
+  ["tiangong-kb-report-search", "report_search.sh"],
+  ["tiangong-kb-esg-search", "esg_search.sh"],
+  ["tiangong-kb-course-search", "course_search.sh"],
+  ["tiangong-kb-edu-search", "edu_search.sh"],
+  ["tiangong-kb-textbook-search", "textbook_search.sh"],
+];
+
+test("Tiangong KB search skills share one exact standalone CLI pin", async () => {
+  for (const [skill, wrapperName] of SKILLS) {
+    const skillText = await readFile(path.join(REPO_ROOT, skill, "SKILL.md"), "utf8");
+    const wrapperText = await readFile(
+      path.join(REPO_ROOT, skill, "scripts", wrapperName),
+      "utf8",
+    );
+
+    assert.match(skillText, new RegExp(`@tiangong-ai/cli@${CLI_VERSION.replaceAll(".", "\\.")}`), skill);
+    assert.doesNotMatch(skillText, /@tiangong-ai\/cli@0\.0\.(?:19|30)/, skill);
+    assert.match(
+      wrapperText,
+      new RegExp(`STANDALONE_TESTED_CLI_VERSION="${CLI_VERSION.replaceAll(".", "\\.")}"`),
+      skill,
+    );
+    assert.match(wrapperText, /npx --yes --package "@tiangong-ai\/cli@\$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai/, skill);
+    assert.doesNotMatch(wrapperText, /@tiangong-ai\/cli@0\.0\.(?:19|30)/, skill);
+  }
+});

--- a/scripts/tests/tiangong-kb-search-wrapper.test.mjs
+++ b/scripts/tests/tiangong-kb-search-wrapper.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const CASES = [
+  { skill: "tiangong-kb-esg-search", wrapper: "esg_search.sh", command: "research", source: "esg", credential: "TIANGONG_ESG_APIKEY" },
+  { skill: "tiangong-kb-course-search", wrapper: "course_search.sh", command: "education", source: "course", credential: "TIANGONG_COURSE_APIKEY" },
+  { skill: "tiangong-kb-edu-search", wrapper: "edu_search.sh", command: "education", source: "edu", credential: "TIANGONG_EDU_APIKEY" },
+  { skill: "tiangong-kb-textbook-search", wrapper: "textbook_search.sh", command: "education", source: "textbook", credential: "TIANGONG_TEXTBOOK_APIKEY" },
+];
+
+for (const entry of CASES) {
+  test(`${entry.skill} keeps credentials out of input and loads only owner env`, async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), `${entry.skill}.`));
+    try {
+      const wrapper = path.join(REPO_ROOT, entry.skill, "scripts", entry.wrapper);
+      const fakeCli = path.join(root, "fake-cli");
+      const marker = path.join(root, "invoked");
+      const argsFile = path.join(root, "args.txt");
+      const envFile = path.join(root, "owner.env");
+      const secret = `owner-${entry.source}-secret`;
+      await writeFile(
+        fakeCli,
+        [
+          "#!/bin/bash",
+          "set -euo pipefail",
+          ': > "$FAKE_MARKER"',
+          'printf "%s\\n" "$@" > "$FAKE_ARGS"',
+          `printf '%s\\n' "\${${entry.credential}:-}" "\${EVIL_SETTING:-}" > "$FAKE_ENV"`,
+          'printf \'{"ok":true}\\n\'',
+        ].join("\n"),
+        { mode: 0o700 },
+      );
+      await writeFile(envFile, `${entry.credential}=${secret}\nEVIL_SETTING=ignored\n`, { mode: 0o600 });
+      const baseEnv = {
+        ...process.env,
+        FAKE_MARKER: marker,
+        FAKE_ARGS: argsFile,
+        FAKE_ENV: path.join(root, "env.txt"),
+        TIANGONG_AI_CLI_BIN: fakeCli,
+      };
+
+      const success = spawnSync(
+        wrapper,
+        [JSON.stringify({ query: "deterministic query", dry_run: true, env_file: envFile })],
+        { encoding: "utf8", env: baseEnv },
+      );
+      assert.equal(success.status, 0, success.stderr);
+      const args = await readFile(argsFile, "utf8");
+      assert.match(args, new RegExp(`^${entry.command}$`, "m"));
+      assert.match(args, new RegExp(`^${entry.source}$`, "m"));
+      assert.equal(await readFile(baseEnv.FAKE_ENV, "utf8"), `${secret}\n\n`);
+      assert.doesNotMatch(args + success.stdout + success.stderr, new RegExp(secret));
+
+      await rm(marker);
+      const inline = spawnSync(
+        wrapper,
+        [JSON.stringify({ query: "blocked", api_key: secret })],
+        { encoding: "utf8", env: baseEnv },
+      );
+      assert.notEqual(inline.status, 0);
+      assert.doesNotMatch(inline.stdout + inline.stderr, new RegExp(secret));
+      await assert.rejects(readFile(marker));
+
+      await chmod(envFile, 0o644);
+      const permissive = spawnSync(
+        wrapper,
+        [JSON.stringify({ query: "blocked", env_file: envFile })],
+        { encoding: "utf8", env: baseEnv },
+      );
+      assert.notEqual(permissive.status, 0);
+
+      const request = path.join(root, "request.json");
+      const requestLink = path.join(root, "request-link.json");
+      await writeFile(request, '{"query":"safe"}\n');
+      await symlink(request, requestLink);
+      const linked = spawnSync(
+        wrapper,
+        [JSON.stringify({ request_file: requestLink })],
+        { encoding: "utf8", env: baseEnv },
+      );
+      assert.notEqual(linked.status, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}
+
+test("tiangong-kb-esg-search preserves the dedicated base URL environment override", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "tiangong-kb-esg-search-endpoint."));
+  try {
+    const wrapper = path.join(REPO_ROOT, "tiangong-kb-esg-search", "scripts", "esg_search.sh");
+    const fakeCli = path.join(root, "fake-cli");
+    const argsFile = path.join(root, "args.txt");
+    const envFile = path.join(root, "owner.env");
+    await writeFile(fakeCli, "#!/bin/bash\nset -euo pipefail\nprintf '%s\\n' \"$@\" > \"$FAKE_ARGS\"\nprintf '{\"ok\":true}\\n'\n", { mode: 0o700 });
+    await writeFile(envFile, "TIANGONG_ESG_API_BASE_URL=https://example.invalid/api\n", { mode: 0o600 });
+
+    const result = spawnSync(
+      wrapper,
+      [JSON.stringify({ query: "endpoint compatibility", env_file: envFile })],
+      {
+        encoding: "utf8",
+        env: { ...process.env, FAKE_ARGS: argsFile, TIANGONG_AI_CLI_BIN: fakeCli },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const args = await readFile(argsFile, "utf8");
+    assert.match(args, /^--api-base-url$/m);
+    assert.match(args, /^https:\/\/example\.invalid\/api$/m);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tiangong-kb-course-search/SKILL.md
+++ b/tiangong-kb-course-search/SKILL.md
@@ -10,17 +10,17 @@ single-source: always search `course`, never `all`, `edu`, or `textbook`.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
+- The wrapper defaults to the exact reviewed entrypoint
+  `npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
-  override the CLI entrypoint.
-- Course search should use bearer auth. Pass `bearer_token`; if only `api_key`
-  is provided to this wrapper, it is also forwarded as `--bearer-token` so the
-  CLI emits `Authorization: Bearer ...` for the course source.
+  override the CLI entrypoint intentionally.
+- Set `TIANGONG_EDUCATION_BEARER_TOKEN` for scoped bearer auth, or use
+  `TIANGONG_COURSE_APIKEY` / `TIANGONG_AI_APIKEY`. Credentials are never
+  accepted in wrapper JSON, request files, URLs, or CLI arguments.
 - When `request_file` / `input_file` is provided, the wrapper loads `.env` from
   that file's directory by default. `env_file` can point to a different dotenv
-  file. Loaded dotenv values only fill unset environment variables; explicit
-  JSON fields such as `api_key`, `bearer_token`, and `api_base_url` are passed
-  as CLI flags and take precedence.
+  file. It must be an owner-only regular non-symlink file (`chmod 600`), and
+  only documented Tiangong variables are loaded. Existing process variables win.
 - Optionally set `TIANGONG_AI_API_BASE_URL`; the CLI accepts a Supabase project
   root, `/functions/v1`, or `/rest/v1` and derives Functions URLs.
 
@@ -39,7 +39,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 education search --query <query> --sources course --json
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai education search --query <query> --sources course --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:
@@ -54,7 +54,7 @@ For exact edge-function payloads, provide `request_file` or `input_file`:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 education search --input <request.json> --sources course --json
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai education search --input <request.json> --sources course --json
 ```
 
 ## Raw Payload Filters
@@ -92,10 +92,7 @@ forward them through the CLI `--input` path. The same payload can also be put in
 - `sources`: optional compatibility field; only `course` or `default` is
   accepted.
 - `dry_run`: true to return the exact request plan with masked credentials.
-- `api_base_url`, `api_key`, `bearer_token`, `course_api_key`. For course
-  search, prefer `bearer_token`; `api_key` is treated as the same token when
-  `bearer_token` is omitted.
-- `course_url`, `region`, `timeout`.
+- `api_base_url`, `course_url`, `region`, `timeout` as non-secret routing values.
 - `top_k`, `ext_k`: only used in query mode.
 
 When writing reader-facing prose from retrieved results, state historical facts

--- a/tiangong-kb-course-search/scripts/course_search.sh
+++ b/tiangong-kb-course-search/scripts/course_search.sh
@@ -3,16 +3,18 @@
 # Usage: ./course_search.sh '{"query": "topic", ...}' [output_file]
 
 set -euo pipefail
+umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
+STANDALONE_TESTED_CLI_VERSION="0.0.62"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
+    CLI_COMMAND=(npx --yes --package "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai)
 fi
 
 if [ -z "$JSON_INPUT" ]; then
@@ -36,6 +38,15 @@ if ! echo "$JSON_INPUT" | jq empty 2>/dev/null; then
     exit 1
 fi
 
+contains_sensitive_json() {
+    jq -e '[.. | objects | keys[]] | any(.[]; test("(^|[_-])(access[_-]?token|api[_-]?key|apikey|auth|authorization|cookie|credential|password|secret|session|token)([_-]|$)"; "i"))' >/dev/null
+}
+
+if echo "$JSON_INPUT" | contains_sensitive_json; then
+    echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
+    exit 2
+fi
+
 jq_value() {
     local key="$1"
     echo "$JSON_INPUT" | jq -r ".${key} // empty"
@@ -48,7 +59,28 @@ jq_bool() {
 
 load_env_file() {
     local env_file="$1"
-    [ -f "$env_file" ] || return 0
+    local required="${2:-false}"
+    if [ ! -e "$env_file" ]; then
+        if [ "$required" = "true" ]; then
+            echo "Error: explicit env_file does not exist" >&2
+            exit 2
+        fi
+        return 0
+    fi
+    if [ -L "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo "Error: env_file must be a regular non-symlink file" >&2
+        exit 2
+    fi
+    local mode=""
+    if stat -f '%Lp' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -f '%Lp' "$env_file")"
+    elif stat -c '%a' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -c '%a' "$env_file")"
+    fi
+    if [ -n "$mode" ] && [ $((10#$mode % 100)) -ne 0 ]; then
+        echo "Error: env_file must be owner-only (chmod 600)" >&2
+        exit 2
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
@@ -66,6 +98,13 @@ load_env_file() {
         value="${value#\"}"
         value="${value%\'}"
         value="${value#\'}"
+        case "$key" in
+            TIANGONG_AI_APIKEY|TIANGONG_COURSE_APIKEY|TIANGONG_EDUCATION_BEARER_TOKEN|TIANGONG_KB_READ_TOKEN|TIANGONG_EDUCATION_API_BASE_URL|TIANGONG_AI_SEARCH_API_BASE_URL|TIANGONG_AI_API_BASE_URL|TIANGONG_COURSE_SEARCH_URL|TIANGONG_REGION|TIANGONG_EDUCATION_TIMEOUT)
+                ;;
+            *)
+                continue
+                ;;
+        esac
         export "$key=$value"
     done < "$env_file"
 }
@@ -99,8 +138,23 @@ QUERY=$(echo "$JSON_INPUT" | jq -r '.query // .input // empty')
 TMP_REQUEST_FILE=""
 ENV_FILE=$(echo "$JSON_INPUT" | jq -r '.env_file // empty')
 
+if [ -n "$REQUEST_FILE" ]; then
+    if [ -L "$REQUEST_FILE" ] || [ ! -f "$REQUEST_FILE" ]; then
+        echo "Error: request_file must be a regular non-symlink JSON file" >&2
+        exit 2
+    fi
+    if ! jq empty "$REQUEST_FILE" 2>/dev/null; then
+        echo "Error: request_file is not valid JSON" >&2
+        exit 2
+    fi
+    if contains_sensitive_json < "$REQUEST_FILE"; then
+        echo "Error: request_file contains credential-like fields; use owner environment variables" >&2
+        exit 2
+    fi
+fi
+
 if [ -n "$ENV_FILE" ]; then
-    load_env_file "$ENV_FILE"
+    load_env_file "$ENV_FILE" true
 elif [ -n "$REQUEST_FILE" ]; then
     load_env_near_file "$REQUEST_FILE"
 fi
@@ -108,6 +162,9 @@ fi
 cleanup() {
     if [ -n "$TMP_REQUEST_FILE" ]; then
         rm -f "$TMP_REQUEST_FILE"
+    fi
+    if [ -n "${TMP_OUTPUT:-}" ]; then
+        rm -f "$TMP_OUTPUT"
     fi
 }
 trap cleanup EXIT
@@ -155,17 +212,28 @@ value_arg() {
     fi
 }
 
-value_arg "api_base_url" "--api-base-url"
-value_arg "api_key" "--api-key"
-value_arg "bearer_token" "--bearer-token"
-value_arg "course_api_key" "--course-api-key"
-value_arg "course_url" "--course-url"
+safe_url_arg() {
+    local json_key="$1"
+    local cli_flag="$2"
+    local value
+    value=$(jq_value "$json_key")
+    if [ -z "$value" ]; then
+        return 0
+    fi
+    case "$value" in
+        https://*) ;;
+        *) echo "Error: $json_key must be an HTTPS URL" >&2; exit 2 ;;
+    esac
+    case "$value" in
+        *\?*|*\#*|*@*) echo "Error: $json_key must not contain userinfo, query parameters, or fragments" >&2; exit 2 ;;
+    esac
+    ARGS+=("$cli_flag" "$value")
+}
+
+safe_url_arg "api_base_url" "--api-base-url"
+safe_url_arg "course_url" "--course-url"
 value_arg "region" "--region"
 value_arg "timeout" "--timeout"
-
-if [ -z "$(jq_value "bearer_token")" ] && [ -n "$(jq_value "api_key")" ]; then
-    ARGS+=(--bearer-token "$(jq_value "api_key")")
-fi
 
 if [ -z "$REQUEST_FILE" ]; then
     value_arg "top_k" "--top-k"
@@ -178,22 +246,26 @@ fi
 
 run_cli() {
     if [[ "${CLI_COMMAND[0]}" == *.js ]]; then
-        node "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 node "${CLI_COMMAND[@]}" "${ARGS[@]}"
     else
-        "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 "${CLI_COMMAND[@]}" "${ARGS[@]}"
     fi
 }
 
 if [ -n "$OUTPUT_FILE" ]; then
-    TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
+    if [ -L "$OUTPUT_FILE" ]; then
+        echo "Error: output_file must not be a symbolic link" >&2
+        exit 2
+    fi
+    TMP_OUTPUT=$(mktemp "${OUTPUT_FILE}.tmp.XXXXXX")
     if run_cli > "$TMP_OUTPUT"; then
         mv "$TMP_OUTPUT" "$OUTPUT_FILE"
+        TMP_OUTPUT=""
         echo "Results saved to: $OUTPUT_FILE"
     else
-        STATUS=$?
-        cat "$TMP_OUTPUT" >&2 || true
-        rm -f "$TMP_OUTPUT"
-        exit "$STATUS"
+        status=$?
+        echo "Error: Tiangong CLI search failed; see its sanitized stderr diagnostic" >&2
+        exit "$status"
     fi
 else
     run_cli

--- a/tiangong-kb-edu-search/SKILL.md
+++ b/tiangong-kb-edu-search/SKILL.md
@@ -11,15 +11,16 @@ intentionally single-source: always search `edu`, never `all`, `course`, or
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
+- The wrapper defaults to the exact reviewed entrypoint
+  `npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
-  override the CLI entrypoint.
-- Set the authentication environment variables expected by `tiangong-ai`.
+  override the CLI entrypoint intentionally.
+- Set `TIANGONG_EDU_APIKEY` or `TIANGONG_AI_APIKEY`. Credentials are never
+  accepted in wrapper JSON, request files, URLs, or CLI arguments.
 - When `request_file` / `input_file` is provided, the wrapper loads `.env` from
   that file's directory by default. `env_file` can point to a different dotenv
-  file. Loaded dotenv values only fill unset environment variables; explicit
-  JSON fields such as `api_key`, `edu_api_key`, and `api_base_url` are passed as
-  CLI flags and take precedence.
+  file. It must be an owner-only regular non-symlink file (`chmod 600`), and
+  only documented Tiangong variables are loaded. Existing process variables win.
 - Optionally set `TIANGONG_AI_API_BASE_URL`; the CLI accepts a Supabase project
   root, `/functions/v1`, or `/rest/v1` and derives Functions URLs.
 
@@ -37,7 +38,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 education search --query <query> --sources edu --json
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai education search --query <query> --sources edu --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:
@@ -87,6 +88,5 @@ forward them through the CLI `--input` path. The same payload can also be put in
   fields for `edu_search`.
 - `sources`: optional compatibility field; only `edu` or `default` is accepted.
 - `dry_run`: true to return the exact request plan with masked credentials.
-- `api_base_url`, `api_key`, `edu_api_key`.
-- `edu_url`, `region`, `timeout`.
+- `api_base_url`, `edu_url`, `region`, `timeout` as non-secret routing values.
 - `top_k`, `ext_k`: only used in query mode.

--- a/tiangong-kb-edu-search/scripts/edu_search.sh
+++ b/tiangong-kb-edu-search/scripts/edu_search.sh
@@ -3,16 +3,18 @@
 # Usage: ./edu_search.sh '{"query": "topic", ...}' [output_file]
 
 set -euo pipefail
+umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
+STANDALONE_TESTED_CLI_VERSION="0.0.62"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
+    CLI_COMMAND=(npx --yes --package "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai)
 fi
 
 if [ -z "$JSON_INPUT" ]; then
@@ -30,6 +32,15 @@ if ! echo "$JSON_INPUT" | jq empty 2>/dev/null; then
     exit 1
 fi
 
+contains_sensitive_json() {
+    jq -e '[.. | objects | keys[]] | any(.[]; test("(^|[_-])(access[_-]?token|api[_-]?key|apikey|auth|authorization|cookie|credential|password|secret|session|token)([_-]|$)"; "i"))' >/dev/null
+}
+
+if echo "$JSON_INPUT" | contains_sensitive_json; then
+    echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
+    exit 2
+fi
+
 jq_value() {
     local key="$1"
     echo "$JSON_INPUT" | jq -r ".${key} // empty"
@@ -42,7 +53,28 @@ jq_bool() {
 
 load_env_file() {
     local env_file="$1"
-    [ -f "$env_file" ] || return 0
+    local required="${2:-false}"
+    if [ ! -e "$env_file" ]; then
+        if [ "$required" = "true" ]; then
+            echo "Error: explicit env_file does not exist" >&2
+            exit 2
+        fi
+        return 0
+    fi
+    if [ -L "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo "Error: env_file must be a regular non-symlink file" >&2
+        exit 2
+    fi
+    local mode=""
+    if stat -f '%Lp' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -f '%Lp' "$env_file")"
+    elif stat -c '%a' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -c '%a' "$env_file")"
+    fi
+    if [ -n "$mode" ] && [ $((10#$mode % 100)) -ne 0 ]; then
+        echo "Error: env_file must be owner-only (chmod 600)" >&2
+        exit 2
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
@@ -60,6 +92,13 @@ load_env_file() {
         value="${value#\"}"
         value="${value%\'}"
         value="${value#\'}"
+        case "$key" in
+            TIANGONG_AI_APIKEY|TIANGONG_EDU_APIKEY|TIANGONG_EDUCATION_API_BASE_URL|TIANGONG_AI_SEARCH_API_BASE_URL|TIANGONG_AI_API_BASE_URL|TIANGONG_EDU_SEARCH_URL|TIANGONG_REGION|TIANGONG_EDUCATION_TIMEOUT)
+                ;;
+            *)
+                continue
+                ;;
+        esac
         export "$key=$value"
     done < "$env_file"
 }
@@ -93,8 +132,23 @@ QUERY=$(echo "$JSON_INPUT" | jq -r '.query // .input // empty')
 TMP_REQUEST_FILE=""
 ENV_FILE=$(echo "$JSON_INPUT" | jq -r '.env_file // empty')
 
+if [ -n "$REQUEST_FILE" ]; then
+    if [ -L "$REQUEST_FILE" ] || [ ! -f "$REQUEST_FILE" ]; then
+        echo "Error: request_file must be a regular non-symlink JSON file" >&2
+        exit 2
+    fi
+    if ! jq empty "$REQUEST_FILE" 2>/dev/null; then
+        echo "Error: request_file is not valid JSON" >&2
+        exit 2
+    fi
+    if contains_sensitive_json < "$REQUEST_FILE"; then
+        echo "Error: request_file contains credential-like fields; use owner environment variables" >&2
+        exit 2
+    fi
+fi
+
 if [ -n "$ENV_FILE" ]; then
-    load_env_file "$ENV_FILE"
+    load_env_file "$ENV_FILE" true
 elif [ -n "$REQUEST_FILE" ]; then
     load_env_near_file "$REQUEST_FILE"
 fi
@@ -102,6 +156,9 @@ fi
 cleanup() {
     if [ -n "$TMP_REQUEST_FILE" ]; then
         rm -f "$TMP_REQUEST_FILE"
+    fi
+    if [ -n "${TMP_OUTPUT:-}" ]; then
+        rm -f "$TMP_OUTPUT"
     fi
 }
 trap cleanup EXIT
@@ -149,10 +206,19 @@ value_arg() {
     fi
 }
 
-value_arg "api_base_url" "--api-base-url"
-value_arg "api_key" "--api-key"
-value_arg "edu_api_key" "--edu-api-key"
-value_arg "edu_url" "--edu-url"
+safe_url_arg() {
+    local json_key="$1"
+    local cli_flag="$2"
+    local value
+    value=$(jq_value "$json_key")
+    if [ -z "$value" ]; then return 0; fi
+    case "$value" in https://*) ;; *) echo "Error: $json_key must be an HTTPS URL" >&2; exit 2 ;; esac
+    case "$value" in *\?*|*\#*|*@*) echo "Error: $json_key must not contain userinfo, query parameters, or fragments" >&2; exit 2 ;; esac
+    ARGS+=("$cli_flag" "$value")
+}
+
+safe_url_arg "api_base_url" "--api-base-url"
+safe_url_arg "edu_url" "--edu-url"
 value_arg "region" "--region"
 value_arg "timeout" "--timeout"
 
@@ -167,22 +233,26 @@ fi
 
 run_cli() {
     if [[ "${CLI_COMMAND[0]}" == *.js ]]; then
-        node "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 node "${CLI_COMMAND[@]}" "${ARGS[@]}"
     else
-        "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 "${CLI_COMMAND[@]}" "${ARGS[@]}"
     fi
 }
 
 if [ -n "$OUTPUT_FILE" ]; then
-    TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
+    if [ -L "$OUTPUT_FILE" ]; then
+        echo "Error: output_file must not be a symbolic link" >&2
+        exit 2
+    fi
+    TMP_OUTPUT=$(mktemp "${OUTPUT_FILE}.tmp.XXXXXX")
     if run_cli > "$TMP_OUTPUT"; then
         mv "$TMP_OUTPUT" "$OUTPUT_FILE"
+        TMP_OUTPUT=""
         echo "Results saved to: $OUTPUT_FILE"
     else
-        STATUS=$?
-        cat "$TMP_OUTPUT" >&2 || true
-        rm -f "$TMP_OUTPUT"
-        exit "$STATUS"
+        status=$?
+        echo "Error: Tiangong CLI search failed; see its sanitized stderr diagnostic" >&2
+        exit "$status"
     fi
 else
     run_cli

--- a/tiangong-kb-esg-search/SKILL.md
+++ b/tiangong-kb-esg-search/SKILL.md
@@ -11,16 +11,16 @@ multi-source preset.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
+- The wrapper defaults to the exact reviewed entrypoint
+  `npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
-  override the CLI entrypoint. Native ESG search requires
-  `@tiangong-ai/cli@0.0.19` or later.
-- Set `TIANGONG_ESG_APIKEY` or `TIANGONG_AI_APIKEY`. The explicit JSON field
-  `esg_api_key` takes precedence over `api_key`, and both take precedence over
-  environment credentials.
+  override the CLI entrypoint intentionally.
+- Set `TIANGONG_ESG_APIKEY` or `TIANGONG_AI_APIKEY`. Credentials are never
+  accepted in wrapper JSON, request files, URLs, or CLI arguments.
 - When `request_file` / `input_file` is provided, the wrapper loads `.env` from
   that file's directory by default. `env_file` can point to a different dotenv
-  file. Loaded dotenv values only fill unset environment variables.
+  file. It must be an owner-only regular non-symlink file (`chmod 600`), and
+  only documented Tiangong variables are loaded. Existing process variables win.
 - Optionally set `TIANGONG_ESG_SEARCH_URL`. The CLI otherwise derives the
   `esg_search` endpoint from `TIANGONG_RESEARCH_API_BASE_URL`,
   `TIANGONG_AI_SEARCH_API_BASE_URL`, or `TIANGONG_AI_API_BASE_URL`. The wrapper
@@ -40,7 +40,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 research search --sources esg --query <query> --json
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai research search --sources esg --query <query> --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:
@@ -99,5 +99,5 @@ them through the CLI `--input` path:
   `topK`, `extK`: optional inline raw payload fields for `esg_search`.
 - `sources`: optional compatibility field; only `esg` or `default` is accepted.
 - `dry_run`: return the exact request plan with masked credentials.
-- `api_base_url`, `api_key`, `esg_api_key`, `esg_url`, `region`, `timeout`.
+- `api_base_url`, `esg_url`, `region`, `timeout` as non-secret routing values.
 - `top_k`, `ext_k`: only used in query mode.

--- a/tiangong-kb-esg-search/scripts/esg_search.sh
+++ b/tiangong-kb-esg-search/scripts/esg_search.sh
@@ -3,16 +3,18 @@
 # Usage: ./esg_search.sh '{"query": "topic", ...}' [output_file]
 
 set -euo pipefail
+umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
+STANDALONE_TESTED_CLI_VERSION="0.0.62"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
+    CLI_COMMAND=(npx --yes --package "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai)
 fi
 
 if [ -z "$JSON_INPUT" ]; then
@@ -30,6 +32,15 @@ if ! echo "$JSON_INPUT" | jq empty 2>/dev/null; then
     exit 1
 fi
 
+contains_sensitive_json() {
+    jq -e '[.. | objects | keys[]] | any(.[]; test("(^|[_-])(access[_-]?token|api[_-]?key|apikey|auth|authorization|cookie|credential|password|secret|session|token)([_-]|$)"; "i"))' >/dev/null
+}
+
+if echo "$JSON_INPUT" | contains_sensitive_json; then
+    echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
+    exit 2
+fi
+
 jq_value() {
     local key="$1"
     echo "$JSON_INPUT" | jq -r ".${key} // empty"
@@ -42,7 +53,28 @@ jq_bool() {
 
 load_env_file() {
     local env_file="$1"
-    [ -f "$env_file" ] || return 0
+    local required="${2:-false}"
+    if [ ! -e "$env_file" ]; then
+        if [ "$required" = "true" ]; then
+            echo "Error: explicit env_file does not exist" >&2
+            exit 2
+        fi
+        return 0
+    fi
+    if [ -L "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo "Error: env_file must be a regular non-symlink file" >&2
+        exit 2
+    fi
+    local mode=""
+    if stat -f '%Lp' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -f '%Lp' "$env_file")"
+    elif stat -c '%a' "$env_file" >/dev/null 2>&1; then
+        mode="$(stat -c '%a' "$env_file")"
+    fi
+    if [ -n "$mode" ] && [ $((10#$mode % 100)) -ne 0 ]; then
+        echo "Error: env_file must be owner-only (chmod 600)" >&2
+        exit 2
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
@@ -60,6 +92,13 @@ load_env_file() {
         value="${value#\"}"
         value="${value%\'}"
         value="${value#\'}"
+        case "$key" in
+            TIANGONG_AI_APIKEY|TIANGONG_ESG_APIKEY|TIANGONG_RESEARCH_API_BASE_URL|TIANGONG_AI_SEARCH_API_BASE_URL|TIANGONG_AI_API_BASE_URL|TIANGONG_ESG_API_BASE_URL|TIANGONG_ESG_SEARCH_URL|TIANGONG_REGION|TIANGONG_RESEARCH_TIMEOUT)
+                ;;
+            *)
+                continue
+                ;;
+        esac
         export "$key=$value"
     done < "$env_file"
 }
@@ -93,8 +132,23 @@ QUERY=$(echo "$JSON_INPUT" | jq -r '.query // .input // empty')
 TMP_REQUEST_FILE=""
 ENV_FILE=$(echo "$JSON_INPUT" | jq -r '.env_file // empty')
 
+if [ -n "$REQUEST_FILE" ]; then
+    if [ -L "$REQUEST_FILE" ] || [ ! -f "$REQUEST_FILE" ]; then
+        echo "Error: request_file must be a regular non-symlink JSON file" >&2
+        exit 2
+    fi
+    if ! jq empty "$REQUEST_FILE" 2>/dev/null; then
+        echo "Error: request_file is not valid JSON" >&2
+        exit 2
+    fi
+    if contains_sensitive_json < "$REQUEST_FILE"; then
+        echo "Error: request_file contains credential-like fields; use owner environment variables" >&2
+        exit 2
+    fi
+fi
+
 if [ -n "$ENV_FILE" ]; then
-    load_env_file "$ENV_FILE"
+    load_env_file "$ENV_FILE" true
 elif [ -n "$REQUEST_FILE" ]; then
     load_env_near_file "$REQUEST_FILE"
 fi
@@ -102,6 +156,9 @@ fi
 cleanup() {
     if [ -n "$TMP_REQUEST_FILE" ]; then
         rm -f "$TMP_REQUEST_FILE"
+    fi
+    if [ -n "${TMP_OUTPUT:-}" ]; then
+        rm -f "$TMP_OUTPUT"
     fi
 }
 trap cleanup EXIT
@@ -185,26 +242,36 @@ value_arg() {
     fi
 }
 
-ESG_API_KEY=$(jq_value "esg_api_key")
-if [ -n "$ESG_API_KEY" ]; then
-    ARGS+=(--esg-api-key "$ESG_API_KEY")
-else
-    API_KEY=$(jq_value "api_key")
-    if [ -n "$API_KEY" ]; then
-        ARGS+=(--api-key "$API_KEY")
+safe_url_arg() {
+    local json_key="$1"
+    local cli_flag="$2"
+    local value
+    value=$(jq_value "$json_key")
+    if [ -z "$value" ]; then
+        return 0
     fi
-fi
+    case "$value" in
+        https://*) ;;
+        *) echo "Error: $json_key must be an HTTPS URL" >&2; exit 2 ;;
+    esac
+    case "$value" in
+        *\?*|*\#*|*@*) echo "Error: $json_key must not contain userinfo, query parameters, or fragments" >&2; exit 2 ;;
+    esac
+    ARGS+=("$cli_flag" "$value")
+}
 
-ESG_URL=$(jq_value "esg_url")
-if [ -n "$ESG_URL" ]; then
-    ARGS+=(--esg-url "$ESG_URL")
+safe_url_arg "api_base_url" "--api-base-url"
+if [ -z "$(jq_value "api_base_url")" ] && [ -n "${TIANGONG_ESG_API_BASE_URL:-}" ]; then
+    case "$TIANGONG_ESG_API_BASE_URL" in
+        https://*) ;;
+        *) echo "Error: TIANGONG_ESG_API_BASE_URL must be an HTTPS URL" >&2; exit 2 ;;
+    esac
+    case "$TIANGONG_ESG_API_BASE_URL" in
+        *\?*|*\#*|*@*) echo "Error: TIANGONG_ESG_API_BASE_URL must not contain userinfo, query parameters, or fragments" >&2; exit 2 ;;
+    esac
+    ARGS+=(--api-base-url "$TIANGONG_ESG_API_BASE_URL")
 fi
-
-API_BASE_URL=$(jq_value "api_base_url")
-API_BASE_URL="${API_BASE_URL:-${TIANGONG_ESG_API_BASE_URL:-}}"
-if [ -n "$API_BASE_URL" ]; then
-    ARGS+=(--api-base-url "$API_BASE_URL")
-fi
+safe_url_arg "esg_url" "--esg-url"
 
 value_arg "region" "--region"
 value_arg "timeout" "--timeout"
@@ -220,22 +287,26 @@ fi
 
 run_cli() {
     if [[ "${CLI_COMMAND[0]}" == *.js ]]; then
-        node "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 node "${CLI_COMMAND[@]}" "${ARGS[@]}"
     else
-        "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 "${CLI_COMMAND[@]}" "${ARGS[@]}"
     fi
 }
 
 if [ -n "$OUTPUT_FILE" ]; then
-    TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
+    if [ -L "$OUTPUT_FILE" ]; then
+        echo "Error: output_file must not be a symbolic link" >&2
+        exit 2
+    fi
+    TMP_OUTPUT=$(mktemp "${OUTPUT_FILE}.tmp.XXXXXX")
     if run_cli > "$TMP_OUTPUT"; then
         mv "$TMP_OUTPUT" "$OUTPUT_FILE"
+        TMP_OUTPUT=""
         echo "Results saved to: $OUTPUT_FILE"
     else
-        STATUS=$?
-        cat "$TMP_OUTPUT" >&2 || true
-        rm -f "$TMP_OUTPUT"
-        exit "$STATUS"
+        status=$?
+        echo "Error: Tiangong CLI search failed; see its sanitized stderr diagnostic" >&2
+        exit "$status"
     fi
 else
     run_cli

--- a/tiangong-kb-patent-search/SKILL.md
+++ b/tiangong-kb-patent-search/SKILL.md
@@ -17,7 +17,7 @@ The standalone wrapper never reads the workspace broker credential store.
 ## Prerequisites
 
 - The standalone wrapper defaults to its separately tested CLI version
-  `0.0.30`; this is not the Auto Research workspace runtime. Set
+  `0.0.62`; this is not the Auto Research workspace runtime. Set
   `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to intentionally override the
   standalone entrypoint.
 - Set `TIANGONG_PATENT_APIKEY` or the common fallback
@@ -50,7 +50,7 @@ then emits a non-secret audit event.
 The script calls:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.30 research search --query <query> --sources patent --json
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai research search --query <query> --sources patent --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-patent-search/scripts/patent_search.sh
+++ b/tiangong-kb-patent-search/scripts/patent_search.sh
@@ -7,14 +7,14 @@ umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
-STANDALONE_TESTED_CLI_VERSION="0.0.30"
+STANDALONE_TESTED_CLI_VERSION="0.0.62"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx --yes "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION")
+    CLI_COMMAND=(npx --yes --package "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-report-search/SKILL.md
+++ b/tiangong-kb-report-search/SKILL.md
@@ -17,7 +17,7 @@ The standalone wrapper never reads the workspace broker credential store.
 ## Prerequisites
 
 - The standalone wrapper defaults to its separately tested CLI version
-  `0.0.30`; this is not the Auto Research workspace runtime. Set
+  `0.0.62`; this is not the Auto Research workspace runtime. Set
   `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to intentionally override the
   standalone entrypoint.
 - Set `TIANGONG_REPORT_APIKEY` or the common fallback
@@ -50,7 +50,7 @@ then emits a non-secret audit event.
 The script calls:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.30 research search --query <query> --sources report --json
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai research search --query <query> --sources report --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:

--- a/tiangong-kb-report-search/scripts/report_search.sh
+++ b/tiangong-kb-report-search/scripts/report_search.sh
@@ -7,14 +7,14 @@ umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
-STANDALONE_TESTED_CLI_VERSION="0.0.30"
+STANDALONE_TESTED_CLI_VERSION="0.0.62"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx --yes "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION")
+    CLI_COMMAND=(npx --yes --package "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-sci-search/SKILL.md
+++ b/tiangong-kb-sci-search/SKILL.md
@@ -25,7 +25,7 @@ service failure; do not try to bypass it.
 ## Direct-search prerequisites
 
 - The standalone wrapper defaults to its separately tested CLI version
-  `0.0.30`. This is not the Auto Research workspace runtime. Managed research
+  `0.0.62`. This is not the Auto Research workspace runtime. Managed research
   resolves its exact version from the immutable setup plan or
   `runtime-lock.json` and must use the broker.
   Set `TIANGONG_AI_CLI_BIN` to one exact executable path, or
@@ -54,7 +54,7 @@ export TIANGONG_SCI_APIKEY='owner-authorized key'
 The wrapper invokes the pinned CLI equivalent of:
 
 ```bash
-npx --yes @tiangong-ai/cli@0.0.30 research search \
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai research search \
   --query <query> --sources sci --json
 ```
 

--- a/tiangong-kb-sci-search/scripts/sci_search.sh
+++ b/tiangong-kb-sci-search/scripts/sci_search.sh
@@ -7,14 +7,14 @@ umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
-STANDALONE_TESTED_CLI_VERSION="0.0.30"
+STANDALONE_TESTED_CLI_VERSION="0.0.62"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx --yes "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION")
+    CLI_COMMAND=(npx --yes --package "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai)
 fi
 
 if [ -z "$JSON_INPUT" ]; then

--- a/tiangong-kb-textbook-search/SKILL.md
+++ b/tiangong-kb-textbook-search/SKILL.md
@@ -10,15 +10,16 @@ single-source: always search `textbook`, never `all`, `course`, or `edu`.
 
 ## Prerequisites
 
-- The wrapper defaults to `npx @tiangong-ai/cli@0.0.19`; users do not need a
+- The wrapper defaults to the exact reviewed entrypoint
+  `npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai`; users do not need a
   preinstalled CLI. Set `TIANGONG_AI_CLI` or `TIANGONG_AI_CLI_BIN` only to
-  override the CLI entrypoint.
-- Set the authentication environment variables expected by `tiangong-ai`.
+  override the CLI entrypoint intentionally.
+- Set `TIANGONG_TEXTBOOK_APIKEY` or `TIANGONG_AI_APIKEY`. Credentials are never
+  accepted in wrapper JSON, request files, URLs, or CLI arguments.
 - When `request_file` / `input_file` is provided, the wrapper loads `.env` from
   that file's directory by default. `env_file` can point to a different dotenv
-  file. Loaded dotenv values only fill unset environment variables; explicit
-  JSON fields such as `api_key`, `textbook_api_key`, and `api_base_url` are
-  passed as CLI flags and take precedence.
+  file. It must be an owner-only regular non-symlink file (`chmod 600`), and
+  only documented Tiangong variables are loaded. Existing process variables win.
 - Optionally set `TIANGONG_AI_API_BASE_URL`; the CLI accepts a Supabase project
   root, `/functions/v1`, or `/rest/v1` and derives Functions URLs.
 
@@ -36,7 +37,7 @@ For normal searches, pass a query:
 The script calls:
 
 ```bash
-npx @tiangong-ai/cli@0.0.19 education search --query <query> --sources textbook --json
+npx --yes --package "@tiangong-ai/cli@0.0.62" -- tiangong-ai education search --query <query> --sources textbook --json
 ```
 
 For exact edge-function payloads, provide `request_file` or `input_file`:
@@ -87,6 +88,5 @@ forward them through the CLI `--input` path. The same payload can also be put in
 - `sources`: optional compatibility field; only `textbook` or `default` is
   accepted.
 - `dry_run`: true to return the exact request plan with masked credentials.
-- `api_base_url`, `api_key`, `textbook_api_key`.
-- `textbook_url`, `region`, `timeout`.
+- `api_base_url`, `textbook_url`, `region`, `timeout` as non-secret routing values.
 - `top_k`, `ext_k`: only used in query mode.

--- a/tiangong-kb-textbook-search/scripts/textbook_search.sh
+++ b/tiangong-kb-textbook-search/scripts/textbook_search.sh
@@ -3,16 +3,18 @@
 # Usage: ./textbook_search.sh '{"query": "topic", ...}' [output_file]
 
 set -euo pipefail
+umask 077
 
 JSON_INPUT="${1:-}"
 OUTPUT_FILE="${2:-}"
+STANDALONE_TESTED_CLI_VERSION="0.0.62"
 CLI_COMMAND=()
 if [ -n "${TIANGONG_AI_CLI:-}" ]; then
     read -r -a CLI_COMMAND <<< "$TIANGONG_AI_CLI"
 elif [ -n "${TIANGONG_AI_CLI_BIN:-}" ]; then
     CLI_COMMAND=("$TIANGONG_AI_CLI_BIN")
 else
-    CLI_COMMAND=(npx @tiangong-ai/cli@0.0.19)
+    CLI_COMMAND=(npx --yes --package "@tiangong-ai/cli@$STANDALONE_TESTED_CLI_VERSION" -- tiangong-ai)
 fi
 
 if [ -z "$JSON_INPUT" ]; then
@@ -30,6 +32,15 @@ if ! echo "$JSON_INPUT" | jq empty 2>/dev/null; then
     exit 1
 fi
 
+contains_sensitive_json() {
+    jq -e '[.. | objects | keys[]] | any(.[]; test("(^|[_-])(access[_-]?token|api[_-]?key|apikey|auth|authorization|cookie|credential|password|secret|session|token)([_-]|$)"; "i"))' >/dev/null
+}
+
+if echo "$JSON_INPUT" | contains_sensitive_json; then
+    echo "Error: credentials are not accepted in wrapper JSON; use owner environment variables" >&2
+    exit 2
+fi
+
 jq_value() {
     local key="$1"
     echo "$JSON_INPUT" | jq -r ".${key} // empty"
@@ -42,7 +53,25 @@ jq_bool() {
 
 load_env_file() {
     local env_file="$1"
-    [ -f "$env_file" ] || return 0
+    local required="${2:-false}"
+    if [ ! -e "$env_file" ]; then
+        if [ "$required" = "true" ]; then
+            echo "Error: explicit env_file does not exist" >&2
+            exit 2
+        fi
+        return 0
+    fi
+    if [ -L "$env_file" ] || [ ! -f "$env_file" ]; then
+        echo "Error: env_file must be a regular non-symlink file" >&2
+        exit 2
+    fi
+    local mode=""
+    if stat -f '%Lp' "$env_file" >/dev/null 2>&1; then mode="$(stat -f '%Lp' "$env_file")";
+    elif stat -c '%a' "$env_file" >/dev/null 2>&1; then mode="$(stat -c '%a' "$env_file")"; fi
+    if [ -n "$mode" ] && [ $((10#$mode % 100)) -ne 0 ]; then
+        echo "Error: env_file must be owner-only (chmod 600)" >&2
+        exit 2
+    fi
     while IFS= read -r line || [ -n "$line" ]; do
         line="${line#"${line%%[![:space:]]*}"}"
         line="${line%"${line##*[![:space:]]}"}"
@@ -60,6 +89,11 @@ load_env_file() {
         value="${value#\"}"
         value="${value%\'}"
         value="${value#\'}"
+        case "$key" in
+            TIANGONG_AI_APIKEY|TIANGONG_TEXTBOOK_APIKEY|TIANGONG_EDUCATION_API_BASE_URL|TIANGONG_AI_SEARCH_API_BASE_URL|TIANGONG_AI_API_BASE_URL|TIANGONG_TEXTBOOK_SEARCH_URL|TIANGONG_REGION|TIANGONG_EDUCATION_TIMEOUT)
+                ;;
+            *) continue ;;
+        esac
         export "$key=$value"
     done < "$env_file"
 }
@@ -93,8 +127,23 @@ QUERY=$(echo "$JSON_INPUT" | jq -r '.query // .input // empty')
 TMP_REQUEST_FILE=""
 ENV_FILE=$(echo "$JSON_INPUT" | jq -r '.env_file // empty')
 
+if [ -n "$REQUEST_FILE" ]; then
+    if [ -L "$REQUEST_FILE" ] || [ ! -f "$REQUEST_FILE" ]; then
+        echo "Error: request_file must be a regular non-symlink JSON file" >&2
+        exit 2
+    fi
+    if ! jq empty "$REQUEST_FILE" 2>/dev/null; then
+        echo "Error: request_file is not valid JSON" >&2
+        exit 2
+    fi
+    if contains_sensitive_json < "$REQUEST_FILE"; then
+        echo "Error: request_file contains credential-like fields; use owner environment variables" >&2
+        exit 2
+    fi
+fi
+
 if [ -n "$ENV_FILE" ]; then
-    load_env_file "$ENV_FILE"
+    load_env_file "$ENV_FILE" true
 elif [ -n "$REQUEST_FILE" ]; then
     load_env_near_file "$REQUEST_FILE"
 fi
@@ -103,6 +152,7 @@ cleanup() {
     if [ -n "$TMP_REQUEST_FILE" ]; then
         rm -f "$TMP_REQUEST_FILE"
     fi
+    if [ -n "${TMP_OUTPUT:-}" ]; then rm -f "$TMP_OUTPUT"; fi
 }
 trap cleanup EXIT
 
@@ -150,10 +200,19 @@ value_arg() {
     fi
 }
 
-value_arg "api_base_url" "--api-base-url"
-value_arg "api_key" "--api-key"
-value_arg "textbook_api_key" "--textbook-api-key"
-value_arg "textbook_url" "--textbook-url"
+safe_url_arg() {
+    local json_key="$1"
+    local cli_flag="$2"
+    local value
+    value=$(jq_value "$json_key")
+    if [ -z "$value" ]; then return 0; fi
+    case "$value" in https://*) ;; *) echo "Error: $json_key must be an HTTPS URL" >&2; exit 2 ;; esac
+    case "$value" in *\?*|*\#*|*@*) echo "Error: $json_key must not contain userinfo, query parameters, or fragments" >&2; exit 2 ;; esac
+    ARGS+=("$cli_flag" "$value")
+}
+
+safe_url_arg "api_base_url" "--api-base-url"
+safe_url_arg "textbook_url" "--textbook-url"
 value_arg "region" "--region"
 value_arg "timeout" "--timeout"
 
@@ -168,22 +227,23 @@ fi
 
 run_cli() {
     if [[ "${CLI_COMMAND[0]}" == *.js ]]; then
-        node "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 node "${CLI_COMMAND[@]}" "${ARGS[@]}"
     else
-        "${CLI_COMMAND[@]}" "${ARGS[@]}"
+        DO_NOT_TRACK=1 "${CLI_COMMAND[@]}" "${ARGS[@]}"
     fi
 }
 
 if [ -n "$OUTPUT_FILE" ]; then
-    TMP_OUTPUT="${OUTPUT_FILE}.tmp.$$"
+    if [ -L "$OUTPUT_FILE" ]; then echo "Error: output_file must not be a symbolic link" >&2; exit 2; fi
+    TMP_OUTPUT=$(mktemp "${OUTPUT_FILE}.tmp.XXXXXX")
     if run_cli > "$TMP_OUTPUT"; then
         mv "$TMP_OUTPUT" "$OUTPUT_FILE"
+        TMP_OUTPUT=""
         echo "Results saved to: $OUTPUT_FILE"
     else
-        STATUS=$?
-        cat "$TMP_OUTPUT" >&2 || true
-        rm -f "$TMP_OUTPUT"
-        exit "$STATUS"
+        status=$?
+        echo "Error: Tiangong CLI search failed; see its sanitized stderr diagnostic" >&2
+        exit "$status"
     fi
 else
     run_cli


### PR DESCRIPTION
## Summary

- pin all seven standalone Tiangong KB search Skills to the exact reviewed `@tiangong-ai/cli@0.0.62` entrypoint
- align ESG, course, education, and textbook wrappers with the existing secure credential and file boundary
- add repository contracts for pin consistency, dotenv permissions, secret rejection, symlink rejection, and ESG endpoint compatibility
- record the required docpact review evidence for the governed Skill surfaces

## Validation

- `node --test scripts/tests/tiangong-kb-search-pin.test.mjs scripts/tests/tiangong-kb-search-wrapper.test.mjs`
- all seven live-source smokes through exact CLI `0.0.62`
- exact-package isolated-cache smoke on Node `24.19.0`
- all seven Skills pass `quick_validate.py`
- `scripts/test-clean-container.sh --cold-build`
- `../scripts/docpact validate-config --root . --strict`
- `../scripts/docpact lint --root . --staged --format json --output .docpact/runs/latest.json`
- `git diff --check`

## Risk and rollback

The main compatibility risk is stricter handling of legacy inline credentials and permissive dotenv files. The documented environment-variable path remains supported, including `TIANGONG_ESG_API_BASE_URL`. Rollback is a revert of this commit.

Closes #128
